### PR TITLE
Phase 2: IPC foundation + CLI skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,12 +91,14 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 name = "amux-app"
 version = "0.1.0"
 dependencies = [
+ "amux-ipc",
  "amux-term",
  "anyhow",
  "arboard",
  "eframe",
  "egui",
  "portable-pty",
+ "serde_json",
  "tracing",
  "tracing-subscriber",
  "wezterm-term",
@@ -105,10 +107,26 @@ dependencies = [
 [[package]]
 name = "amux-cli"
 version = "0.1.0"
+dependencies = [
+ "amux-ipc",
+ "anyhow",
+ "clap",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "amux-ipc"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
 
 [[package]]
 name = "amux-layout"
@@ -182,6 +200,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -531,6 +599,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +662,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -745,6 +859,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1248,6 +1383,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -1597,6 +1743,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,6 +2077,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2425,6 +2588,18 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
@@ -2962,6 +3137,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3381,6 +3567,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3675,6 +3871,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3945,6 +4167,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,16 @@ cosmic-text = "0.12"
 # Clipboard
 arboard = "3"
 
+# Async runtime
+tokio = { version = "1", features = ["rt", "net", "io-util", "sync", "macros", "time"] }
+
+# CLI
+clap = { version = "4", features = ["derive"] }
+
+# Utilities
+uuid = { version = "1", features = ["v4"] }
+dirs = "6"
+
 # Error handling
 anyhow = "1"
 

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -15,3 +15,5 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 portable-pty = { workspace = true }
+amux-ipc = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
 
+use amux_ipc::IpcCommand;
 use amux_term::color::resolve_color;
 use amux_term::config::AmuxTermConfig;
 use amux_term::pane::TerminalPane;
@@ -14,8 +15,18 @@ const FONT_SIZE: f32 = 14.0;
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
-    let cmd = CommandBuilder::new(&shell);
+    // Start IPC server first to get the socket path for env injection
+    let (ipc_rx, ipc_addr) = amux_ipc::start_server()?;
+    tracing::info!("IPC server: {}", ipc_addr);
+
+    // Spawn terminal with user's shell + injected env vars
+    let shell = default_shell();
+    let mut cmd = CommandBuilder::new(&shell);
+    cmd.env("AMUX_SOCKET_PATH", ipc_addr.to_string());
+    cmd.env("AMUX_WORKSPACE_ID", "default");
+    cmd.env("AMUX_SURFACE_ID", "default");
+    cmd.env("TERM", "xterm-256color");
+
     let config = Arc::new(AmuxTermConfig::default());
     let mut pane = TerminalPane::spawn(80, 24, cmd, config)?;
 
@@ -44,23 +55,53 @@ fn main() -> anyhow::Result<()> {
         ..Default::default()
     };
 
-    eframe::run_native(
+    let ipc_addr_cleanup = ipc_addr.clone();
+    let result = eframe::run_native(
         "amux",
         options,
         Box::new(move |_cc| {
             Ok(Box::new(AmuxApp {
                 pane,
                 byte_rx,
+                ipc_rx,
                 last_size: (0, 0),
             }))
         }),
     )
-    .map_err(|e| anyhow::anyhow!("{}", e))
+    .map_err(|e| anyhow::anyhow!("{}", e));
+
+    // Clean up socket file
+    cleanup_addr(&ipc_addr_cleanup);
+
+    result
+}
+
+fn default_shell() -> String {
+    #[cfg(unix)]
+    {
+        std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string())
+    }
+    #[cfg(windows)]
+    {
+        std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+    }
+}
+
+fn cleanup_addr(addr: &amux_ipc::IpcAddr) {
+    match addr {
+        #[cfg(unix)]
+        amux_ipc::IpcAddr::Unix(path) => {
+            let _ = std::fs::remove_file(path);
+        }
+        #[cfg(windows)]
+        amux_ipc::IpcAddr::NamedPipe(_) => {}
+    }
 }
 
 struct AmuxApp {
     pane: TerminalPane,
     byte_rx: mpsc::Receiver<Vec<u8>>,
+    ipc_rx: std::sync::mpsc::Receiver<IpcCommand>,
     last_size: (usize, usize),
 }
 
@@ -72,6 +113,9 @@ impl eframe::App for AmuxApp {
             got_data = true;
             self.pane.feed_bytes(&bytes);
         }
+
+        // Process IPC commands
+        self.process_ipc_commands();
 
         // Handle keyboard/paste input
         self.handle_input(ctx);
@@ -99,6 +143,66 @@ impl eframe::App for AmuxApp {
 }
 
 impl AmuxApp {
+    fn process_ipc_commands(&mut self) {
+        while let Ok(cmd) = self.ipc_rx.try_recv() {
+            let response = self.dispatch_ipc(&cmd.request);
+            let _ = cmd.reply_tx.send(response);
+        }
+    }
+
+    fn dispatch_ipc(&mut self, req: &amux_ipc::Request) -> amux_ipc::Response {
+        use amux_ipc::Response;
+        match req.method.as_str() {
+            "system.ping" => Response::ok(req.id.clone(), serde_json::json!({"pong": true})),
+            "system.capabilities" => Response::ok(
+                req.id.clone(),
+                serde_json::json!({"methods": amux_ipc::methods::METHODS}),
+            ),
+            "system.identify" => Response::ok(
+                req.id.clone(),
+                serde_json::json!({
+                    "workspace_id": "default",
+                    "surface_id": "default",
+                }),
+            ),
+            "surface.list" => {
+                let (cols, rows) = self.pane.dimensions();
+                Response::ok(
+                    req.id.clone(),
+                    serde_json::json!({
+                        "surfaces": [{
+                            "id": "default",
+                            "title": self.pane.title(),
+                            "cols": cols,
+                            "rows": rows,
+                            "alive": self.pane.is_alive(),
+                        }],
+                    }),
+                )
+            }
+            "surface.send_text" => {
+                match serde_json::from_value::<amux_ipc::methods::SendTextParams>(
+                    req.params.clone(),
+                ) {
+                    Ok(params) => match self.pane.write_bytes(params.text.as_bytes()) {
+                        Ok(_) => Response::ok(req.id.clone(), serde_json::json!({})),
+                        Err(e) => Response::err(req.id.clone(), "write_error", &e.to_string()),
+                    },
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
+            "surface.read_text" => {
+                let text = self.pane.read_screen_text();
+                Response::ok(req.id.clone(), serde_json::json!({"text": text}))
+            }
+            _ => Response::err(
+                req.id.clone(),
+                "method_not_found",
+                &format!("unknown method: {}", req.method),
+            ),
+        }
+    }
+
     fn render_terminal(&mut self, ui: &mut egui::Ui) {
         let font_id = egui::FontId::monospace(FONT_SIZE);
         let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));

--- a/crates/amux-cli/Cargo.toml
+++ b/crates/amux-cli/Cargo.toml
@@ -5,4 +5,13 @@ edition.workspace = true
 license.workspace = true
 description = "amux CLI binary (socket client)"
 
+[[bin]]
+name = "amux"
+path = "src/main.rs"
+
 [dependencies]
+amux-ipc = { workspace = true }
+clap = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -1,3 +1,167 @@
-fn main() {
-    println!("amux-cli: not yet implemented");
+use amux_ipc::{read_last_addr, IpcAddr, IpcClient};
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "amux", about = "Terminal multiplexer for AI coding agents")]
+struct Cli {
+    /// Socket path (auto-detected if omitted)
+    #[arg(long, global = true)]
+    socket: Option<String>,
+
+    /// Output as JSON
+    #[arg(long, global = true)]
+    json: bool,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Check if the amux server is running
+    Ping,
+    /// List surfaces (hierarchical view)
+    Tree,
+    /// Send text to a surface
+    Send {
+        /// Text to send
+        text: String,
+        /// Target surface ID
+        #[arg(long)]
+        surface: Option<String>,
+    },
+    /// Read screen text from a surface
+    ReadScreen {
+        /// Target surface ID
+        #[arg(long)]
+        surface: Option<String>,
+    },
+    /// List server capabilities
+    Capabilities,
+    /// Identify focused workspace/surface
+    Identify,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    let addr = resolve_addr(&cli)?;
+    let mut client = IpcClient::connect(&addr).await?;
+
+    match cli.command {
+        Command::Ping => {
+            let resp = client.call("system.ping", serde_json::json!({})).await?;
+            print_response(&resp, cli.json);
+        }
+        Command::Tree => {
+            let resp = client.call("surface.list", serde_json::json!({})).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if let Some(result) = &resp.result {
+                print_tree(result);
+            }
+        }
+        Command::Send { text, surface } => {
+            let surface_id = surface
+                .or_else(|| std::env::var("AMUX_SURFACE_ID").ok())
+                .unwrap_or_else(|| "default".to_string());
+            let resp = client
+                .call(
+                    "surface.send_text",
+                    serde_json::json!({
+                        "surface_id": surface_id,
+                        "text": text,
+                    }),
+                )
+                .await?;
+            print_response(&resp, cli.json);
+        }
+        Command::ReadScreen { surface } => {
+            let surface_id = surface
+                .or_else(|| std::env::var("AMUX_SURFACE_ID").ok())
+                .unwrap_or_else(|| "default".to_string());
+            let resp = client
+                .call(
+                    "surface.read_text",
+                    serde_json::json!({
+                        "surface_id": surface_id,
+                    }),
+                )
+                .await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if let Some(result) = &resp.result {
+                if let Some(text) = result.get("text").and_then(|t| t.as_str()) {
+                    println!("{}", text);
+                }
+            }
+        }
+        Command::Capabilities => {
+            let resp = client
+                .call("system.capabilities", serde_json::json!({}))
+                .await?;
+            print_response(&resp, cli.json);
+        }
+        Command::Identify => {
+            let resp = client
+                .call("system.identify", serde_json::json!({}))
+                .await?;
+            print_response(&resp, cli.json);
+        }
+    }
+    Ok(())
+}
+
+fn resolve_addr(cli: &Cli) -> anyhow::Result<IpcAddr> {
+    if let Some(ref socket) = cli.socket {
+        return Ok(IpcAddr::from_stored(socket));
+    }
+
+    // Check environment variable
+    if let Ok(path) = std::env::var("AMUX_SOCKET_PATH") {
+        return Ok(IpcAddr::from_stored(&path));
+    }
+
+    // Fall back to last-known address
+    read_last_addr()
+}
+
+fn print_response(resp: &amux_ipc::Response, json: bool) {
+    if json {
+        println!("{}", serde_json::to_string_pretty(resp).unwrap());
+    } else if resp.ok {
+        if let Some(result) = &resp.result {
+            println!("{}", serde_json::to_string_pretty(result).unwrap());
+        }
+    } else if let Some(err) = &resp.error {
+        eprintln!("error [{}]: {}", err.code, err.message);
+        std::process::exit(1);
+    }
+}
+
+fn print_tree(result: &serde_json::Value) {
+    if let Some(surfaces) = result.get("surfaces").and_then(|s| s.as_array()) {
+        println!("workspace: default");
+        for (i, surface) in surfaces.iter().enumerate() {
+            let prefix = if i == surfaces.len() - 1 {
+                "└──"
+            } else {
+                "├──"
+            };
+            let id = surface.get("id").and_then(|v| v.as_str()).unwrap_or("?");
+            let title = surface.get("title").and_then(|v| v.as_str()).unwrap_or("");
+            let cols = surface.get("cols").and_then(|v| v.as_u64()).unwrap_or(0);
+            let rows = surface.get("rows").and_then(|v| v.as_u64()).unwrap_or(0);
+            let alive = surface
+                .get("alive")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let status = if alive { "running" } else { "exited" };
+            println!(
+                "  {} surface:{} \"{}\" {}x{} [{}]",
+                prefix, id, title, cols, rows, status
+            );
+        }
+    }
 }

--- a/crates/amux-ipc/Cargo.toml
+++ b/crates/amux-ipc/Cargo.toml
@@ -6,3 +6,10 @@ license.workspace = true
 description = "amux socket server + JSON-RPC protocol"
 
 [dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+dirs = { workspace = true }
+uuid = { workspace = true }

--- a/crates/amux-ipc/src/client.rs
+++ b/crates/amux-ipc/src/client.rs
@@ -1,0 +1,69 @@
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+
+use crate::protocol::{Request, Response};
+use crate::socket_path::IpcAddr;
+
+/// IPC client for connecting to the amux server.
+pub struct IpcClient {
+    #[cfg(unix)]
+    reader: Lines<BufReader<tokio::net::unix::OwnedReadHalf>>,
+    #[cfg(unix)]
+    writer: tokio::net::unix::OwnedWriteHalf,
+
+    #[cfg(windows)]
+    reader: Lines<BufReader<tokio::io::ReadHalf<tokio::net::windows::named_pipe::NamedPipeClient>>>,
+    #[cfg(windows)]
+    writer: tokio::io::WriteHalf<tokio::net::windows::named_pipe::NamedPipeClient>,
+}
+
+impl IpcClient {
+    /// Connect to the amux IPC server at the given address.
+    pub async fn connect(addr: &IpcAddr) -> anyhow::Result<Self> {
+        #[cfg(unix)]
+        {
+            let IpcAddr::Unix(ref path) = addr;
+            let stream = tokio::net::UnixStream::connect(path).await?;
+            let (read_half, write_half) = stream.into_split();
+            Ok(Self {
+                reader: BufReader::new(read_half).lines(),
+                writer: write_half,
+            })
+        }
+
+        #[cfg(windows)]
+        {
+            let IpcAddr::NamedPipe(ref name) = addr;
+            let client = tokio::net::windows::named_pipe::ClientOptions::new().open(name)?;
+            let (read_half, write_half) = tokio::io::split(client);
+            Ok(Self {
+                reader: BufReader::new(read_half).lines(),
+                writer: write_half,
+            })
+        }
+    }
+
+    /// Send a JSON-RPC request and wait for the response.
+    pub async fn call(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> anyhow::Result<Response> {
+        let req = Request {
+            id: uuid::Uuid::new_v4().to_string(),
+            method: method.to_string(),
+            params,
+        };
+        let mut json = serde_json::to_string(&req)?;
+        json.push('\n');
+        self.writer.write_all(json.as_bytes()).await?;
+        self.writer.flush().await?;
+
+        let line = self
+            .reader
+            .next_line()
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("connection closed"))?;
+        let resp: Response = serde_json::from_str(&line)?;
+        Ok(resp)
+    }
+}

--- a/crates/amux-ipc/src/lib.rs
+++ b/crates/amux-ipc/src/lib.rs
@@ -1,1 +1,10 @@
+pub mod client;
+pub mod methods;
+pub mod protocol;
+pub mod server;
+pub mod socket_path;
 
+pub use client::IpcClient;
+pub use protocol::{Request, Response, RpcError};
+pub use server::{start_server, IpcCommand};
+pub use socket_path::{read_last_addr, IpcAddr};

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+
+/// All methods the server can handle.
+pub const METHODS: &[&str] = &[
+    "system.ping",
+    "system.capabilities",
+    "system.identify",
+    "surface.send_text",
+    "surface.read_text",
+    "surface.list",
+];
+
+// --- Params ---
+
+#[derive(Debug, Deserialize)]
+pub struct SendTextParams {
+    pub surface_id: String,
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReadTextParams {
+    pub surface_id: String,
+}
+
+// --- Results ---
+
+#[derive(Debug, Serialize)]
+pub struct PingResult {
+    pub pong: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CapabilitiesResult {
+    pub methods: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IdentifyResult {
+    pub workspace_id: String,
+    pub surface_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SurfaceInfo {
+    pub id: String,
+    pub title: String,
+    pub cols: usize,
+    pub rows: usize,
+    pub alive: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SurfaceListResult {
+    pub surfaces: Vec<SurfaceInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReadTextResult {
+    pub text: String,
+}

--- a/crates/amux-ipc/src/protocol.rs
+++ b/crates/amux-ipc/src/protocol.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+
+/// JSON-RPC v2 request (newline-delimited).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Request {
+    pub id: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+/// JSON-RPC v2 response (newline-delimited).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Response {
+    pub id: String,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+}
+
+/// Structured error in a JSON-RPC response.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RpcError {
+    pub code: String,
+    pub message: String,
+}
+
+impl Response {
+    pub fn ok(id: String, result: serde_json::Value) -> Self {
+        Self {
+            id,
+            ok: true,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn err(id: String, code: &str, message: &str) -> Self {
+        Self {
+            id,
+            ok: false,
+            result: None,
+            error: Some(RpcError {
+                code: code.to_string(),
+                message: message.to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_ok_response() {
+        let resp = Response::ok("1".into(), serde_json::json!({"pong": true}));
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"ok\":true"));
+        assert!(json.contains("\"pong\":true"));
+        assert!(!json.contains("\"error\""));
+    }
+
+    #[test]
+    fn serialize_err_response() {
+        let resp = Response::err("2".into(), "not_found", "no such surface");
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"ok\":false"));
+        assert!(json.contains("\"not_found\""));
+        assert!(!json.contains("\"result\""));
+    }
+
+    #[test]
+    fn deserialize_request() {
+        let json = r#"{"id":"1","method":"system.ping","params":{}}"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.method, "system.ping");
+    }
+
+    #[test]
+    fn deserialize_request_missing_params() {
+        let json = r#"{"id":"1","method":"system.ping"}"#;
+        let req: Request = serde_json::from_str(json).unwrap();
+        assert_eq!(req.params, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn roundtrip_response() {
+        let resp = Response::ok("42".into(), serde_json::json!({"methods": ["a", "b"]}));
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: Response = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, "42");
+        assert!(parsed.ok);
+    }
+}

--- a/crates/amux-ipc/src/server.rs
+++ b/crates/amux-ipc/src/server.rs
@@ -1,0 +1,161 @@
+use std::sync::mpsc as std_mpsc;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::oneshot;
+
+use crate::protocol::{Request, Response};
+use crate::socket_path::{default_addr, write_last_addr, IpcAddr};
+
+/// A command sent from the IPC server to the main (eframe) thread.
+pub struct IpcCommand {
+    pub request: Request,
+    pub reply_tx: oneshot::Sender<Response>,
+}
+
+/// Start the IPC server on a background thread.
+///
+/// Returns the command receiver (for the main thread to drain) and the IPC address.
+pub fn start_server() -> anyhow::Result<(std_mpsc::Receiver<IpcCommand>, IpcAddr)> {
+    let addr = default_addr();
+    cleanup_stale(&addr);
+    write_last_addr(&addr)?;
+
+    let (cmd_tx, cmd_rx) = std_mpsc::channel::<IpcCommand>();
+    let addr_clone = addr.clone();
+
+    std::thread::Builder::new()
+        .name("ipc-server".to_string())
+        .spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio runtime");
+            rt.block_on(run_server(addr_clone, cmd_tx));
+        })?;
+
+    Ok((cmd_rx, addr))
+}
+
+/// Remove a stale socket file (Unix only).
+fn cleanup_stale(addr: &IpcAddr) {
+    match addr {
+        #[cfg(unix)]
+        IpcAddr::Unix(path) => {
+            let _ = std::fs::remove_file(path);
+        }
+        #[cfg(windows)]
+        IpcAddr::NamedPipe(_) => {
+            // Named pipes are kernel objects; no file to clean up.
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unix implementation
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+async fn run_server(addr: IpcAddr, cmd_tx: std_mpsc::Sender<IpcCommand>) {
+    let IpcAddr::Unix(ref path) = addr;
+    let listener = tokio::net::UnixListener::bind(path).expect("bind unix socket");
+    tracing::info!("IPC server listening on {}", path.display());
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, _)) => {
+                let tx = cmd_tx.clone();
+                let (reader, writer) = stream.into_split();
+                tokio::spawn(handle_connection(BufReader::new(reader), writer, tx));
+            }
+            Err(e) => {
+                tracing::error!("accept error: {}", e);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Windows implementation
+// ---------------------------------------------------------------------------
+
+#[cfg(windows)]
+async fn run_server(addr: IpcAddr, cmd_tx: std_mpsc::Sender<IpcCommand>) {
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    let IpcAddr::NamedPipe(ref name) = addr;
+    let mut server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(name)
+        .expect("create named pipe");
+    tracing::info!("IPC server listening on {}", name);
+
+    loop {
+        // Wait for a client to connect to the current pipe instance.
+        if let Err(e) = server.connect().await {
+            tracing::error!("named pipe connect error: {}", e);
+            continue;
+        }
+
+        let connected = server;
+        // Create a new pipe instance for the next client BEFORE handling this one.
+        server = ServerOptions::new()
+            .create(name)
+            .expect("create next named pipe instance");
+
+        let tx = cmd_tx.clone();
+        let (reader, writer) = tokio::io::split(connected);
+        tokio::spawn(handle_connection(BufReader::new(reader), writer, tx));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared connection handler
+// ---------------------------------------------------------------------------
+
+async fn handle_connection<R, W>(
+    reader: BufReader<R>,
+    mut writer: W,
+    cmd_tx: std_mpsc::Sender<IpcCommand>,
+) where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let mut lines = reader.lines();
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        let request: Request = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(e) => {
+                let err_resp = Response::err(String::new(), "parse_error", &e.to_string());
+                let _ = write_response(&mut writer, &err_resp).await;
+                continue;
+            }
+        };
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let cmd = IpcCommand { request, reply_tx };
+
+        if cmd_tx.send(cmd).is_err() {
+            break; // main thread gone
+        }
+
+        // Wait for the main thread to process and reply.
+        match reply_rx.await {
+            Ok(response) => {
+                let _ = write_response(&mut writer, &response).await;
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+async fn write_response<W: tokio::io::AsyncWrite + Unpin>(
+    writer: &mut W,
+    response: &Response,
+) -> anyhow::Result<()> {
+    let mut json = serde_json::to_string(response)?;
+    json.push('\n');
+    writer.write_all(json.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}

--- a/crates/amux-ipc/src/socket_path.rs
+++ b/crates/amux-ipc/src/socket_path.rs
@@ -1,0 +1,82 @@
+use std::fmt;
+use std::path::PathBuf;
+
+/// Platform-abstracted IPC address.
+#[derive(Debug, Clone)]
+pub enum IpcAddr {
+    /// Unix domain socket path (macOS/Linux).
+    #[cfg(unix)]
+    Unix(PathBuf),
+
+    /// Windows named pipe name (e.g. `\\.\pipe\amux-1234`).
+    #[cfg(windows)]
+    NamedPipe(String),
+}
+
+impl fmt::Display for IpcAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            #[cfg(unix)]
+            IpcAddr::Unix(p) => write!(f, "{}", p.display()),
+            #[cfg(windows)]
+            IpcAddr::NamedPipe(name) => write!(f, "{}", name),
+        }
+    }
+}
+
+impl IpcAddr {
+    /// Serialize to string for storage.
+    pub fn to_string_lossy(&self) -> String {
+        self.to_string()
+    }
+
+    /// Parse from stored string.
+    pub fn from_stored(s: &str) -> Self {
+        #[cfg(unix)]
+        {
+            IpcAddr::Unix(PathBuf::from(s))
+        }
+        #[cfg(windows)]
+        {
+            IpcAddr::NamedPipe(s.to_string())
+        }
+    }
+}
+
+/// Compute the IPC address for this process.
+pub fn default_addr() -> IpcAddr {
+    let pid = std::process::id();
+
+    #[cfg(unix)]
+    {
+        let dir = std::env::var("XDG_RUNTIME_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| std::env::temp_dir());
+        IpcAddr::Unix(dir.join(format!("amux-{}.sock", pid)))
+    }
+
+    #[cfg(windows)]
+    {
+        IpcAddr::NamedPipe(format!(r"\\.\pipe\amux-{}", pid))
+    }
+}
+
+/// Write the IPC address to `{data_dir}/amux/last-socket-path`
+/// so the CLI can discover it without knowing the PID.
+pub fn write_last_addr(addr: &IpcAddr) -> anyhow::Result<()> {
+    let data_dir = dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("amux");
+    std::fs::create_dir_all(&data_dir)?;
+    std::fs::write(data_dir.join("last-socket-path"), addr.to_string())?;
+    Ok(())
+}
+
+/// Read the last-known IPC address (for CLI auto-discovery).
+pub fn read_last_addr() -> anyhow::Result<IpcAddr> {
+    let data_dir = dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("amux");
+    let content = std::fs::read_to_string(data_dir.join("last-socket-path"))?;
+    Ok(IpcAddr::from_stored(content.trim()))
+}

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -255,4 +255,29 @@ impl TerminalPane {
     pub fn rendered_seqno(&self) -> SequenceNo {
         self.seqno
     }
+
+    /// Read the visible screen content as a string (lines joined by newlines).
+    pub fn read_screen_text(&self) -> String {
+        let (cols, rows) = self.dimensions();
+        let screen = self.terminal.screen();
+        let total = screen.scrollback_rows();
+        let start = total.saturating_sub(rows);
+        let lines = screen.lines_in_phys_range(start..total);
+
+        let mut result = String::new();
+        for (i, line) in lines.iter().enumerate() {
+            if i > 0 {
+                result.push('\n');
+            }
+            let mut line_text = String::new();
+            for cell in line.visible_cells() {
+                if cell.cell_index() >= cols {
+                    break;
+                }
+                line_text.push_str(cell.str());
+            }
+            result.push_str(line_text.trim_end());
+        }
+        result
+    }
 }


### PR DESCRIPTION
## Summary
- JSON-RPC v2 socket server (`amux-ipc`) with cross-platform support: Unix sockets (macOS/Linux) + named pipes (Windows) behind `IpcAddr` abstraction
- CLI client (`amux-cli`) with clap: `amux ping/tree/send/read-screen/capabilities/identify`
- Server runs on background tokio thread, communicates with eframe main thread via mpsc channels + oneshot reply pattern
- Environment injection (`AMUX_SOCKET_PATH`, `AMUX_WORKSPACE_ID`, `AMUX_SURFACE_ID`) into PTY child processes
- `TerminalPane::read_screen_text()` for reading visible screen content

## Test plan
- [x] `cargo build --workspace` compiles
- [x] `cargo test --workspace` — 35 tests pass (5 new protocol tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `amux ping` → `{"pong": true}`
- [x] `amux send "echo hello"` → text appears in terminal
- [x] `amux read-screen` → returns visible screen text
- [x] `amux capabilities` → lists 6 methods
- [x] `amux identify` → workspace/surface IDs
- [x] `amux tree` → shows surface tree with title, dimensions, status
- [ ] Verify on Windows (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Inter-Process Communication (IPC) server enabling external tools to query system information, manage surfaces, and interact with terminal content via standardized commands (`system.ping`, `system.capabilities`, `system.identify`, `surface.list`, `surface.send_text`, `surface.read_text`).
  * Implemented fully functional command-line interface with subcommands for connectivity testing, surface inspection, text input/output, and server introspection.
  * Added JSON output mode for programmatic CLI usage and terminal screen content reading capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->