### PR TITLE
Phase 3: Layout engine + split panes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,12 +92,14 @@ name = "amux-app"
 version = "0.1.0"
 dependencies = [
  "amux-ipc",
+ "amux-layout",
  "amux-term",
  "anyhow",
  "arboard",
  "eframe",
  "egui",
  "portable-pty",
+ "serde",
  "serde_json",
  "tracing",
  "tracing-subscriber",
@@ -131,6 +133,10 @@ dependencies = [
 [[package]]
 name = "amux-layout"
 version = "0.1.0"
+dependencies = [
+ "egui",
+ "serde",
+]
 
 [[package]]
 name = "amux-notify"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
+ "wezterm-surface",
  "wezterm-term",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ repository = "https://github.com/yourusername/amux"
 [workspace.dependencies]
 # Terminal engine
 wezterm-term = { git = "https://github.com/wezterm/wezterm", rev = "05343b387085842b434d267f91b6b0ec157e4331" }
+wezterm-surface = { git = "https://github.com/wezterm/wezterm", rev = "05343b387085842b434d267f91b6b0ec157e4331" }
 portable-pty = "0.9"
 
 # Windowing

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -8,6 +8,7 @@ description = "amux main binary: GUI + event loop"
 [dependencies]
 amux-term = { workspace = true }
 wezterm-term = { workspace = true }
+wezterm-surface = { workspace = true }
 eframe = { workspace = true }
 egui = { workspace = true }
 arboard = { workspace = true }

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -16,4 +16,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 portable-pty = { workspace = true }
 amux-ipc = { workspace = true }
+amux-layout = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -207,6 +207,18 @@ impl eframe::App for AmuxApp {
                     // Normal mode: render all panes at computed rects
                     let layout = self.tree.layout(panel_rect);
 
+                    // Click-to-focus: switch focus when clicking inside a pane
+                    if ui.input(|i| i.pointer.any_pressed()) {
+                        if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
+                            for &(id, rect) in &layout {
+                                if rect.contains(pos) && id != self.focused {
+                                    self.focused = id;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
                     // Render dividers
                     let dividers = self.tree.dividers(panel_rect);
                     let painter = ui.painter();

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
 use std::io::Read;
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
 
 use amux_ipc::IpcCommand;
+use amux_layout::{NavDirection, PaneId, PaneTree, SplitDirection};
 use amux_term::color::resolve_color;
 use amux_term::config::AmuxTermConfig;
 use amux_term::pane::TerminalPane;
@@ -19,34 +21,14 @@ fn main() -> anyhow::Result<()> {
     let (ipc_rx, ipc_addr) = amux_ipc::start_server()?;
     tracing::info!("IPC server: {}", ipc_addr);
 
-    // Spawn terminal with user's shell + injected env vars
-    let shell = default_shell();
-    let mut cmd = CommandBuilder::new(&shell);
-    cmd.env("AMUX_SOCKET_PATH", ipc_addr.to_string());
-    cmd.env("AMUX_WORKSPACE_ID", "default");
-    cmd.env("AMUX_SURFACE_ID", "default");
-    cmd.env("TERM", "xterm-256color");
-
     let config = Arc::new(AmuxTermConfig::default());
-    let mut pane = TerminalPane::spawn(80, 24, cmd, config)?;
 
-    // Take reader for background thread
-    let mut reader = pane.take_reader().expect("reader already taken");
-    let (byte_tx, byte_rx) = mpsc::channel::<Vec<u8>>();
+    // Spawn initial pane
+    let initial_id: PaneId = 0;
+    let managed = spawn_managed_pane(80, 24, &ipc_addr, &config)?;
 
-    thread::spawn(move || {
-        let mut buf = [0u8; 8192];
-        loop {
-            match reader.read(&mut buf) {
-                Ok(0) | Err(_) => break,
-                Ok(n) => {
-                    if byte_tx.send(buf[..n].to_vec()).is_err() {
-                        break;
-                    }
-                }
-            }
-        }
-    });
+    let mut panes = HashMap::new();
+    panes.insert(initial_id, managed);
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
@@ -61,18 +43,23 @@ fn main() -> anyhow::Result<()> {
         options,
         Box::new(move |_cc| {
             Ok(Box::new(AmuxApp {
-                pane,
-                byte_rx,
+                panes,
+                tree: PaneTree::new(initial_id),
+                focused: initial_id,
+                zoomed: None,
+                next_pane_id: 1,
                 ipc_rx,
-                last_size: (0, 0),
+                socket_addr: ipc_addr,
+                config,
+                last_panel_rect: None,
+                dragging_divider: None,
+                last_pane_sizes: HashMap::new(),
             }))
         }),
     )
     .map_err(|e| anyhow::anyhow!("{}", e));
 
-    // Clean up socket file
     cleanup_addr(&ipc_addr_cleanup);
-
     result
 }
 
@@ -98,42 +85,137 @@ fn cleanup_addr(addr: &amux_ipc::IpcAddr) {
     }
 }
 
-struct AmuxApp {
+struct ManagedPane {
     pane: TerminalPane,
     byte_rx: mpsc::Receiver<Vec<u8>>,
+}
+
+fn spawn_managed_pane(
+    cols: u16,
+    rows: u16,
+    ipc_addr: &amux_ipc::IpcAddr,
+    config: &Arc<AmuxTermConfig>,
+) -> anyhow::Result<ManagedPane> {
+    let shell = default_shell();
+    let mut cmd = CommandBuilder::new(&shell);
+    cmd.env("AMUX_SOCKET_PATH", ipc_addr.to_string());
+    cmd.env("AMUX_WORKSPACE_ID", "default");
+    cmd.env("AMUX_SURFACE_ID", "default");
+    cmd.env("TERM", "xterm-256color");
+
+    let mut pane = TerminalPane::spawn(cols, rows, cmd, config.clone())?;
+
+    let mut reader = pane.take_reader().expect("reader already taken");
+    let (byte_tx, byte_rx) = mpsc::channel::<Vec<u8>>();
+
+    thread::spawn(move || {
+        let mut buf = [0u8; 8192];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    if byte_tx.send(buf[..n].to_vec()).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(ManagedPane { pane, byte_rx })
+}
+
+struct AmuxApp {
+    panes: HashMap<PaneId, ManagedPane>,
+    tree: PaneTree,
+    focused: PaneId,
+    zoomed: Option<PaneId>,
+    next_pane_id: PaneId,
     ipc_rx: std::sync::mpsc::Receiver<IpcCommand>,
-    last_size: (usize, usize),
+    socket_addr: amux_ipc::IpcAddr,
+    config: Arc<AmuxTermConfig>,
+    last_panel_rect: Option<egui::Rect>,
+    dragging_divider: Option<DragState>,
+    last_pane_sizes: HashMap<PaneId, (usize, usize)>,
+}
+
+struct DragState {
+    node_path: Vec<usize>,
+    direction: SplitDirection,
 }
 
 impl eframe::App for AmuxApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // Drain PTY output from background reader
+        // Drain PTY output from all panes
         let mut got_data = false;
-        while let Ok(bytes) = self.byte_rx.try_recv() {
-            got_data = true;
-            self.pane.feed_bytes(&bytes);
+        for managed in self.panes.values_mut() {
+            while let Ok(bytes) = managed.byte_rx.try_recv() {
+                got_data = true;
+                managed.pane.feed_bytes(&bytes);
+            }
         }
 
         // Process IPC commands
         self.process_ipc_commands();
 
-        // Handle keyboard/paste input
-        self.handle_input(ctx);
+        // Handle keyboard shortcuts BEFORE terminal input
+        let shortcut_consumed = self.handle_shortcuts(ctx);
 
-        // Render terminal
+        // Handle keyboard/paste input → focused pane only
+        if !shortcut_consumed {
+            self.handle_input(ctx);
+        }
+
+        // Render
         egui::CentralPanel::default()
             .frame(egui::Frame::NONE)
             .show(ctx, |ui| {
-                self.render_terminal(ui);
+                let panel_rect = ui.available_rect_before_wrap();
+                self.last_panel_rect = Some(panel_rect);
+
+                // Handle divider dragging
+                self.handle_divider_drag(ui, panel_rect);
+
+                if let Some(zoomed_id) = self.zoomed {
+                    // Zoomed mode: render single pane fullscreen
+                    if let Some(managed) = self.panes.get_mut(&zoomed_id) {
+                        render_pane(ui, &mut managed.pane, panel_rect, true);
+                        self.resize_pane_if_needed(zoomed_id, panel_rect, ui);
+                    }
+                } else {
+                    // Normal mode: render all panes at computed rects
+                    let layout = self.tree.layout(panel_rect);
+
+                    // Render dividers
+                    let dividers = self.tree.dividers(panel_rect);
+                    let painter = ui.painter();
+                    for div in &dividers {
+                        painter.rect_filled(div.rect, 0.0, egui::Color32::from_gray(60));
+                    }
+
+                    // Render each pane
+                    for &(id, rect) in &layout {
+                        let is_focused = id == self.focused;
+                        if let Some(managed) = self.panes.get_mut(&id) {
+                            render_pane(ui, &mut managed.pane, rect, is_focused);
+                        }
+                        self.resize_pane_if_needed(id, rect, ui);
+                    }
+                }
+
+                // Allocate the full panel area for interaction
+                ui.allocate_rect(panel_rect, egui::Sense::click_and_drag());
             });
 
-        // Update window title from terminal
-        let title = self.pane.title();
-        if !title.is_empty() {
-            ctx.send_viewport_cmd(egui::ViewportCommand::Title(format!("amux — {}", title)));
+        // Update window title from focused pane
+        if let Some(managed) = self.panes.get(&self.focused) {
+            let title = managed.pane.title();
+            if !title.is_empty() {
+                ctx.send_viewport_cmd(egui::ViewportCommand::Title(format!("amux — {}", title)));
+            }
         }
 
-        // Smart repaint: immediate when data flowing, slow poll when idle
+        // Smart repaint
         if got_data {
             ctx.request_repaint();
         } else {
@@ -143,6 +225,240 @@ impl eframe::App for AmuxApp {
 }
 
 impl AmuxApp {
+    fn resize_pane_if_needed(&mut self, id: PaneId, rect: egui::Rect, ui: &egui::Ui) {
+        let font_id = egui::FontId::monospace(FONT_SIZE);
+        let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
+        let cell_height = ui.fonts(|f| f.row_height(&font_id));
+
+        let cols = (rect.width() / cell_width).floor() as usize;
+        let rows = (rect.height() / cell_height).floor() as usize;
+
+        if cols == 0 || rows == 0 {
+            return;
+        }
+
+        let last = self.last_pane_sizes.get(&id).copied().unwrap_or((0, 0));
+        if (cols, rows) != last {
+            self.last_pane_sizes.insert(id, (cols, rows));
+            if let Some(managed) = self.panes.get_mut(&id) {
+                let _ = managed.pane.resize(cols as u16, rows as u16);
+            }
+        }
+    }
+
+    fn spawn_pane(&mut self) -> PaneId {
+        let id = self.next_pane_id;
+        self.next_pane_id += 1;
+
+        match spawn_managed_pane(80, 24, &self.socket_addr, &self.config) {
+            Ok(managed) => {
+                self.panes.insert(id, managed);
+            }
+            Err(e) => {
+                tracing::error!("Failed to spawn pane: {}", e);
+            }
+        }
+        id
+    }
+
+    fn handle_shortcuts(&mut self, ctx: &egui::Context) -> bool {
+        let events = ctx.input(|i| i.events.clone());
+
+        for event in &events {
+            if let egui::Event::Key {
+                key,
+                pressed: true,
+                modifiers,
+                ..
+            } = event
+            {
+                // Platform-aware shortcuts
+                #[cfg(target_os = "macos")]
+                let is_cmd = modifiers.mac_cmd || modifiers.command;
+                #[cfg(not(target_os = "macos"))]
+                let is_cmd = modifiers.ctrl && modifiers.shift;
+
+                // Split right: Cmd+D (macOS) / Ctrl+Shift+D
+                if is_cmd && !modifiers.shift && *key == egui::Key::D {
+                    return self.do_split(SplitDirection::Horizontal);
+                }
+                // Split down: Cmd+Shift+D (macOS) / Ctrl+Shift+Down
+                #[cfg(target_os = "macos")]
+                if is_cmd && modifiers.shift && *key == egui::Key::D {
+                    return self.do_split(SplitDirection::Vertical);
+                }
+                #[cfg(not(target_os = "macos"))]
+                if modifiers.ctrl && modifiers.shift && *key == egui::Key::ArrowDown {
+                    return self.do_split(SplitDirection::Vertical);
+                }
+
+                // Close pane: Cmd+W (macOS) / Ctrl+Shift+W
+                if is_cmd && *key == egui::Key::W {
+                    return self.do_close_pane();
+                }
+
+                // Navigate: Option+Cmd+Arrow (macOS) / Ctrl+Alt+Arrow
+                #[cfg(target_os = "macos")]
+                let is_nav = is_cmd && modifiers.alt;
+                #[cfg(not(target_os = "macos"))]
+                let is_nav = modifiers.ctrl && modifiers.alt;
+
+                if is_nav {
+                    let dir = match key {
+                        egui::Key::ArrowLeft => Some(NavDirection::Left),
+                        egui::Key::ArrowRight => Some(NavDirection::Right),
+                        egui::Key::ArrowUp => Some(NavDirection::Up),
+                        egui::Key::ArrowDown => Some(NavDirection::Down),
+                        _ => None,
+                    };
+                    if let Some(dir) = dir {
+                        return self.do_navigate(dir);
+                    }
+                }
+
+                // Zoom toggle: Cmd+Shift+Enter (macOS) / Ctrl+Shift+Enter
+                #[cfg(target_os = "macos")]
+                let is_zoom = is_cmd && modifiers.shift && *key == egui::Key::Enter;
+                #[cfg(not(target_os = "macos"))]
+                let is_zoom = modifiers.ctrl && modifiers.shift && *key == egui::Key::Enter;
+
+                if is_zoom {
+                    return self.do_toggle_zoom();
+                }
+            }
+        }
+        false
+    }
+
+    fn do_split(&mut self, direction: SplitDirection) -> bool {
+        let new_id = self.spawn_pane();
+        self.tree.split(self.focused, direction, new_id);
+        self.focused = new_id;
+        true
+    }
+
+    fn do_close_pane(&mut self) -> bool {
+        // Don't close the last pane
+        if self.tree.iter_panes().len() <= 1 {
+            return true;
+        }
+        let closing = self.focused;
+        if let Some(new_focus) = self.tree.close(closing) {
+            self.focused = new_focus;
+            self.panes.remove(&closing);
+            self.last_pane_sizes.remove(&closing);
+            if self.zoomed == Some(closing) {
+                self.zoomed = None;
+            }
+        }
+        true
+    }
+
+    fn do_navigate(&mut self, dir: NavDirection) -> bool {
+        if let Some(rect) = self.last_panel_rect {
+            if let Some(neighbor) = self.tree.neighbor(self.focused, dir, rect) {
+                self.focused = neighbor;
+            }
+        }
+        true
+    }
+
+    fn do_toggle_zoom(&mut self) -> bool {
+        if self.zoomed.is_some() {
+            self.zoomed = None;
+        } else {
+            self.zoomed = Some(self.focused);
+        }
+        true
+    }
+
+    fn handle_divider_drag(&mut self, ui: &egui::Ui, panel_rect: egui::Rect) {
+        if self.zoomed.is_some() {
+            return;
+        }
+
+        let response = ui.interact(panel_rect, ui.id().with("dividers"), egui::Sense::drag());
+        let pointer_pos = ui.input(|i| i.pointer.hover_pos());
+
+        if let Some(pos) = pointer_pos {
+            let dividers = self.tree.dividers(panel_rect);
+
+            // Hit test for hover cursor
+            let hovering_divider = dividers.iter().find(|d| d.rect.contains(pos));
+            if let Some(div) = hovering_divider {
+                match div.direction {
+                    SplitDirection::Horizontal => {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeHorizontal);
+                    }
+                    SplitDirection::Vertical => {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeVertical);
+                    }
+                }
+            }
+
+            // Start drag
+            if response.drag_started() {
+                if let Some(div) = hovering_divider {
+                    self.dragging_divider = Some(DragState {
+                        node_path: div.node_path.clone(),
+                        direction: div.direction,
+                    });
+                }
+            }
+        }
+
+        // Continue drag
+        if response.dragged() {
+            if let Some(ref drag) = self.dragging_divider {
+                let delta = response.drag_delta();
+                let px_delta = match drag.direction {
+                    SplitDirection::Horizontal => delta.x,
+                    SplitDirection::Vertical => delta.y,
+                };
+                self.tree
+                    .resize_divider(&drag.node_path, px_delta, panel_rect);
+            }
+        }
+
+        if response.drag_stopped() {
+            self.dragging_divider = None;
+        }
+    }
+
+    fn handle_input(&mut self, ctx: &egui::Context) {
+        let events = ctx.input(|i| i.events.clone());
+        let focused = self.focused;
+
+        let managed = match self.panes.get_mut(&focused) {
+            Some(m) => m,
+            None => return,
+        };
+
+        for event in &events {
+            match event {
+                egui::Event::Text(text) => {
+                    let _ = managed.pane.write_bytes(text.as_bytes());
+                }
+                egui::Event::Key {
+                    key,
+                    pressed: true,
+                    modifiers,
+                    ..
+                } => {
+                    if let Some(bytes) = encode_egui_key(key, modifiers) {
+                        let _ = managed.pane.write_bytes(&bytes);
+                    }
+                }
+                egui::Event::Paste(text) => {
+                    let _ = managed.pane.write_bytes(b"\x1b[200~");
+                    let _ = managed.pane.write_bytes(text.as_bytes());
+                    let _ = managed.pane.write_bytes(b"\x1b[201~");
+                }
+                _ => {}
+            }
+        }
+    }
+
     fn process_ipc_commands(&mut self) {
         while let Ok(cmd) = self.ipc_rx.try_recv() {
             let response = self.dispatch_ipc(&cmd.request);
@@ -162,38 +478,163 @@ impl AmuxApp {
                 req.id.clone(),
                 serde_json::json!({
                     "workspace_id": "default",
-                    "surface_id": "default",
+                    "surface_id": self.focused.to_string(),
                 }),
             ),
             "surface.list" => {
-                let (cols, rows) = self.pane.dimensions();
-                Response::ok(
-                    req.id.clone(),
-                    serde_json::json!({
-                        "surfaces": [{
-                            "id": "default",
-                            "title": self.pane.title(),
-                            "cols": cols,
-                            "rows": rows,
-                            "alive": self.pane.is_alive(),
-                        }],
-                    }),
-                )
+                let surfaces: Vec<serde_json::Value> = self
+                    .tree
+                    .iter_panes()
+                    .iter()
+                    .filter_map(|id| {
+                        self.panes.get_mut(id).map(|m| {
+                            let (cols, rows) = m.pane.dimensions();
+                            serde_json::json!({
+                                "id": id.to_string(),
+                                "title": m.pane.title(),
+                                "cols": cols,
+                                "rows": rows,
+                                "alive": m.pane.is_alive(),
+                            })
+                        })
+                    })
+                    .collect();
+                Response::ok(req.id.clone(), serde_json::json!({"surfaces": surfaces}))
             }
             "surface.send_text" => {
                 match serde_json::from_value::<amux_ipc::methods::SendTextParams>(
                     req.params.clone(),
                 ) {
-                    Ok(params) => match self.pane.write_bytes(params.text.as_bytes()) {
-                        Ok(_) => Response::ok(req.id.clone(), serde_json::json!({})),
-                        Err(e) => Response::err(req.id.clone(), "write_error", &e.to_string()),
-                    },
+                    Ok(params) => {
+                        let pane_id = self.resolve_surface_id(&params.surface_id);
+                        match self.panes.get_mut(&pane_id) {
+                            Some(m) => match m.pane.write_bytes(params.text.as_bytes()) {
+                                Ok(_) => Response::ok(req.id.clone(), serde_json::json!({})),
+                                Err(e) => {
+                                    Response::err(req.id.clone(), "write_error", &e.to_string())
+                                }
+                            },
+                            None => Response::err(req.id.clone(), "not_found", "pane not found"),
+                        }
+                    }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
                 }
             }
             "surface.read_text" => {
-                let text = self.pane.read_screen_text();
-                Response::ok(req.id.clone(), serde_json::json!({"text": text}))
+                match serde_json::from_value::<amux_ipc::methods::ReadTextParams>(
+                    req.params.clone(),
+                ) {
+                    Ok(params) => {
+                        let pane_id = self.resolve_surface_id(&params.surface_id);
+                        match self.panes.get(&pane_id) {
+                            Some(m) => {
+                                let text = m.pane.read_screen_text();
+                                Response::ok(req.id.clone(), serde_json::json!({"text": text}))
+                            }
+                            None => Response::err(req.id.clone(), "not_found", "pane not found"),
+                        }
+                    }
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
+            "pane.split" => {
+                #[derive(::serde::Deserialize)]
+                struct SplitParams {
+                    #[serde(default = "default_direction")]
+                    direction: String,
+                }
+                fn default_direction() -> String {
+                    "right".to_string()
+                }
+                match serde_json::from_value::<SplitParams>(req.params.clone()) {
+                    Ok(params) => {
+                        let dir = match params.direction.as_str() {
+                            "down" | "vertical" => SplitDirection::Vertical,
+                            _ => SplitDirection::Horizontal,
+                        };
+                        let new_id = self.spawn_pane();
+                        self.tree.split(self.focused, dir, new_id);
+                        self.focused = new_id;
+                        Response::ok(
+                            req.id.clone(),
+                            serde_json::json!({"pane_id": new_id.to_string()}),
+                        )
+                    }
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
+            "pane.close" => {
+                #[derive(::serde::Deserialize)]
+                struct CloseParams {
+                    #[serde(default)]
+                    pane_id: Option<String>,
+                }
+                match serde_json::from_value::<CloseParams>(req.params.clone()) {
+                    Ok(params) => {
+                        let target = params
+                            .pane_id
+                            .and_then(|s| s.parse::<PaneId>().ok())
+                            .unwrap_or(self.focused);
+                        if self.tree.iter_panes().len() <= 1 {
+                            return Response::err(
+                                req.id.clone(),
+                                "last_pane",
+                                "cannot close the last pane",
+                            );
+                        }
+                        if let Some(new_focus) = self.tree.close(target) {
+                            if self.focused == target {
+                                self.focused = new_focus;
+                            }
+                            self.panes.remove(&target);
+                            self.last_pane_sizes.remove(&target);
+                            if self.zoomed == Some(target) {
+                                self.zoomed = None;
+                            }
+                            Response::ok(
+                                req.id.clone(),
+                                serde_json::json!({"focused": self.focused.to_string()}),
+                            )
+                        } else {
+                            Response::err(req.id.clone(), "not_found", "pane not found in tree")
+                        }
+                    }
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
+            "pane.focus" => {
+                #[derive(::serde::Deserialize)]
+                struct FocusParams {
+                    pane_id: String,
+                }
+                match serde_json::from_value::<FocusParams>(req.params.clone()) {
+                    Ok(params) => match params.pane_id.parse::<PaneId>() {
+                        Ok(id) if self.tree.contains(id) => {
+                            self.focused = id;
+                            Response::ok(req.id.clone(), serde_json::json!({}))
+                        }
+                        _ => Response::err(req.id.clone(), "not_found", "pane not found"),
+                    },
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
+            "pane.list" => {
+                let pane_ids = self.tree.iter_panes();
+                let focused = self.focused;
+                let mut pane_list = Vec::new();
+                for id in &pane_ids {
+                    if let Some(m) = self.panes.get_mut(id) {
+                        let (cols, rows) = m.pane.dimensions();
+                        pane_list.push(serde_json::json!({
+                            "id": id.to_string(),
+                            "focused": *id == focused,
+                            "cols": cols,
+                            "rows": rows,
+                            "alive": m.pane.is_alive(),
+                        }));
+                    }
+                }
+                Response::ok(req.id.clone(), serde_json::json!({"panes": pane_list}))
             }
             _ => Response::err(
                 req.id.clone(),
@@ -203,134 +644,116 @@ impl AmuxApp {
         }
     }
 
-    fn render_terminal(&mut self, ui: &mut egui::Ui) {
-        let font_id = egui::FontId::monospace(FONT_SIZE);
-        let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
-        let cell_height = ui.fonts(|f| f.row_height(&font_id));
-
-        let available = ui.available_size();
-        let cols = (available.x / cell_width).floor() as usize;
-        let rows = (available.y / cell_height).floor() as usize;
-
-        if cols == 0 || rows == 0 {
-            return;
+    fn resolve_surface_id(&self, surface_id: &str) -> PaneId {
+        if surface_id == "default" || surface_id.is_empty() {
+            self.focused
+        } else {
+            surface_id.parse::<PaneId>().unwrap_or(self.focused)
         }
+    }
+}
 
-        // Resize terminal if dimensions changed
-        if (cols, rows) != self.last_size {
-            self.last_size = (cols, rows);
-            let _ = self.pane.resize(cols as u16, rows as u16);
-        }
+fn render_pane(ui: &mut egui::Ui, pane: &mut TerminalPane, rect: egui::Rect, is_focused: bool) {
+    let font_id = egui::FontId::monospace(FONT_SIZE);
+    let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
+    let cell_height = ui.fonts(|f| f.row_height(&font_id));
 
-        let (actual_cols, actual_rows) = self.pane.dimensions();
-        let palette = self.pane.palette();
-        let cursor = self.pane.cursor();
-        let screen = self.pane.screen();
-
-        let painter = ui.painter();
-        let origin = ui.min_rect().min;
-        let bg_default = srgba_to_egui(palette.background);
-
-        // Fill terminal background
-        let terminal_rect = egui::Rect::from_min_size(
-            origin,
-            egui::vec2(
-                actual_cols as f32 * cell_width,
-                actual_rows as f32 * cell_height,
-            ),
-        );
-        painter.rect_filled(terminal_rect, 0.0, bg_default);
-
-        // Draw cells — scrollback_rows() returns total line count (lines.len())
-        let total = screen.scrollback_rows();
-        let start = total.saturating_sub(actual_rows);
-        let lines = screen.lines_in_phys_range(start..total);
-
-        for (row_idx, line) in lines.iter().enumerate() {
-            let y = origin.y + row_idx as f32 * cell_height;
-
-            for cell_ref in line.visible_cells() {
-                let col_idx = cell_ref.cell_index();
-                if col_idx >= actual_cols {
-                    break;
-                }
-
-                let x = origin.x + col_idx as f32 * cell_width;
-                let attrs = cell_ref.attrs();
-                let reverse = attrs.reverse();
-
-                let bg =
-                    srgba_to_egui(resolve_color(&attrs.background(), &palette, false, reverse));
-                let fg = srgba_to_egui(resolve_color(&attrs.foreground(), &palette, true, reverse));
-
-                // Cell background (only if different from default)
-                if bg != bg_default {
-                    painter.rect_filled(
-                        egui::Rect::from_min_size(
-                            egui::pos2(x, y),
-                            egui::vec2(cell_width, cell_height),
-                        ),
-                        0.0,
-                        bg,
-                    );
-                }
-
-                // Cell text
-                let text = cell_ref.str();
-                if !text.is_empty() && text != " " {
-                    painter.text(
-                        egui::pos2(x, y),
-                        egui::Align2::LEFT_TOP,
-                        text,
-                        font_id.clone(),
-                        fg,
-                    );
-                }
-            }
-        }
-
-        // Draw cursor
-        if cursor.y >= 0 && (cursor.y as usize) < actual_rows && cursor.x < actual_cols {
-            let cx = origin.x + cursor.x as f32 * cell_width;
-            let cy = origin.y + cursor.y as f32 * cell_height;
-            let cursor_color = srgba_to_egui(palette.cursor_bg);
-            painter.rect_filled(
-                egui::Rect::from_min_size(egui::pos2(cx, cy), egui::vec2(cell_width, cell_height)),
-                0.0,
-                cursor_color,
-            );
-        }
-
-        // Tell egui we used this space
-        ui.allocate_rect(terminal_rect, egui::Sense::click_and_drag());
+    let (actual_cols, actual_rows) = pane.dimensions();
+    if actual_cols == 0 || actual_rows == 0 {
+        return;
     }
 
-    fn handle_input(&mut self, ctx: &egui::Context) {
-        let events = ctx.input(|i| i.events.clone());
+    let palette = pane.palette();
+    let cursor = pane.cursor();
+    let screen = pane.screen();
 
-        for event in &events {
-            match event {
-                egui::Event::Text(text) => {
-                    let _ = self.pane.write_bytes(text.as_bytes());
-                }
-                egui::Event::Key {
-                    key,
-                    pressed: true,
-                    modifiers,
-                    ..
-                } => {
-                    if let Some(bytes) = encode_egui_key(key, modifiers) {
-                        let _ = self.pane.write_bytes(&bytes);
-                    }
-                }
-                egui::Event::Paste(text) => {
-                    let _ = self.pane.write_bytes(b"\x1b[200~");
-                    let _ = self.pane.write_bytes(text.as_bytes());
-                    let _ = self.pane.write_bytes(b"\x1b[201~");
-                }
-                _ => {}
+    let painter = ui.painter();
+    let origin = rect.min;
+    let bg_default = srgba_to_egui(palette.background);
+
+    // Fill terminal background
+    let terminal_rect = egui::Rect::from_min_size(
+        origin,
+        egui::vec2(
+            actual_cols as f32 * cell_width,
+            actual_rows as f32 * cell_height,
+        ),
+    );
+    // Clip to pane rect
+    let clipped_rect = terminal_rect.intersect(rect);
+    painter.rect_filled(clipped_rect, 0.0, bg_default);
+
+    // Draw cells
+    let total = screen.scrollback_rows();
+    let start = total.saturating_sub(actual_rows);
+    let lines = screen.lines_in_phys_range(start..total);
+
+    for (row_idx, line) in lines.iter().enumerate() {
+        let y = origin.y + row_idx as f32 * cell_height;
+        if y + cell_height < rect.min.y || y > rect.max.y {
+            continue; // clip
+        }
+
+        for cell_ref in line.visible_cells() {
+            let col_idx = cell_ref.cell_index();
+            if col_idx >= actual_cols {
+                break;
+            }
+
+            let x = origin.x + col_idx as f32 * cell_width;
+            if x + cell_width < rect.min.x || x > rect.max.x {
+                continue; // clip
+            }
+
+            let attrs = cell_ref.attrs();
+            let reverse = attrs.reverse();
+            let bg = srgba_to_egui(resolve_color(&attrs.background(), &palette, false, reverse));
+            let fg = srgba_to_egui(resolve_color(&attrs.foreground(), &palette, true, reverse));
+
+            if bg != bg_default {
+                painter.rect_filled(
+                    egui::Rect::from_min_size(
+                        egui::pos2(x, y),
+                        egui::vec2(cell_width, cell_height),
+                    ),
+                    0.0,
+                    bg,
+                );
+            }
+
+            let text = cell_ref.str();
+            if !text.is_empty() && text != " " {
+                painter.text(
+                    egui::pos2(x, y),
+                    egui::Align2::LEFT_TOP,
+                    text,
+                    font_id.clone(),
+                    fg,
+                );
             }
         }
+    }
+
+    // Draw cursor
+    if cursor.y >= 0 && (cursor.y as usize) < actual_rows && cursor.x < actual_cols {
+        let cx = origin.x + cursor.x as f32 * cell_width;
+        let cy = origin.y + cursor.y as f32 * cell_height;
+        let cursor_color = srgba_to_egui(palette.cursor_bg);
+        painter.rect_filled(
+            egui::Rect::from_min_size(egui::pos2(cx, cy), egui::vec2(cell_width, cell_height)),
+            0.0,
+            cursor_color,
+        );
+    }
+
+    // Focus indicator: subtle border on focused pane
+    if is_focused {
+        painter.rect_stroke(
+            rect,
+            0.0,
+            egui::Stroke::new(2.0, egui::Color32::from_rgb(80, 140, 220)),
+            egui::StrokeKind::Inside,
+        );
     }
 }
 
@@ -346,21 +769,18 @@ fn srgba_to_egui(color: SrgbaTuple) -> egui::Color32 {
 // --- Key encoding (egui events → terminal bytes) ---
 
 fn encode_egui_key(key: &egui::Key, modifiers: &egui::Modifiers) -> Option<Vec<u8>> {
-    // Ctrl+letter → control character
     if modifiers.ctrl && !modifiers.alt {
         if let Some(byte) = ctrl_byte_for_key(key) {
             return Some(vec![byte]);
         }
     }
 
-    // Alt+letter → ESC prefix + letter
     if modifiers.alt && !modifiers.ctrl {
         if let Some(ch) = key_to_char(key) {
             return Some(vec![0x1b, ch as u8]);
         }
     }
 
-    // Ctrl+Alt → ESC prefix + control character
     if modifiers.ctrl && modifiers.alt {
         if let Some(byte) = ctrl_byte_for_key(key) {
             return Some(vec![0x1b, byte]);
@@ -388,13 +808,11 @@ fn encode_egui_key(key: &egui::Key, modifiers: &egui::Modifiers) -> Option<Vec<u
         }
         egui::Key::Space if modifiers.ctrl => Some(vec![0x00]),
 
-        // Arrow keys
         egui::Key::ArrowUp => Some(encode_arrow(b'A', modifier_param)),
         egui::Key::ArrowDown => Some(encode_arrow(b'B', modifier_param)),
         egui::Key::ArrowRight => Some(encode_arrow(b'C', modifier_param)),
         egui::Key::ArrowLeft => Some(encode_arrow(b'D', modifier_param)),
 
-        // Navigation
         egui::Key::Home => Some(encode_csi_letter(b'H', modifier_param)),
         egui::Key::End => Some(encode_csi_letter(b'F', modifier_param)),
         egui::Key::Insert => Some(encode_csi_tilde(2, modifier_param)),
@@ -402,7 +820,6 @@ fn encode_egui_key(key: &egui::Key, modifiers: &egui::Modifiers) -> Option<Vec<u
         egui::Key::PageUp => Some(encode_csi_tilde(5, modifier_param)),
         egui::Key::PageDown => Some(encode_csi_tilde(6, modifier_param)),
 
-        // Function keys
         egui::Key::F1 => Some(encode_fn_key(b'P', 11, modifier_param)),
         egui::Key::F2 => Some(encode_fn_key(b'Q', 12, modifier_param)),
         egui::Key::F3 => Some(encode_fn_key(b'R', 13, modifier_param)),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -10,6 +10,7 @@ use amux_term::color::resolve_color;
 use amux_term::config::AmuxTermConfig;
 use amux_term::pane::TerminalPane;
 use portable_pty::CommandBuilder;
+use wezterm_surface::{CursorShape, CursorVisibility};
 use wezterm_term::color::SrgbaTuple;
 
 const FONT_SIZE: f32 = 14.0;
@@ -810,39 +811,60 @@ fn render_pane(
         }
     }
 
-    // Draw cursor only in the focused pane, and only when not scrolled up
+    // Draw cursor: respect visibility (TUI apps hide it) and shape
     if is_focused
         && scroll_offset == 0
+        && cursor.visibility == CursorVisibility::Visible
         && cursor.y >= 0
         && (cursor.y as usize) < actual_rows
         && cursor.x < actual_cols
     {
         let cx = origin.x + cursor.x as f32 * cell_width;
         let cy = origin.y + cursor.y as f32 * cell_height;
-        let cursor_rect =
-            egui::Rect::from_min_size(egui::pos2(cx, cy), egui::vec2(cell_width, cell_height));
+        let cursor_color = srgba_to_egui(palette.cursor_bg);
 
-        let cursor_bg = srgba_to_egui(palette.cursor_bg);
-        let cursor_fg = srgba_to_egui(palette.cursor_fg);
-        painter.rect_filled(cursor_rect, 0.0, cursor_bg);
+        match cursor.shape {
+            CursorShape::BlinkingBar | CursorShape::SteadyBar => {
+                // Thin vertical bar (2px wide)
+                let bar_rect =
+                    egui::Rect::from_min_size(egui::pos2(cx, cy), egui::vec2(2.0, cell_height));
+                painter.rect_filled(bar_rect, 0.0, cursor_color);
+            }
+            CursorShape::BlinkingUnderline | CursorShape::SteadyUnderline => {
+                // Underline (2px tall at bottom of cell)
+                let underline_rect = egui::Rect::from_min_size(
+                    egui::pos2(cx, cy + cell_height - 2.0),
+                    egui::vec2(cell_width, 2.0),
+                );
+                painter.rect_filled(underline_rect, 0.0, cursor_color);
+            }
+            CursorShape::Default | CursorShape::BlinkingBlock | CursorShape::SteadyBlock => {
+                // Block cursor: fill background, re-draw character in cursor_fg
+                let cursor_rect = egui::Rect::from_min_size(
+                    egui::pos2(cx, cy),
+                    egui::vec2(cell_width, cell_height),
+                );
+                let cursor_fg = srgba_to_egui(palette.cursor_fg);
+                painter.rect_filled(cursor_rect, 0.0, cursor_color);
 
-        // Re-draw the character under the cursor in inverse color
-        let cursor_line_idx = cursor.y as usize;
-        if cursor_line_idx < lines.len() {
-            let line = &lines[cursor_line_idx];
-            for cell_ref in line.visible_cells() {
-                if cell_ref.cell_index() == cursor.x {
-                    let text = cell_ref.str();
-                    if !text.is_empty() && text != " " {
-                        painter.text(
-                            egui::pos2(cx, cy),
-                            egui::Align2::LEFT_TOP,
-                            text,
-                            font_id.clone(),
-                            cursor_fg,
-                        );
+                let cursor_line_idx = cursor.y as usize;
+                if cursor_line_idx < lines.len() {
+                    let line = &lines[cursor_line_idx];
+                    for cell_ref in line.visible_cells() {
+                        if cell_ref.cell_index() == cursor.x {
+                            let text = cell_ref.str();
+                            if !text.is_empty() && text != " " {
+                                painter.text(
+                                    egui::pos2(cx, cy),
+                                    egui::Align2::LEFT_TOP,
+                                    text,
+                                    font_id.clone(),
+                                    cursor_fg,
+                                );
+                            }
+                            break;
+                        }
                     }
-                    break;
                 }
             }
         }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -810,8 +810,9 @@ fn render_pane(
         }
     }
 
-    // Draw cursor (only when at bottom — not scrolled up)
-    if scroll_offset == 0
+    // Draw cursor only in the focused pane, and only when not scrolled up
+    if is_focused
+        && scroll_offset == 0
         && cursor.y >= 0
         && (cursor.y as usize) < actual_rows
         && cursor.x < actual_cols
@@ -821,40 +822,29 @@ fn render_pane(
         let cursor_rect =
             egui::Rect::from_min_size(egui::pos2(cx, cy), egui::vec2(cell_width, cell_height));
 
-        if is_focused {
-            // Block cursor: fill background, re-draw character in cursor_fg
-            let cursor_bg = srgba_to_egui(palette.cursor_bg);
-            let cursor_fg = srgba_to_egui(palette.cursor_fg);
-            painter.rect_filled(cursor_rect, 0.0, cursor_bg);
+        let cursor_bg = srgba_to_egui(palette.cursor_bg);
+        let cursor_fg = srgba_to_egui(palette.cursor_fg);
+        painter.rect_filled(cursor_rect, 0.0, cursor_bg);
 
-            // Re-draw the character under the cursor
-            let cursor_line_idx = cursor.y as usize;
-            if cursor_line_idx < lines.len() {
-                let line = &lines[cursor_line_idx];
-                for cell_ref in line.visible_cells() {
-                    if cell_ref.cell_index() == cursor.x {
-                        let text = cell_ref.str();
-                        if !text.is_empty() && text != " " {
-                            painter.text(
-                                egui::pos2(cx, cy),
-                                egui::Align2::LEFT_TOP,
-                                text,
-                                font_id.clone(),
-                                cursor_fg,
-                            );
-                        }
-                        break;
+        // Re-draw the character under the cursor in inverse color
+        let cursor_line_idx = cursor.y as usize;
+        if cursor_line_idx < lines.len() {
+            let line = &lines[cursor_line_idx];
+            for cell_ref in line.visible_cells() {
+                if cell_ref.cell_index() == cursor.x {
+                    let text = cell_ref.str();
+                    if !text.is_empty() && text != " " {
+                        painter.text(
+                            egui::pos2(cx, cy),
+                            egui::Align2::LEFT_TOP,
+                            text,
+                            font_id.clone(),
+                            cursor_fg,
+                        );
                     }
+                    break;
                 }
             }
-        } else {
-            // Unfocused: hollow rectangle outline
-            painter.rect_stroke(
-                cursor_rect,
-                0.0,
-                egui::Stroke::new(1.0, srgba_to_egui(palette.cursor_bg)),
-                egui::StrokeKind::Inside,
-            );
         }
     }
 

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -88,6 +88,8 @@ fn cleanup_addr(addr: &amux_ipc::IpcAddr) {
 struct ManagedPane {
     pane: TerminalPane,
     byte_rx: mpsc::Receiver<Vec<u8>>,
+    /// Scrollback offset: 0 = bottom (live), >0 = scrolled up by N lines.
+    scroll_offset: usize,
 }
 
 fn spawn_managed_pane(
@@ -122,7 +124,11 @@ fn spawn_managed_pane(
         }
     });
 
-    Ok(ManagedPane { pane, byte_rx })
+    Ok(ManagedPane {
+        pane,
+        byte_rx,
+        scroll_offset: 0,
+    })
 }
 
 struct AmuxApp {
@@ -149,9 +155,17 @@ impl eframe::App for AmuxApp {
         // Drain PTY output from all panes
         let mut got_data = false;
         for managed in self.panes.values_mut() {
+            let mut pane_got_data = false;
             while let Ok(bytes) = managed.byte_rx.try_recv() {
-                got_data = true;
+                pane_got_data = true;
                 managed.pane.feed_bytes(&bytes);
+            }
+            if pane_got_data {
+                got_data = true;
+                // Auto-snap to bottom when new output arrives
+                if managed.scroll_offset > 0 {
+                    managed.scroll_offset = 0;
+                }
             }
         }
 
@@ -179,7 +193,13 @@ impl eframe::App for AmuxApp {
                 if let Some(zoomed_id) = self.zoomed {
                     // Zoomed mode: render single pane fullscreen
                     if let Some(managed) = self.panes.get_mut(&zoomed_id) {
-                        render_pane(ui, &mut managed.pane, panel_rect, true);
+                        render_pane(
+                            ui,
+                            &mut managed.pane,
+                            panel_rect,
+                            true,
+                            managed.scroll_offset,
+                        );
                         self.resize_pane_if_needed(zoomed_id, panel_rect, ui);
                     }
                 } else {
@@ -197,7 +217,13 @@ impl eframe::App for AmuxApp {
                     for &(id, rect) in &layout {
                         let is_focused = id == self.focused;
                         if let Some(managed) = self.panes.get_mut(&id) {
-                            render_pane(ui, &mut managed.pane, rect, is_focused);
+                            render_pane(
+                                ui,
+                                &mut managed.pane,
+                                rect,
+                                is_focused,
+                                managed.scroll_offset,
+                            );
                         }
                         self.resize_pane_if_needed(id, rect, ui);
                     }
@@ -325,8 +351,27 @@ impl AmuxApp {
                 if is_zoom {
                     return self.do_toggle_zoom();
                 }
+
+                // Scroll: Shift+PageUp / Shift+PageDown
+                if modifiers.shift && *key == egui::Key::PageUp {
+                    return self.do_scroll(-1);
+                }
+                if modifiers.shift && *key == egui::Key::PageDown {
+                    return self.do_scroll(1);
+                }
             }
         }
+
+        // Mouse wheel scrolling on focused pane
+        let scroll_delta = ctx.input(|i| i.smooth_scroll_delta.y);
+        if scroll_delta != 0.0 {
+            // Convert pixel delta to lines (3 lines per scroll notch)
+            let lines = (-scroll_delta / 20.0).round() as isize;
+            if lines != 0 {
+                self.do_scroll_lines(lines);
+            }
+        }
+
         false
     }
 
@@ -370,6 +415,30 @@ impl AmuxApp {
             self.zoomed = Some(self.focused);
         }
         true
+    }
+
+    /// Scroll focused pane by pages (-1 = page up, 1 = page down).
+    fn do_scroll(&mut self, pages: isize) -> bool {
+        if let Some(managed) = self.panes.get_mut(&self.focused) {
+            let (_, rows) = managed.pane.dimensions();
+            let page_size = rows.saturating_sub(1).max(1);
+            let lines = pages * page_size as isize;
+            self.do_scroll_lines(lines);
+        }
+        true
+    }
+
+    /// Scroll focused pane by N lines (positive = scroll down/toward bottom,
+    /// negative = scroll up/toward history).
+    fn do_scroll_lines(&mut self, lines: isize) {
+        if let Some(managed) = self.panes.get_mut(&self.focused) {
+            let (_, rows) = managed.pane.dimensions();
+            let total = managed.pane.screen().scrollback_rows();
+            let max_offset = total.saturating_sub(rows);
+
+            let new_offset = managed.scroll_offset as isize - lines;
+            managed.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
+        }
     }
 
     fn handle_divider_drag(&mut self, ui: &egui::Ui, panel_rect: egui::Rect) {
@@ -653,7 +722,13 @@ impl AmuxApp {
     }
 }
 
-fn render_pane(ui: &mut egui::Ui, pane: &mut TerminalPane, rect: egui::Rect, is_focused: bool) {
+fn render_pane(
+    ui: &mut egui::Ui,
+    pane: &mut TerminalPane,
+    rect: egui::Rect,
+    is_focused: bool,
+    scroll_offset: usize,
+) {
     let font_id = egui::FontId::monospace(FONT_SIZE);
     let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
     let cell_height = ui.fonts(|f| f.row_height(&font_id));
@@ -683,10 +758,11 @@ fn render_pane(ui: &mut egui::Ui, pane: &mut TerminalPane, rect: egui::Rect, is_
     let clipped_rect = terminal_rect.intersect(rect);
     painter.rect_filled(clipped_rect, 0.0, bg_default);
 
-    // Draw cells
+    // Draw cells — apply scroll offset (0 = bottom/live view)
     let total = screen.scrollback_rows();
-    let start = total.saturating_sub(actual_rows);
-    let lines = screen.lines_in_phys_range(start..total);
+    let end = total.saturating_sub(scroll_offset);
+    let start = end.saturating_sub(actual_rows);
+    let lines = screen.lines_in_phys_range(start..end);
 
     for (row_idx, line) in lines.iter().enumerate() {
         let y = origin.y + row_idx as f32 * cell_height;
@@ -734,8 +810,12 @@ fn render_pane(ui: &mut egui::Ui, pane: &mut TerminalPane, rect: egui::Rect, is_
         }
     }
 
-    // Draw cursor
-    if cursor.y >= 0 && (cursor.y as usize) < actual_rows && cursor.x < actual_cols {
+    // Draw cursor (only when at bottom — not scrolled up)
+    if scroll_offset == 0
+        && cursor.y >= 0
+        && (cursor.y as usize) < actual_rows
+        && cursor.x < actual_cols
+    {
         let cx = origin.x + cursor.x as f32 * cell_width;
         let cy = origin.y + cursor.y as f32 * cell_height;
         let cursor_color = srgba_to_egui(palette.cursor_bg);

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -91,6 +91,8 @@ struct ManagedPane {
     byte_rx: mpsc::Receiver<Vec<u8>>,
     /// Scrollback offset: 0 = bottom (live), >0 = scrolled up by N lines.
     scroll_offset: usize,
+    /// Accumulated fractional scroll for smooth trackpad scrolling.
+    scroll_accum: f32,
 }
 
 fn spawn_managed_pane(
@@ -129,6 +131,7 @@ fn spawn_managed_pane(
         pane,
         byte_rx,
         scroll_offset: 0,
+        scroll_accum: 0.0,
     })
 }
 
@@ -156,17 +159,9 @@ impl eframe::App for AmuxApp {
         // Drain PTY output from all panes
         let mut got_data = false;
         for managed in self.panes.values_mut() {
-            let mut pane_got_data = false;
             while let Ok(bytes) = managed.byte_rx.try_recv() {
-                pane_got_data = true;
-                managed.pane.feed_bytes(&bytes);
-            }
-            if pane_got_data {
                 got_data = true;
-                // Auto-snap to bottom when new output arrives
-                if managed.scroll_offset > 0 {
-                    managed.scroll_offset = 0;
-                }
+                managed.pane.feed_bytes(&bytes);
             }
         }
 
@@ -375,13 +370,20 @@ impl AmuxApp {
             }
         }
 
-        // Mouse wheel scrolling on focused pane
+        // Mouse wheel scrolling — accumulate fractional lines for smooth trackpad
         let scroll_delta = ctx.input(|i| i.smooth_scroll_delta.y);
         if scroll_delta != 0.0 {
-            // Convert pixel delta to lines (3 lines per scroll notch)
-            let lines = (-scroll_delta / 20.0).round() as isize;
-            if lines != 0 {
-                self.do_scroll_lines(lines);
+            if let Some(managed) = self.panes.get_mut(&self.focused) {
+                let font_id = egui::FontId::monospace(FONT_SIZE);
+                let cell_height = ctx.fonts(|f| f.row_height(&font_id));
+
+                // Accumulate pixel delta, convert to lines when >= 1 line
+                managed.scroll_accum += -scroll_delta / cell_height;
+                let whole_lines = managed.scroll_accum.trunc() as isize;
+                if whole_lines != 0 {
+                    managed.scroll_accum -= whole_lines as f32;
+                    self.do_scroll_lines(whole_lines);
+                }
             }
         }
 
@@ -535,6 +537,9 @@ impl AmuxApp {
         for event in &events {
             match event {
                 egui::Event::Text(text) => {
+                    // Snap to bottom on user input
+                    managed.scroll_offset = 0;
+                    managed.scroll_accum = 0.0;
                     let _ = managed.pane.write_bytes(text.as_bytes());
                 }
                 egui::Event::Key {
@@ -544,10 +549,15 @@ impl AmuxApp {
                     ..
                 } => {
                     if let Some(bytes) = encode_egui_key(key, modifiers) {
+                        // Snap to bottom on user input
+                        managed.scroll_offset = 0;
+                        managed.scroll_accum = 0.0;
                         let _ = managed.pane.write_bytes(&bytes);
                     }
                 }
                 egui::Event::Paste(text) => {
+                    managed.scroll_offset = 0;
+                    managed.scroll_accum = 0.0;
                     let _ = managed.pane.write_bytes(b"\x1b[200~");
                     let _ = managed.pane.write_bytes(text.as_bytes());
                     let _ = managed.pane.write_bytes(b"\x1b[201~");
@@ -896,6 +906,34 @@ fn render_pane(
                 }
             }
         }
+    }
+
+    // Scroll indicator when viewing history
+    if scroll_offset > 0 {
+        let indicator = format!("[+{}]", scroll_offset);
+        let indicator_font = egui::FontId::monospace(FONT_SIZE * 0.8);
+        let text_color = egui::Color32::from_rgba_unmultiplied(255, 200, 50, 200);
+        let bg_color = egui::Color32::from_rgba_unmultiplied(40, 40, 40, 180);
+
+        let galley = painter.layout_no_wrap(indicator, indicator_font, text_color);
+        let text_size = galley.size();
+        let padding = 4.0;
+        let indicator_rect = egui::Rect::from_min_size(
+            egui::pos2(
+                rect.right() - text_size.x - padding * 2.0,
+                rect.top() + padding,
+            ),
+            egui::vec2(text_size.x + padding * 2.0, text_size.y + padding),
+        );
+        painter.rect_filled(indicator_rect, 3.0, bg_color);
+        painter.galley(
+            egui::pos2(
+                indicator_rect.left() + padding,
+                indicator_rect.top() + padding * 0.5,
+            ),
+            galley,
+            text_color,
+        );
     }
 
     // Focus indicator: subtle border on focused pane

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -459,28 +459,33 @@ impl AmuxApp {
             return;
         }
 
-        let response = ui.interact(panel_rect, ui.id().with("dividers"), egui::Sense::drag());
+        let dividers = self.tree.dividers(panel_rect);
         let pointer_pos = ui.input(|i| i.pointer.hover_pos());
+        let primary_down = ui.input(|i| i.pointer.primary_down());
+        let primary_pressed = ui.input(|i| i.pointer.primary_pressed());
+        let primary_released = ui.input(|i| i.pointer.primary_released());
 
+        // Hover cursor feedback
         if let Some(pos) = pointer_pos {
-            let dividers = self.tree.dividers(panel_rect);
-
-            // Hit test for hover cursor
-            let hovering_divider = dividers.iter().find(|d| d.rect.contains(pos));
-            if let Some(div) = hovering_divider {
-                match div.direction {
-                    SplitDirection::Horizontal => {
-                        ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeHorizontal);
-                    }
-                    SplitDirection::Vertical => {
-                        ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeVertical);
+            if self.dragging_divider.is_none() {
+                if let Some(div) = dividers.iter().find(|d| d.rect.contains(pos)) {
+                    match div.direction {
+                        SplitDirection::Horizontal => {
+                            ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeHorizontal);
+                        }
+                        SplitDirection::Vertical => {
+                            ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeVertical);
+                        }
                     }
                 }
             }
+        }
 
-            // Start drag
-            if response.drag_started() {
-                if let Some(div) = hovering_divider {
+        // Start drag on click over a divider
+        if primary_pressed && self.dragging_divider.is_none() {
+            if let Some(pos) = pointer_pos {
+                // Use a slightly expanded hit area for easier grabbing
+                if let Some(div) = dividers.iter().find(|d| d.rect.expand(4.0).contains(pos)) {
                     self.dragging_divider = Some(DragState {
                         node_path: div.node_path.clone(),
                         direction: div.direction,
@@ -489,20 +494,31 @@ impl AmuxApp {
             }
         }
 
-        // Continue drag
-        if response.dragged() {
+        // Continue drag using pointer delta
+        if primary_down {
             if let Some(ref drag) = self.dragging_divider {
-                let delta = response.drag_delta();
+                let delta = ui.input(|i| i.pointer.delta());
                 let px_delta = match drag.direction {
                     SplitDirection::Horizontal => delta.x,
                     SplitDirection::Vertical => delta.y,
                 };
-                self.tree
-                    .resize_divider(&drag.node_path, px_delta, panel_rect);
+                if px_delta != 0.0 {
+                    self.tree
+                        .resize_divider(&drag.node_path, px_delta, panel_rect);
+                }
+                // Show resize cursor while dragging
+                match drag.direction {
+                    SplitDirection::Horizontal => {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeHorizontal);
+                    }
+                    SplitDirection::Vertical => {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeVertical);
+                    }
+                }
             }
         }
 
-        if response.drag_stopped() {
+        if primary_released {
             self.dragging_divider = None;
         }
     }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -818,12 +818,44 @@ fn render_pane(
     {
         let cx = origin.x + cursor.x as f32 * cell_width;
         let cy = origin.y + cursor.y as f32 * cell_height;
-        let cursor_color = srgba_to_egui(palette.cursor_bg);
-        painter.rect_filled(
-            egui::Rect::from_min_size(egui::pos2(cx, cy), egui::vec2(cell_width, cell_height)),
-            0.0,
-            cursor_color,
-        );
+        let cursor_rect =
+            egui::Rect::from_min_size(egui::pos2(cx, cy), egui::vec2(cell_width, cell_height));
+
+        if is_focused {
+            // Block cursor: fill background, re-draw character in cursor_fg
+            let cursor_bg = srgba_to_egui(palette.cursor_bg);
+            let cursor_fg = srgba_to_egui(palette.cursor_fg);
+            painter.rect_filled(cursor_rect, 0.0, cursor_bg);
+
+            // Re-draw the character under the cursor
+            let cursor_line_idx = cursor.y as usize;
+            if cursor_line_idx < lines.len() {
+                let line = &lines[cursor_line_idx];
+                for cell_ref in line.visible_cells() {
+                    if cell_ref.cell_index() == cursor.x {
+                        let text = cell_ref.str();
+                        if !text.is_empty() && text != " " {
+                            painter.text(
+                                egui::pos2(cx, cy),
+                                egui::Align2::LEFT_TOP,
+                                text,
+                                font_id.clone(),
+                                cursor_fg,
+                            );
+                        }
+                        break;
+                    }
+                }
+            }
+        } else {
+            // Unfocused: hollow rectangle outline
+            painter.rect_stroke(
+                cursor_rect,
+                0.0,
+                egui::Stroke::new(1.0, srgba_to_egui(palette.cursor_bg)),
+                egui::StrokeKind::Inside,
+            );
+        }
     }
 
     // Focus indicator: subtle border on focused pane

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -40,6 +40,25 @@ enum Command {
     Capabilities,
     /// Identify focused workspace/surface
     Identify,
+    /// Split the focused pane
+    Split {
+        /// Split direction: right or down
+        #[arg(long, default_value = "right")]
+        direction: String,
+    },
+    /// Close a pane
+    ClosePane {
+        /// Pane ID to close (defaults to focused)
+        #[arg(long)]
+        pane: Option<String>,
+    },
+    /// Focus a specific pane
+    FocusPane {
+        /// Pane ID to focus
+        pane_id: String,
+    },
+    /// List all panes
+    ListPanes,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -109,6 +128,61 @@ async fn main() -> anyhow::Result<()> {
                 .await?;
             print_response(&resp, cli.json);
         }
+        Command::Split { direction } => {
+            let resp = client
+                .call(
+                    "pane.split",
+                    serde_json::json!({
+                        "direction": direction,
+                    }),
+                )
+                .await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                if let Some(result) = &resp.result {
+                    if let Some(id) = result.get("pane_id").and_then(|v| v.as_str()) {
+                        println!("Split pane created: {}", id);
+                    }
+                }
+            } else {
+                print_response(&resp, false);
+            }
+        }
+        Command::ClosePane { pane } => {
+            let params = match pane {
+                Some(id) => serde_json::json!({"pane_id": id}),
+                None => serde_json::json!({}),
+            };
+            let resp = client.call("pane.close", params).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                println!("Pane closed");
+            } else {
+                print_response(&resp, false);
+            }
+        }
+        Command::FocusPane { pane_id } => {
+            let resp = client
+                .call("pane.focus", serde_json::json!({"pane_id": pane_id}))
+                .await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                println!("Focused pane {}", pane_id);
+            } else {
+                print_response(&resp, false);
+            }
+        }
+        Command::ListPanes => {
+            let resp = client.call("pane.list", serde_json::json!({})).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if let Some(result) = &resp.result {
+                print_pane_list(result);
+            }
+        }
     }
     Ok(())
 }
@@ -118,12 +192,10 @@ fn resolve_addr(cli: &Cli) -> anyhow::Result<IpcAddr> {
         return Ok(IpcAddr::from_stored(socket));
     }
 
-    // Check environment variable
     if let Ok(path) = std::env::var("AMUX_SOCKET_PATH") {
         return Ok(IpcAddr::from_stored(&path));
     }
 
-    // Fall back to last-known address
     read_last_addr()
 }
 
@@ -162,6 +234,24 @@ fn print_tree(result: &serde_json::Value) {
                 "  {} surface:{} \"{}\" {}x{} [{}]",
                 prefix, id, title, cols, rows, status
             );
+        }
+    }
+}
+
+fn print_pane_list(result: &serde_json::Value) {
+    if let Some(panes) = result.get("panes").and_then(|p| p.as_array()) {
+        for pane in panes {
+            let id = pane.get("id").and_then(|v| v.as_str()).unwrap_or("?");
+            let focused = pane
+                .get("focused")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let cols = pane.get("cols").and_then(|v| v.as_u64()).unwrap_or(0);
+            let rows = pane.get("rows").and_then(|v| v.as_u64()).unwrap_or(0);
+            let alive = pane.get("alive").and_then(|v| v.as_bool()).unwrap_or(false);
+            let focus_marker = if focused { " *" } else { "" };
+            let status = if alive { "running" } else { "exited" };
+            println!("pane:{}{} {}x{} [{}]", id, focus_marker, cols, rows, status);
         }
     }
 }

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -8,6 +8,10 @@ pub const METHODS: &[&str] = &[
     "surface.send_text",
     "surface.read_text",
     "surface.list",
+    "pane.split",
+    "pane.close",
+    "pane.focus",
+    "pane.list",
 ];
 
 // --- Params ---

--- a/crates/amux-layout/Cargo.toml
+++ b/crates/amux-layout/Cargo.toml
@@ -6,3 +6,5 @@ license.workspace = true
 description = "amux PaneTree binary tree layout engine"
 
 [dependencies]
+serde = { workspace = true }
+egui = { workspace = true }

--- a/crates/amux-layout/src/lib.rs
+++ b/crates/amux-layout/src/lib.rs
@@ -1,1 +1,433 @@
+use egui::Rect;
+use serde::{Deserialize, Serialize};
 
+pub type PaneId = u64;
+
+/// Divider thickness in logical pixels (split between the two children).
+const DIVIDER_PX: f32 = 4.0;
+
+/// Minimum pane dimension in pixels (prevents degenerate splits).
+const MIN_PANE_PX: f32 = 20.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SplitDirection {
+    Horizontal,
+    Vertical,
+}
+
+/// A divider between two panes, for hit-testing and dragging.
+#[derive(Debug, Clone)]
+pub struct Divider {
+    pub rect: Rect,
+    pub direction: SplitDirection,
+    /// Path of child indices from root to the Split node that owns this divider.
+    pub node_path: Vec<usize>,
+}
+
+/// Binary tree of panes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PaneTree {
+    Leaf(PaneId),
+    Split {
+        direction: SplitDirection,
+        /// Fraction of space allocated to `first` (0.0–1.0).
+        ratio: f32,
+        first: Box<PaneTree>,
+        second: Box<PaneTree>,
+    },
+}
+
+impl PaneTree {
+    /// Create a tree with a single pane.
+    pub fn new(id: PaneId) -> Self {
+        PaneTree::Leaf(id)
+    }
+
+    /// Compute layout rects for all leaf panes within the given rect.
+    pub fn layout(&self, rect: Rect) -> Vec<(PaneId, Rect)> {
+        let mut out = Vec::new();
+        self.layout_inner(rect, &mut out);
+        out
+    }
+
+    fn layout_inner(&self, rect: Rect, out: &mut Vec<(PaneId, Rect)>) {
+        match self {
+            PaneTree::Leaf(id) => out.push((*id, rect)),
+            PaneTree::Split {
+                direction,
+                ratio,
+                first,
+                second,
+            } => {
+                let half_div = DIVIDER_PX / 2.0;
+                match direction {
+                    SplitDirection::Horizontal => {
+                        // Split left/right
+                        let split_x = rect.left() + rect.width() * ratio;
+                        let first_rect = Rect::from_min_max(
+                            rect.min,
+                            egui::pos2(split_x - half_div, rect.max.y),
+                        );
+                        let second_rect = Rect::from_min_max(
+                            egui::pos2(split_x + half_div, rect.min.y),
+                            rect.max,
+                        );
+                        first.layout_inner(first_rect, out);
+                        second.layout_inner(second_rect, out);
+                    }
+                    SplitDirection::Vertical => {
+                        // Split top/bottom
+                        let split_y = rect.top() + rect.height() * ratio;
+                        let first_rect = Rect::from_min_max(
+                            rect.min,
+                            egui::pos2(rect.max.x, split_y - half_div),
+                        );
+                        let second_rect = Rect::from_min_max(
+                            egui::pos2(rect.min.x, split_y + half_div),
+                            rect.max,
+                        );
+                        first.layout_inner(first_rect, out);
+                        second.layout_inner(second_rect, out);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Split a leaf pane into two. The existing pane becomes `first`,
+    /// the new pane becomes `second`.
+    pub fn split(&mut self, target: PaneId, direction: SplitDirection, new_id: PaneId) -> bool {
+        match self {
+            PaneTree::Leaf(id) if *id == target => {
+                *self = PaneTree::Split {
+                    direction,
+                    ratio: 0.5,
+                    first: Box::new(PaneTree::Leaf(target)),
+                    second: Box::new(PaneTree::Leaf(new_id)),
+                };
+                true
+            }
+            PaneTree::Leaf(_) => false,
+            PaneTree::Split { first, second, .. } => {
+                first.split(target, direction, new_id) || second.split(target, direction, new_id)
+            }
+        }
+    }
+
+    /// Close a leaf pane. Returns the sibling's first leaf (new focus candidate).
+    /// If this is the last pane, returns None.
+    pub fn close(&mut self, target: PaneId) -> Option<PaneId> {
+        self.close_inner(target)
+    }
+
+    fn close_inner(&mut self, target: PaneId) -> Option<PaneId> {
+        match self {
+            PaneTree::Leaf(_) => None,
+            PaneTree::Split { first, second, .. } => {
+                // Check if first child is the target leaf
+                if matches!(first.as_ref(), PaneTree::Leaf(id) if *id == target) {
+                    let sibling = second.as_ref().clone();
+                    let focus = sibling.first_leaf();
+                    *self = sibling;
+                    return Some(focus);
+                }
+                // Check if second child is the target leaf
+                if matches!(second.as_ref(), PaneTree::Leaf(id) if *id == target) {
+                    let sibling = first.as_ref().clone();
+                    let focus = sibling.first_leaf();
+                    *self = sibling;
+                    return Some(focus);
+                }
+                // Recurse
+                first
+                    .close_inner(target)
+                    .or_else(|| second.close_inner(target))
+            }
+        }
+    }
+
+    /// Get all leaf pane IDs.
+    pub fn iter_panes(&self) -> Vec<PaneId> {
+        let mut out = Vec::new();
+        self.collect_panes(&mut out);
+        out
+    }
+
+    fn collect_panes(&self, out: &mut Vec<PaneId>) {
+        match self {
+            PaneTree::Leaf(id) => out.push(*id),
+            PaneTree::Split { first, second, .. } => {
+                first.collect_panes(out);
+                second.collect_panes(out);
+            }
+        }
+    }
+
+    /// Whether the tree contains a pane with the given ID.
+    pub fn contains(&self, id: PaneId) -> bool {
+        match self {
+            PaneTree::Leaf(leaf_id) => *leaf_id == id,
+            PaneTree::Split { first, second, .. } => first.contains(id) || second.contains(id),
+        }
+    }
+
+    /// Get the first leaf ID in the tree (leftmost/topmost).
+    pub fn first_leaf(&self) -> PaneId {
+        match self {
+            PaneTree::Leaf(id) => *id,
+            PaneTree::Split { first, .. } => first.first_leaf(),
+        }
+    }
+
+    /// Compute divider rects for hit-testing. Each divider includes its node path
+    /// so `resize_divider` can find the correct Split node.
+    pub fn dividers(&self, rect: Rect) -> Vec<Divider> {
+        let mut out = Vec::new();
+        self.dividers_inner(rect, &mut Vec::new(), &mut out);
+        out
+    }
+
+    fn dividers_inner(&self, rect: Rect, path: &mut Vec<usize>, out: &mut Vec<Divider>) {
+        if let PaneTree::Split {
+            direction,
+            ratio,
+            first,
+            second,
+        } = self
+        {
+            let half_div = DIVIDER_PX / 2.0;
+            match direction {
+                SplitDirection::Horizontal => {
+                    let split_x = rect.left() + rect.width() * ratio;
+                    let div_rect = Rect::from_min_max(
+                        egui::pos2(split_x - half_div, rect.min.y),
+                        egui::pos2(split_x + half_div, rect.max.y),
+                    );
+                    out.push(Divider {
+                        rect: div_rect,
+                        direction: *direction,
+                        node_path: path.clone(),
+                    });
+                    let first_rect =
+                        Rect::from_min_max(rect.min, egui::pos2(split_x - half_div, rect.max.y));
+                    let second_rect =
+                        Rect::from_min_max(egui::pos2(split_x + half_div, rect.min.y), rect.max);
+                    path.push(0);
+                    first.dividers_inner(first_rect, path, out);
+                    path.pop();
+                    path.push(1);
+                    second.dividers_inner(second_rect, path, out);
+                    path.pop();
+                }
+                SplitDirection::Vertical => {
+                    let split_y = rect.top() + rect.height() * ratio;
+                    let div_rect = Rect::from_min_max(
+                        egui::pos2(rect.min.x, split_y - half_div),
+                        egui::pos2(rect.max.x, split_y + half_div),
+                    );
+                    out.push(Divider {
+                        rect: div_rect,
+                        direction: *direction,
+                        node_path: path.clone(),
+                    });
+                    let first_rect =
+                        Rect::from_min_max(rect.min, egui::pos2(rect.max.x, split_y - half_div));
+                    let second_rect =
+                        Rect::from_min_max(egui::pos2(rect.min.x, split_y + half_div), rect.max);
+                    path.push(0);
+                    first.dividers_inner(first_rect, path, out);
+                    path.pop();
+                    path.push(1);
+                    second.dividers_inner(second_rect, path, out);
+                    path.pop();
+                }
+            }
+        }
+    }
+
+    /// Resize a divider by adjusting the ratio of the Split node at the given path.
+    /// `delta` is in pixels (positive = move right/down).
+    /// `total_rect` is the full layout rect (needed to convert delta to ratio).
+    pub fn resize_divider(&mut self, node_path: &[usize], delta: f32, total_rect: Rect) {
+        self.resize_inner(node_path, delta, total_rect);
+    }
+
+    fn resize_inner(&mut self, path: &[usize], delta: f32, rect: Rect) {
+        if let PaneTree::Split {
+            direction,
+            ratio,
+            first,
+            second,
+        } = self
+        {
+            if path.is_empty() {
+                // This is the target node — apply the delta
+                let span = match direction {
+                    SplitDirection::Horizontal => rect.width(),
+                    SplitDirection::Vertical => rect.height(),
+                };
+                if span > 0.0 {
+                    let new_ratio = (*ratio + delta / span).clamp(0.0, 1.0);
+                    // Enforce minimum pane size
+                    let min_ratio = MIN_PANE_PX / span;
+                    let max_ratio = 1.0 - min_ratio;
+                    *ratio = new_ratio.clamp(min_ratio, max_ratio);
+                }
+                return;
+            }
+
+            // Navigate deeper
+            let half_div = DIVIDER_PX / 2.0;
+            let (first_rect, second_rect) = match direction {
+                SplitDirection::Horizontal => {
+                    let split_x = rect.left() + rect.width() * *ratio;
+                    (
+                        Rect::from_min_max(rect.min, egui::pos2(split_x - half_div, rect.max.y)),
+                        Rect::from_min_max(egui::pos2(split_x + half_div, rect.min.y), rect.max),
+                    )
+                }
+                SplitDirection::Vertical => {
+                    let split_y = rect.top() + rect.height() * *ratio;
+                    (
+                        Rect::from_min_max(rect.min, egui::pos2(rect.max.x, split_y - half_div)),
+                        Rect::from_min_max(egui::pos2(rect.min.x, split_y + half_div), rect.max),
+                    )
+                }
+            };
+
+            match path[0] {
+                0 => first.resize_inner(&path[1..], delta, first_rect),
+                1 => second.resize_inner(&path[1..], delta, second_rect),
+                _ => {}
+            }
+        }
+    }
+
+    /// Find a neighboring pane in the given direction from `target`.
+    /// Uses the layout rects to determine adjacency by center-point proximity.
+    pub fn neighbor(&self, target: PaneId, direction: NavDirection, rect: Rect) -> Option<PaneId> {
+        let layout = self.layout(rect);
+        let target_rect = layout.iter().find(|(id, _)| *id == target)?.1;
+        let center = target_rect.center();
+
+        let mut best: Option<(PaneId, f32)> = None;
+
+        for &(id, r) in &layout {
+            if id == target {
+                continue;
+            }
+            let other_center = r.center();
+            let is_valid = match direction {
+                NavDirection::Left => other_center.x < center.x,
+                NavDirection::Right => other_center.x > center.x,
+                NavDirection::Up => other_center.y < center.y,
+                NavDirection::Down => other_center.y > center.y,
+            };
+            if !is_valid {
+                continue;
+            }
+
+            // Distance weighted to prefer panes more directly aligned
+            let dx = other_center.x - center.x;
+            let dy = other_center.y - center.y;
+            let dist = match direction {
+                NavDirection::Left | NavDirection::Right => dx.abs() + dy.abs() * 2.0,
+                NavDirection::Up | NavDirection::Down => dy.abs() + dx.abs() * 2.0,
+            };
+
+            if best.is_none() || dist < best.unwrap().1 {
+                best = Some((id, dist));
+            }
+        }
+
+        best.map(|(id, _)| id)
+    }
+}
+
+/// Navigation direction for focus movement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_pane_layout() {
+        let tree = PaneTree::new(1);
+        let rect = Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(800.0, 600.0));
+        let layout = tree.layout(rect);
+        assert_eq!(layout.len(), 1);
+        assert_eq!(layout[0].0, 1);
+        assert_eq!(layout[0].1, rect);
+    }
+
+    #[test]
+    fn split_and_layout() {
+        let mut tree = PaneTree::new(1);
+        assert!(tree.split(1, SplitDirection::Horizontal, 2));
+        let rect = Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(800.0, 600.0));
+        let layout = tree.layout(rect);
+        assert_eq!(layout.len(), 2);
+        // First pane should be on the left, second on the right
+        assert!(layout[0].1.max.x < layout[1].1.min.x);
+    }
+
+    #[test]
+    fn close_pane() {
+        let mut tree = PaneTree::new(1);
+        tree.split(1, SplitDirection::Horizontal, 2);
+        let focus = tree.close(2);
+        assert_eq!(focus, Some(1));
+        assert!(matches!(tree, PaneTree::Leaf(1)));
+    }
+
+    #[test]
+    fn iter_panes_and_contains() {
+        let mut tree = PaneTree::new(1);
+        tree.split(1, SplitDirection::Horizontal, 2);
+        tree.split(2, SplitDirection::Vertical, 3);
+        let panes = tree.iter_panes();
+        assert_eq!(panes, vec![1, 2, 3]);
+        assert!(tree.contains(3));
+        assert!(!tree.contains(99));
+    }
+
+    #[test]
+    fn dividers_count() {
+        let mut tree = PaneTree::new(1);
+        tree.split(1, SplitDirection::Horizontal, 2);
+        tree.split(2, SplitDirection::Vertical, 3);
+        let rect = Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(800.0, 600.0));
+        let divs = tree.dividers(rect);
+        assert_eq!(divs.len(), 2);
+    }
+
+    #[test]
+    fn neighbor_navigation() {
+        let mut tree = PaneTree::new(1);
+        tree.split(1, SplitDirection::Horizontal, 2);
+        let rect = Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(800.0, 600.0));
+        assert_eq!(tree.neighbor(1, NavDirection::Right, rect), Some(2));
+        assert_eq!(tree.neighbor(2, NavDirection::Left, rect), Some(1));
+        assert_eq!(tree.neighbor(1, NavDirection::Left, rect), None);
+    }
+
+    #[test]
+    fn resize_divider_clamps() {
+        let mut tree = PaneTree::new(1);
+        tree.split(1, SplitDirection::Horizontal, 2);
+        let rect = Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(800.0, 600.0));
+        // Move divider far to the right
+        tree.resize_divider(&[], 10000.0, rect);
+        if let PaneTree::Split { ratio, .. } = &tree {
+            assert!(*ratio < 1.0);
+            assert!(*ratio > 0.9);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `amux-layout` crate with PaneTree binary tree layout engine (split, close, navigate, zoom, divider resize)
- Refactor `amux-app` from single-pane to multi-pane architecture (`HashMap<PaneId, ManagedPane>` + `PaneTree`)
- Add keyboard shortcuts for split (Cmd+D/Cmd+Shift+D), close (Cmd+W), navigate (Option+Cmd+Arrow), zoom (Cmd+Shift+Enter) with cross-platform variants
- Add divider dragging, focus indicator, and pane resize on layout change
- Add IPC methods (`pane.split`, `pane.close`, `pane.focus`, `pane.list`) and CLI commands (`split`, `close-pane`, `focus-pane`, `list-panes`)

## Test plan
- [x] `cargo build --workspace` compiles
- [x] `cargo test --workspace` — 42 tests pass (7 new layout tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: `cargo run -p amux-app` → single pane terminal works
- [ ] Manual: Cmd+D splits right, both panes have shell
- [ ] Manual: Cmd+Shift+D splits down
- [ ] Manual: Option+Cmd+Arrow navigates between panes
- [ ] Manual: Drag dividers to resize
- [ ] Manual: Cmd+Shift+Enter zooms/unzooms
- [ ] Manual: Cmd+W closes focused pane
- [ ] Manual: `amux split --direction right` via CLI
- [ ] Manual: `amux list-panes` shows multiple panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-pane terminal support with horizontal and vertical splits, per-pane scrollback, and fullscreen zoom
  * Interactive divider dragging to resize panes and focused-pane visual indicator
  * Improved cursor rendering (shape/visibility) and per-pane resizing on window changes
  * CLI commands to split, close, focus, and list panes; listing shows id, size, focus, and status


<!-- end of auto-generated comment: release notes by coderabbit.ai -->