### PR TITLE
Phase 5: Notifications, agent status, and flash animations

### DIFF
--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -18,5 +18,6 @@ tracing-subscriber = { workspace = true }
 portable-pty = { workspace = true }
 amux-ipc = { workspace = true }
 amux-layout = { workspace = true }
+amux-notify = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -6,7 +6,9 @@ use std::time::Duration;
 
 use amux_ipc::IpcCommand;
 use amux_layout::{NavDirection, PaneId, PaneTree, SplitDirection};
+use amux_notify::{flash_alpha, FlashReason, NotificationSource, NotificationStore, FLASH_DURATION};
 use amux_term::color::resolve_color;
+use amux_term::osc::NotificationEvent;
 use amux_term::config::AmuxTermConfig;
 use amux_term::pane::TerminalPane;
 use portable_pty::CommandBuilder;
@@ -45,7 +47,6 @@ fn main() -> anyhow::Result<()> {
         zoomed: None,
         dragging_divider: None,
         last_pane_sizes: HashMap::new(),
-        status: None,
     };
 
     let options = eframe::NativeOptions {
@@ -75,8 +76,8 @@ fn main() -> anyhow::Result<()> {
                 socket_addr: ipc_addr,
                 config,
                 last_panel_rect: None,
-                focus_changed_at: std::time::Instant::now(),
-                focus_highlight_pane: initial_pane_id,
+                notifications: NotificationStore::new(),
+                show_notification_panel: false,
             }))
         }),
     )
@@ -145,8 +146,6 @@ struct Workspace {
     zoomed: Option<PaneId>,
     dragging_divider: Option<DragState>,
     last_pane_sizes: HashMap<PaneId, (usize, usize)>,
-    #[allow(dead_code)]
-    status: Option<String>,
 }
 
 struct SidebarState {
@@ -216,10 +215,8 @@ struct AmuxApp {
     socket_addr: amux_ipc::IpcAddr,
     config: Arc<AmuxTermConfig>,
     last_panel_rect: Option<egui::Rect>,
-    /// Instant when focus last changed pane, for fade-out animation.
-    focus_changed_at: std::time::Instant,
-    /// The pane that received focus (for rendering the fade indicator).
-    focus_highlight_pane: PaneId,
+    notifications: NotificationStore,
+    show_notification_panel: bool,
 }
 
 impl AmuxApp {
@@ -235,14 +232,24 @@ impl AmuxApp {
         let ws = self.active_workspace_mut();
         if ws.focused_pane != pane_id {
             ws.focused_pane = pane_id;
-            self.focus_changed_at = std::time::Instant::now();
-            self.focus_highlight_pane = pane_id;
+            // Clear notifications on the newly focused pane
+            self.notifications.mark_pane_read(pane_id);
+            // Navigation flash — but suppress if other panes have unread
+            let pane_ids: Vec<u64> = self.active_workspace().tree.iter_panes();
+            if !self
+                .notifications
+                .has_unread_excluding(&pane_ids, pane_id)
+            {
+                self.notifications
+                    .flash_pane(pane_id, FlashReason::Navigation);
+            }
         }
     }
 
     fn flash_focus(&mut self) {
-        self.focus_changed_at = std::time::Instant::now();
-        self.focus_highlight_pane = self.focused_pane_id();
+        let pane_id = self.focused_pane_id();
+        self.notifications
+            .flash_pane(pane_id, FlashReason::Navigation);
     }
 
     fn focused_pane_id(&self) -> PaneId {
@@ -262,6 +269,9 @@ impl eframe::App for AmuxApp {
                 }
             }
         }
+
+        // Drain notification events from all surfaces
+        self.drain_notifications();
 
         // Process IPC commands
         self.process_ipc_commands();
@@ -329,6 +339,11 @@ impl eframe::App for AmuxApp {
 
                 ui.allocate_rect(panel_rect, egui::Sense::click_and_drag());
             });
+
+        // Notification panel overlay
+        if self.show_notification_panel {
+            self.render_notification_panel(ctx);
+        }
 
         // Update window title from focused pane's active surface
         let focused_id = self.focused_pane_id();
@@ -525,23 +540,67 @@ impl AmuxApp {
             surface.scroll_offset,
         );
 
-        // Fading focus indicator
-        if pane_id == self.focus_highlight_pane {
-            let elapsed = self.focus_changed_at.elapsed().as_secs_f32();
-            let fade_duration = 1.0; // seconds
-            let alpha = ((1.0 - elapsed / fade_duration).clamp(0.0, 1.0) * 255.0) as u8;
-            if alpha > 0 {
-                ui.painter().rect_stroke(
-                    rect,
-                    0.0,
-                    egui::Stroke::new(
-                        2.0,
-                        egui::Color32::from_rgba_unmultiplied(80, 140, 220, alpha),
-                    ),
-                    egui::StrokeKind::Inside,
-                );
-                // Keep repainting during the fade
-                ui.ctx().request_repaint();
+        // Notification ring + flash animation (matching cmux)
+        let pane_u64 = pane_id;
+        let ring_rect = rect.shrink(2.0);
+
+        // 1. Persistent unread ring (NOT on focused pane)
+        if !is_focused && self.notifications.pane_unread(pane_u64) > 0 {
+            // Steady blue ring with glow
+            let ring_color = egui::Color32::from_rgba_unmultiplied(40, 120, 255, 89); // 0.35 * 255
+            ui.painter().rect_stroke(
+                ring_rect,
+                6.0,
+                egui::Stroke::new(2.5, ring_color),
+                egui::StrokeKind::Inside,
+            );
+            ui.ctx().request_repaint();
+        }
+
+        // 2. Flash animation (on ANY pane including focused)
+        if let Some(state) = self.notifications.pane_state(pane_u64) {
+            if let Some(started) = state.flash_started_at {
+                let elapsed = started.elapsed().as_secs_f32();
+                if elapsed < FLASH_DURATION {
+                    let alpha = flash_alpha(elapsed);
+                    let base_color = match state.flash_reason {
+                        Some(FlashReason::Navigation) => [0u8, 128, 128], // teal
+                        _ => [40, 120, 255],                              // blue
+                    };
+                    let glow_alpha = (alpha * 0.6 * 255.0) as u8;
+                    let ring_alpha = (alpha * 255.0) as u8;
+                    // Glow (wider, more transparent)
+                    ui.painter().rect_stroke(
+                        ring_rect.expand(1.0),
+                        6.0,
+                        egui::Stroke::new(
+                            4.0,
+                            egui::Color32::from_rgba_unmultiplied(
+                                base_color[0],
+                                base_color[1],
+                                base_color[2],
+                                glow_alpha,
+                            ),
+                        ),
+                        egui::StrokeKind::Outside,
+                    );
+                    // Ring
+                    ui.painter().rect_stroke(
+                        ring_rect,
+                        6.0,
+                        egui::Stroke::new(
+                            2.5,
+                            egui::Color32::from_rgba_unmultiplied(
+                                base_color[0],
+                                base_color[1],
+                                base_color[2],
+                                ring_alpha,
+                            ),
+                        ),
+                        egui::StrokeKind::Inside,
+                    );
+                    ui.ctx().request_repaint();
+                }
             }
         }
     }
@@ -580,9 +639,14 @@ impl AmuxApp {
                         egui::Color32::TRANSPARENT
                     };
 
+                    let pane_ids: Vec<u64> = ws.tree.iter_panes();
+                    let unread = self.notifications.workspace_unread_count(&pane_ids);
+                    let has_status = self.notifications.workspace_status(ws.id).is_some();
+                    let row_height = if has_status { 38.0 } else { 24.0 };
+
                     let response = ui.horizontal(|ui| {
                         let (rect, response) = ui.allocate_exact_size(
-                            ui.available_size_before_wrap(),
+                            egui::vec2(ui.available_width(), row_height),
                             egui::Sense::click(),
                         );
                         if ui.is_rect_visible(rect) {
@@ -599,16 +663,67 @@ impl AmuxApp {
                                 egui::FontId::proportional(14.0),
                                 text_color,
                             );
-                            // Pane count badge
-                            let count = ws.tree.iter_panes().len();
-                            let count_text = format!("{}", count);
-                            ui.painter().text(
-                                egui::pos2(rect.right() - 8.0, rect.min.y + 4.0),
-                                egui::Align2::RIGHT_TOP,
-                                &count_text,
-                                egui::FontId::proportional(11.0),
-                                egui::Color32::from_gray(100),
-                            );
+
+                            // Unread badge or pane count
+                            if unread > 0 {
+                                let badge_center =
+                                    egui::pos2(rect.right() - 16.0, rect.min.y + 12.0);
+                                ui.painter().circle_filled(
+                                    badge_center,
+                                    8.0,
+                                    egui::Color32::from_rgb(40, 120, 255),
+                                );
+                                ui.painter().text(
+                                    badge_center,
+                                    egui::Align2::CENTER_CENTER,
+                                    format!("{}", unread),
+                                    egui::FontId::proportional(9.0),
+                                    egui::Color32::WHITE,
+                                );
+                            } else {
+                                let count = ws.tree.iter_panes().len();
+                                ui.painter().text(
+                                    egui::pos2(rect.right() - 8.0, rect.min.y + 4.0),
+                                    egui::Align2::RIGHT_TOP,
+                                    format!("{}", count),
+                                    egui::FontId::proportional(11.0),
+                                    egui::Color32::from_gray(100),
+                                );
+                            }
+
+                            // Status pill
+                            if let Some(status) =
+                                self.notifications.workspace_status(ws.id)
+                            {
+                                let (pill_color, default_text) = match status.state {
+                                    amux_notify::AgentState::Active => {
+                                        (egui::Color32::from_rgb(50, 180, 80), "active")
+                                    }
+                                    amux_notify::AgentState::Waiting => {
+                                        (egui::Color32::from_rgb(230, 170, 40), "waiting")
+                                    }
+                                    amux_notify::AgentState::Idle => {
+                                        (egui::Color32::from_gray(100), "idle")
+                                    }
+                                };
+                                let label =
+                                    status.label.as_deref().unwrap_or(default_text);
+                                let pill_pos =
+                                    egui::pos2(rect.min.x + 8.0, rect.min.y + 22.0);
+                                let text_width = label.len() as f32 * 5.5 + 8.0;
+                                let pill_rect = egui::Rect::from_min_size(
+                                    pill_pos,
+                                    egui::vec2(text_width.min(rect.width() - 32.0), 14.0),
+                                );
+                                ui.painter().rect_filled(pill_rect, 7.0, pill_color);
+                                ui.painter().text(
+                                    pill_rect.center(),
+                                    egui::Align2::CENTER_CENTER,
+                                    label,
+                                    egui::FontId::proportional(9.0),
+                                    egui::Color32::WHITE,
+                                );
+                            }
                         }
                         response
                     });
@@ -725,7 +840,6 @@ impl AmuxApp {
             zoomed: None,
             dragging_divider: None,
             last_pane_sizes: HashMap::new(),
-            status: None,
         };
 
         self.workspaces.push(workspace);
@@ -760,10 +874,13 @@ impl AmuxApp {
         if self.workspaces.len() <= 1 {
             return;
         }
+        let ws_id = self.workspaces[ws_idx].id;
         let pane_ids: Vec<PaneId> = self.workspaces[ws_idx].tree.iter_panes();
-        for id in pane_ids {
-            self.panes.remove(&id);
+        for id in &pane_ids {
+            self.panes.remove(id);
+            self.notifications.remove_pane(*id);
         }
+        self.notifications.remove_workspace(ws_id);
         self.workspaces.remove(ws_idx);
         if self.active_workspace_idx >= self.workspaces.len() {
             self.active_workspace_idx = self.workspaces.len() - 1;
@@ -967,6 +1084,18 @@ impl AmuxApp {
                     return self.do_toggle_zoom();
                 }
 
+                // Notification panel: Cmd+I / Ctrl+I
+                if is_cmd && !modifiers.shift && *key == egui::Key::I {
+                    self.show_notification_panel = !self.show_notification_panel;
+                    return true;
+                }
+
+                // Jump to latest unread: Cmd+Shift+U / Ctrl+Shift+U
+                if is_cmd && modifiers.shift && *key == egui::Key::U {
+                    self.jump_to_latest_unread();
+                    return true;
+                }
+
                 // Scroll
                 if modifiers.shift && *key == egui::Key::PageUp {
                     return self.do_scroll(-1);
@@ -1030,6 +1159,7 @@ impl AmuxApp {
                     ws.zoomed = None;
                 }
                 self.panes.remove(&focused_id);
+                self.notifications.remove_pane(focused_id);
                 self.set_focus(new_focus);
             }
             return true;
@@ -1087,6 +1217,194 @@ impl AmuxApp {
             let max_offset = total.saturating_sub(rows);
             let new_offset = surface.scroll_offset as isize - lines;
             surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
+        }
+    }
+
+    // --- Notifications ---
+
+    fn drain_notifications(&mut self) {
+        // Collect events first to avoid borrow conflicts
+        let focused = self.focused_pane_id();
+        let mut events: Vec<(u64, u64, u64, NotificationEvent)> = Vec::new();
+
+        for (&pane_id, managed) in &self.panes {
+            let ws_id = self.workspace_for_pane(pane_id).unwrap_or(0);
+            for surface in &managed.surfaces {
+                for event in surface.pane.drain_notifications() {
+                    events.push((ws_id, pane_id, surface.id, event));
+                }
+            }
+        }
+
+        for (ws_id, pane_id, surface_id, event) in events {
+            let (title, body, source) = match event {
+                NotificationEvent::Toast { title, body } => {
+                    (title.unwrap_or_default(), body, NotificationSource::Toast)
+                }
+                NotificationEvent::Bell => {
+                    (String::new(), "Bell".to_string(), NotificationSource::Bell)
+                }
+                // Title and directory changes are not user-facing notifications
+                NotificationEvent::TitleChanged(_) | NotificationEvent::WorkingDirectoryChanged => {
+                    continue;
+                }
+            };
+
+            if pane_id == focused {
+                // Focused pane: still record but mark as read (flash only, no ring)
+                self.notifications
+                    .push_read(ws_id, pane_id, surface_id, title, body, source);
+            } else {
+                self.notifications
+                    .push(ws_id, pane_id, surface_id, title, body, source);
+            }
+        }
+    }
+
+    fn workspace_for_pane(&self, pane_id: PaneId) -> Option<u64> {
+        self.workspaces
+            .iter()
+            .find(|ws| ws.tree.iter_panes().contains(&pane_id))
+            .map(|ws| ws.id)
+    }
+
+    fn jump_to_latest_unread(&mut self) {
+        if let Some(notif) = self.notifications.most_recent_unread() {
+            let ws_id = notif.workspace_id;
+            let pane_id = notif.pane_id as PaneId;
+
+            // Switch to the notification's workspace
+            if let Some(idx) = self.workspaces.iter().position(|ws| ws.id == ws_id) {
+                self.active_workspace_idx = idx;
+            }
+            self.set_focus(pane_id);
+        }
+    }
+
+    fn render_notification_panel(&mut self, ctx: &egui::Context) {
+        let mut close_panel = false;
+        let mut mark_all = false;
+        let mut jump_to: Option<(u64, u64)> = None; // (workspace_id, pane_id)
+        let mut remove_id: Option<u64> = None;
+
+        egui::Window::new("Notifications")
+            .collapsible(false)
+            .resizable(true)
+            .default_size([380.0, 460.0])
+            .anchor(egui::Align2::RIGHT_TOP, [-10.0, 10.0])
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.heading(
+                        egui::RichText::new("Notifications").color(egui::Color32::from_gray(220)),
+                    );
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui.small_button("Clear All").clicked() {
+                            mark_all = true;
+                        }
+                        if ui.small_button("Jump to Latest").clicked() {
+                            jump_to = self
+                                .notifications
+                                .most_recent_unread()
+                                .map(|n| (n.workspace_id, n.pane_id));
+                            close_panel = true;
+                        }
+                    });
+                });
+                ui.separator();
+
+                let notifications = self.notifications.all_notifications();
+                if notifications.is_empty() {
+                    ui.vertical_centered(|ui| {
+                        ui.add_space(40.0);
+                        ui.label(
+                            egui::RichText::new("No notifications yet")
+                                .color(egui::Color32::from_gray(100)),
+                        );
+                    });
+                } else {
+                    egui::ScrollArea::vertical().show(ui, |ui| {
+                        // Iterate newest first
+                        for notif in notifications.iter().rev() {
+                            let response = ui.horizontal(|ui| {
+                                // Unread dot
+                                let dot_color = if notif.read {
+                                    egui::Color32::from_gray(60)
+                                } else {
+                                    egui::Color32::from_rgb(40, 120, 255)
+                                };
+                                let dot_rect = ui.allocate_exact_size(
+                                    egui::vec2(8.0, 8.0),
+                                    egui::Sense::hover(),
+                                );
+                                ui.painter().circle_filled(
+                                    dot_rect.0.center(),
+                                    3.0,
+                                    dot_color,
+                                );
+
+                                ui.vertical(|ui| {
+                                    let title = if notif.title.is_empty() {
+                                        &notif.body
+                                    } else {
+                                        &notif.title
+                                    };
+                                    ui.label(
+                                        egui::RichText::new(title)
+                                            .color(egui::Color32::from_gray(200)),
+                                    );
+                                    if !notif.title.is_empty() && !notif.body.is_empty() {
+                                        let body_display = if notif.body.len() > 100 {
+                                            format!("{}...", &notif.body[..97])
+                                        } else {
+                                            notif.body.clone()
+                                        };
+                                        ui.label(
+                                            egui::RichText::new(body_display)
+                                                .small()
+                                                .color(egui::Color32::from_gray(140)),
+                                        );
+                                    }
+                                    let age = format_duration(notif.created_at.elapsed());
+                                    ui.label(
+                                        egui::RichText::new(age)
+                                            .small()
+                                            .color(egui::Color32::from_gray(80)),
+                                    );
+                                });
+
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        if ui.small_button("×").clicked() {
+                                            remove_id = Some(notif.id);
+                                        }
+                                    },
+                                );
+                            });
+                            if response.response.interact(egui::Sense::click()).clicked() {
+                                jump_to = Some((notif.workspace_id, notif.pane_id));
+                                close_panel = true;
+                            }
+                            ui.separator();
+                        }
+                    });
+                }
+            });
+
+        if mark_all {
+            self.notifications.mark_all_read();
+        }
+        if let Some(id) = remove_id {
+            self.notifications.remove_notification(id);
+        }
+        if let Some((ws_id, pane_id)) = jump_to {
+            if let Some(idx) = self.workspaces.iter().position(|ws| ws.id == ws_id) {
+                self.active_workspace_idx = idx;
+            }
+            self.set_focus(pane_id as PaneId);
+        }
+        if close_panel {
+            self.show_notification_panel = false;
         }
     }
 
@@ -1351,6 +1669,7 @@ impl AmuxApp {
                                 ws.zoomed = None;
                             }
                             self.panes.remove(&target);
+                            self.notifications.remove_pane(target);
                             if should_refocus {
                                 self.set_focus(new_focus);
                             }
@@ -1633,6 +1952,78 @@ impl AmuxApp {
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
                 }
             }
+            "status.set" => {
+                match serde_json::from_value::<amux_ipc::methods::StatusSetParams>(
+                    req.params.clone(),
+                ) {
+                    Ok(params) => {
+                        let ws_id = params.workspace_id.parse::<u64>().unwrap_or(0);
+                        let state = match params.state.as_str() {
+                            "active" => amux_notify::AgentState::Active,
+                            "waiting" => amux_notify::AgentState::Waiting,
+                            _ => amux_notify::AgentState::Idle,
+                        };
+                        self.notifications.set_status(ws_id, state, params.label);
+                        Response::ok(req.id.clone(), serde_json::json!({}))
+                    }
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
+            "notify.send" => {
+                match serde_json::from_value::<amux_ipc::methods::NotifySendParams>(
+                    req.params.clone(),
+                ) {
+                    Ok(params) => {
+                        let ws_id = params.workspace_id.parse::<u64>().unwrap_or(0);
+                        let pane_id = params
+                            .pane_id
+                            .parse::<u64>()
+                            .unwrap_or(self.focused_pane_id());
+                        let title = params.title.unwrap_or_default();
+                        let nid = self.notifications.push(
+                            ws_id,
+                            pane_id,
+                            0,
+                            title,
+                            params.body,
+                            NotificationSource::Cli,
+                        );
+                        Response::ok(
+                            req.id.clone(),
+                            serde_json::json!({"notification_id": nid}),
+                        )
+                    }
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
+            "notify.list" => {
+                let entries: Vec<serde_json::Value> = self
+                    .notifications
+                    .all_notifications()
+                    .iter()
+                    .map(|n| {
+                        let source_str = match n.source {
+                            NotificationSource::Toast => "toast",
+                            NotificationSource::Bell => "bell",
+                            NotificationSource::Cli => "cli",
+                        };
+                        serde_json::json!({
+                            "id": n.id,
+                            "workspace_id": n.workspace_id.to_string(),
+                            "pane_id": n.pane_id.to_string(),
+                            "title": n.title,
+                            "body": n.body,
+                            "source": source_str,
+                            "read": n.read,
+                        })
+                    })
+                    .collect();
+                Response::ok(req.id.clone(), serde_json::json!({"notifications": entries}))
+            }
+            "notify.clear" => {
+                self.notifications.clear_all();
+                Response::ok(req.id.clone(), serde_json::json!({}))
+            }
             _ => Response::err(
                 req.id.clone(),
                 "method_not_found",
@@ -1876,6 +2267,17 @@ fn srgba_to_egui(color: SrgbaTuple) -> egui::Color32 {
         (color.2 * 255.0).round() as u8,
         (color.3 * 255.0).round() as u8,
     )
+}
+
+fn format_duration(d: Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 60 {
+        format!("{}s ago", secs)
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else {
+        format!("{}h ago", secs / 3600)
+    }
 }
 
 // --- Key encoding (egui events -> terminal bytes) ---

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -100,6 +100,37 @@ enum Command {
         /// Surface ID to focus
         surface_id: String,
     },
+    /// Set workspace agent status (displayed as a sidebar pill)
+    #[command(name = "set-status")]
+    SetStatus {
+        /// Status state: idle, active, waiting
+        state: String,
+        /// Optional label text
+        label: Option<String>,
+        /// Target workspace ID (defaults to AMUX_WORKSPACE_ID)
+        #[arg(long)]
+        workspace: Option<String>,
+    },
+    /// Send a notification
+    Notify {
+        /// Notification body
+        body: String,
+        /// Notification title
+        #[arg(long)]
+        title: Option<String>,
+        /// Target workspace ID (defaults to AMUX_WORKSPACE_ID)
+        #[arg(long)]
+        workspace: Option<String>,
+        /// Target pane ID (defaults to focused pane)
+        #[arg(long)]
+        pane: Option<String>,
+    },
+    /// List notifications
+    #[command(name = "list-notifications")]
+    ListNotifications,
+    /// Clear all notifications
+    #[command(name = "clear-notifications")]
+    ClearNotifications,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -353,6 +384,76 @@ async fn main() -> anyhow::Result<()> {
                 print_response(&resp, true);
             } else if resp.ok {
                 println!("Focused surface {}", surface_id);
+            } else {
+                print_response(&resp, false);
+            }
+        }
+        // --- Notification / Status commands ---
+        Command::SetStatus {
+            state,
+            label,
+            workspace,
+        } => {
+            let ws_id = workspace
+                .or_else(|| std::env::var("AMUX_WORKSPACE_ID").ok())
+                .unwrap_or_else(|| "0".to_string());
+            let mut params = serde_json::json!({
+                "workspace_id": ws_id,
+                "state": state,
+            });
+            if let Some(l) = label {
+                params["label"] = serde_json::json!(l);
+            }
+            let resp = client.call("status.set", params).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                println!("Status set");
+            } else {
+                print_response(&resp, false);
+            }
+        }
+        Command::Notify {
+            body,
+            title,
+            workspace,
+            pane,
+        } => {
+            let ws_id = workspace
+                .or_else(|| std::env::var("AMUX_WORKSPACE_ID").ok())
+                .unwrap_or_else(|| "0".to_string());
+            let pane_id = pane.unwrap_or_else(|| "0".to_string());
+            let mut params = serde_json::json!({
+                "workspace_id": ws_id,
+                "pane_id": pane_id,
+                "body": body,
+            });
+            if let Some(t) = title {
+                params["title"] = serde_json::json!(t);
+            }
+            let resp = client.call("notify.send", params).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                if let Some(result) = &resp.result {
+                    if let Some(id) = result.get("notification_id") {
+                        println!("Notification sent: {}", id);
+                    }
+                }
+            } else {
+                print_response(&resp, false);
+            }
+        }
+        Command::ListNotifications => {
+            let resp = client.call("notify.list", serde_json::json!({})).await?;
+            print_response(&resp, cli.json);
+        }
+        Command::ClearNotifications => {
+            let resp = client.call("notify.clear", serde_json::json!({})).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                println!("Notifications cleared");
             } else {
                 print_response(&resp, false);
             }

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -19,6 +19,10 @@ pub const METHODS: &[&str] = &[
     "pane.close",
     "pane.focus",
     "pane.list",
+    "status.set",
+    "notify.send",
+    "notify.list",
+    "notify.clear",
 ];
 
 // --- Params ---
@@ -69,4 +73,47 @@ pub struct SurfaceListResult {
 #[derive(Debug, Serialize)]
 pub struct ReadTextResult {
     pub text: String,
+}
+
+// --- Status / Notify Params ---
+
+#[derive(Debug, Deserialize)]
+pub struct StatusSetParams {
+    pub workspace_id: String,
+    pub state: String,
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct NotifySendParams {
+    pub workspace_id: String,
+    pub pane_id: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    pub body: String,
+}
+
+// --- Status / Notify Results ---
+
+#[derive(Debug, Serialize)]
+pub struct NotifySendResult {
+    pub notification_id: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NotifyListEntry {
+    pub id: u64,
+    pub workspace_id: String,
+    pub pane_id: String,
+    pub title: String,
+    pub body: String,
+    pub source: String,
+    pub read: bool,
+    pub created_at_ms: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NotifyListResult {
+    pub notifications: Vec<NotifyListEntry>,
 }

--- a/crates/amux-notify/Cargo.toml
+++ b/crates/amux-notify/Cargo.toml
@@ -6,3 +6,4 @@ license.workspace = true
 description = "amux OSC notification parsing + in-app store"
 
 [dependencies]
+serde = { workspace = true }

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -1,1 +1,523 @@
+use std::collections::HashMap;
+use std::time::Instant;
 
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/// Agent status state for a workspace sidebar pill.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentState {
+    Idle,
+    Active,
+    Waiting,
+}
+
+/// What triggered the notification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NotificationSource {
+    Toast,
+    Bell,
+    Cli,
+}
+
+/// Why a pane is flashing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlashReason {
+    /// Pane received focus via keyboard nav or click (teal).
+    Navigation,
+    /// A notification just arrived (blue).
+    NotificationArrival,
+    /// A notification was dismissed (blue).
+    NotificationDismiss,
+}
+
+// ---------------------------------------------------------------------------
+// Structs
+// ---------------------------------------------------------------------------
+
+/// Per-workspace agent status displayed as a pill in the sidebar.
+#[derive(Debug, Clone)]
+pub struct WorkspaceStatus {
+    pub state: AgentState,
+    pub label: Option<String>,
+    pub updated_at: Instant,
+}
+
+/// A single notification entry.
+#[derive(Debug, Clone)]
+pub struct Notification {
+    pub id: u64,
+    pub workspace_id: u64,
+    pub pane_id: u64,
+    pub surface_id: u64,
+    pub title: String,
+    pub body: String,
+    pub source: NotificationSource,
+    pub created_at: Instant,
+    pub read: bool,
+}
+
+/// Per-pane notification visual state (ring + flash).
+#[derive(Debug, Default)]
+pub struct PaneNotifyState {
+    pub unread_count: usize,
+    pub flash_started_at: Option<Instant>,
+    pub flash_reason: Option<FlashReason>,
+}
+
+// ---------------------------------------------------------------------------
+// Flash animation constants (matching cmux)
+// ---------------------------------------------------------------------------
+
+/// Total duration of the double-pulse flash animation.
+pub const FLASH_DURATION: f32 = 0.9;
+
+/// Keyframe times as fractions of FLASH_DURATION.
+const FLASH_KEY_TIMES: [f32; 5] = [0.0, 0.25, 0.5, 0.75, 1.0];
+
+/// Opacity values at each keyframe.
+const FLASH_VALUES: [f32; 5] = [0.0, 1.0, 0.0, 1.0, 0.0];
+
+/// Compute flash opacity for the double-pulse pattern at time `t` seconds.
+/// Returns 0.0 when `t >= FLASH_DURATION`.
+pub fn flash_alpha(t: f32) -> f32 {
+    if !(0.0..FLASH_DURATION).contains(&t) {
+        return 0.0;
+    }
+    let frac = t / FLASH_DURATION;
+    // Find which segment we're in
+    for i in 0..FLASH_KEY_TIMES.len() - 1 {
+        let t0 = FLASH_KEY_TIMES[i];
+        let t1 = FLASH_KEY_TIMES[i + 1];
+        if frac >= t0 && frac < t1 {
+            let local = (frac - t0) / (t1 - t0);
+            // Alternate easeOut / easeIn per cmux pattern
+            let eased = if i % 2 == 0 {
+                ease_out(local)
+            } else {
+                ease_in(local)
+            };
+            let v0 = FLASH_VALUES[i];
+            let v1 = FLASH_VALUES[i + 1];
+            return v0 + (v1 - v0) * eased;
+        }
+    }
+    0.0
+}
+
+fn ease_out(t: f32) -> f32 {
+    1.0 - (1.0 - t) * (1.0 - t)
+}
+
+fn ease_in(t: f32) -> f32 {
+    t * t
+}
+
+// ---------------------------------------------------------------------------
+// NotificationStore
+// ---------------------------------------------------------------------------
+
+/// Central store for notifications and agent status. Owned by AmuxApp.
+pub struct NotificationStore {
+    notifications: Vec<Notification>,
+    next_id: u64,
+    pane_states: HashMap<u64, PaneNotifyState>,
+    workspace_statuses: HashMap<u64, WorkspaceStatus>,
+}
+
+impl NotificationStore {
+    pub fn new() -> Self {
+        Self {
+            notifications: Vec::new(),
+            next_id: 1,
+            pane_states: HashMap::new(),
+            workspace_statuses: HashMap::new(),
+        }
+    }
+
+    /// Add a notification. Triggers a flash on the target pane.
+    pub fn push(
+        &mut self,
+        workspace_id: u64,
+        pane_id: u64,
+        surface_id: u64,
+        title: String,
+        body: String,
+        source: NotificationSource,
+    ) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        self.notifications.push(Notification {
+            id,
+            workspace_id,
+            pane_id,
+            surface_id,
+            title,
+            body,
+            source,
+            created_at: Instant::now(),
+            read: false,
+        });
+
+        let state = self.pane_states.entry(pane_id).or_default();
+        state.unread_count += 1;
+        state.flash_started_at = Some(Instant::now());
+        state.flash_reason = Some(FlashReason::NotificationArrival);
+
+        id
+    }
+
+    /// Push a notification but immediately mark it as read (for focused-pane
+    /// notifications — still triggers arrival flash but no persistent ring).
+    pub fn push_read(
+        &mut self,
+        workspace_id: u64,
+        pane_id: u64,
+        surface_id: u64,
+        title: String,
+        body: String,
+        source: NotificationSource,
+    ) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        self.notifications.push(Notification {
+            id,
+            workspace_id,
+            pane_id,
+            surface_id,
+            title,
+            body,
+            source,
+            created_at: Instant::now(),
+            read: true,
+        });
+
+        // Flash but don't increment unread
+        let state = self.pane_states.entry(pane_id).or_default();
+        state.flash_started_at = Some(Instant::now());
+        state.flash_reason = Some(FlashReason::NotificationArrival);
+
+        id
+    }
+
+    /// Mark all notifications for a pane as read, clear the unread count,
+    /// and trigger a dismiss flash.
+    pub fn mark_pane_read(&mut self, pane_id: u64) {
+        let had_unread = self.pane_unread(pane_id) > 0;
+        for n in &mut self.notifications {
+            if n.pane_id == pane_id && !n.read {
+                n.read = true;
+            }
+        }
+        let state = self.pane_states.entry(pane_id).or_default();
+        state.unread_count = 0;
+        if had_unread {
+            state.flash_started_at = Some(Instant::now());
+            state.flash_reason = Some(FlashReason::NotificationDismiss);
+        }
+    }
+
+    /// Mark all notifications as read.
+    pub fn mark_all_read(&mut self) {
+        for n in &mut self.notifications {
+            n.read = true;
+        }
+        for state in self.pane_states.values_mut() {
+            if state.unread_count > 0 {
+                state.unread_count = 0;
+                state.flash_started_at = Some(Instant::now());
+                state.flash_reason = Some(FlashReason::NotificationDismiss);
+            }
+        }
+    }
+
+    /// Remove a specific notification by id.
+    pub fn remove_notification(&mut self, notification_id: u64) {
+        if let Some(pos) = self.notifications.iter().position(|n| n.id == notification_id) {
+            let notif = self.notifications.remove(pos);
+            if !notif.read {
+                if let Some(state) = self.pane_states.get_mut(&notif.pane_id) {
+                    state.unread_count = state.unread_count.saturating_sub(1);
+                }
+            }
+        }
+    }
+
+    /// Clear all notifications.
+    pub fn clear_all(&mut self) {
+        self.notifications.clear();
+        for state in self.pane_states.values_mut() {
+            state.unread_count = 0;
+        }
+    }
+
+    /// Trigger a flash on a pane without adding a notification.
+    pub fn flash_pane(&mut self, pane_id: u64, reason: FlashReason) {
+        let state = self.pane_states.entry(pane_id).or_default();
+        state.flash_started_at = Some(Instant::now());
+        state.flash_reason = Some(reason);
+    }
+
+    /// Get unread count for a pane.
+    pub fn pane_unread(&self, pane_id: u64) -> usize {
+        self.pane_states
+            .get(&pane_id)
+            .map_or(0, |s| s.unread_count)
+    }
+
+    /// Check if any pane in the given set has unread notifications,
+    /// excluding the specified focused pane.
+    pub fn has_unread_excluding(&self, pane_ids: &[u64], focused_pane_id: u64) -> bool {
+        pane_ids.iter().any(|&id| {
+            id != focused_pane_id
+                && self
+                    .pane_states
+                    .get(&id)
+                    .is_some_and(|s| s.unread_count > 0)
+        })
+    }
+
+    /// Total unread count across the given pane set.
+    pub fn workspace_unread_count(&self, pane_ids: &[u64]) -> usize {
+        pane_ids
+            .iter()
+            .map(|id| self.pane_unread(*id))
+            .sum()
+    }
+
+    /// Get pane visual state (for ring + flash rendering).
+    pub fn pane_state(&self, pane_id: u64) -> Option<&PaneNotifyState> {
+        self.pane_states.get(&pane_id)
+    }
+
+    /// All notifications, oldest first.
+    pub fn all_notifications(&self) -> &[Notification] {
+        &self.notifications
+    }
+
+    /// Find the most recent unread notification.
+    pub fn most_recent_unread(&self) -> Option<&Notification> {
+        self.notifications.iter().rev().find(|n| !n.read)
+    }
+
+    /// Set workspace agent status.
+    pub fn set_status(&mut self, workspace_id: u64, state: AgentState, label: Option<String>) {
+        self.workspace_statuses.insert(
+            workspace_id,
+            WorkspaceStatus {
+                state,
+                label,
+                updated_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Get workspace agent status.
+    pub fn workspace_status(&self, workspace_id: u64) -> Option<&WorkspaceStatus> {
+        self.workspace_statuses.get(&workspace_id)
+    }
+
+    /// Clean up all state for a closed pane.
+    pub fn remove_pane(&mut self, pane_id: u64) {
+        self.pane_states.remove(&pane_id);
+        self.notifications.retain(|n| n.pane_id != pane_id);
+    }
+
+    /// Clean up all state for a closed workspace.
+    pub fn remove_workspace(&mut self, workspace_id: u64) {
+        self.workspace_statuses.remove(&workspace_id);
+        // Collect pane IDs to remove
+        let pane_ids: Vec<u64> = self
+            .notifications
+            .iter()
+            .filter(|n| n.workspace_id == workspace_id)
+            .map(|n| n.pane_id)
+            .collect();
+        for pid in &pane_ids {
+            self.pane_states.remove(pid);
+        }
+        self.notifications
+            .retain(|n| n.workspace_id != workspace_id);
+    }
+}
+
+impl Default for NotificationStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_increments_unread() {
+        let mut store = NotificationStore::new();
+        let id = store.push(1, 10, 100, "Test".into(), "body".into(), NotificationSource::Bell);
+        assert_eq!(id, 1);
+        assert_eq!(store.pane_unread(10), 1);
+        assert_eq!(store.all_notifications().len(), 1);
+        assert!(!store.all_notifications()[0].read);
+    }
+
+    #[test]
+    fn push_read_does_not_increment_unread() {
+        let mut store = NotificationStore::new();
+        store.push_read(1, 10, 100, "Test".into(), "body".into(), NotificationSource::Toast);
+        assert_eq!(store.pane_unread(10), 0);
+        assert_eq!(store.all_notifications().len(), 1);
+        assert!(store.all_notifications()[0].read);
+        // But flash should still be set
+        assert!(store.pane_state(10).unwrap().flash_started_at.is_some());
+    }
+
+    #[test]
+    fn mark_pane_read_clears_unread() {
+        let mut store = NotificationStore::new();
+        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
+        store.push(1, 10, 101, "B".into(), "b".into(), NotificationSource::Toast);
+        assert_eq!(store.pane_unread(10), 2);
+
+        store.mark_pane_read(10);
+        assert_eq!(store.pane_unread(10), 0);
+        assert!(store.all_notifications().iter().all(|n| n.read));
+        // Dismiss flash triggered
+        assert_eq!(
+            store.pane_state(10).unwrap().flash_reason,
+            Some(FlashReason::NotificationDismiss)
+        );
+    }
+
+    #[test]
+    fn mark_all_read() {
+        let mut store = NotificationStore::new();
+        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
+        store.push(2, 20, 200, "B".into(), "b".into(), NotificationSource::Cli);
+        store.mark_all_read();
+        assert_eq!(store.pane_unread(10), 0);
+        assert_eq!(store.pane_unread(20), 0);
+    }
+
+    #[test]
+    fn most_recent_unread() {
+        let mut store = NotificationStore::new();
+        store.push(1, 10, 100, "First".into(), "a".into(), NotificationSource::Bell);
+        store.push(1, 20, 200, "Second".into(), "b".into(), NotificationSource::Toast);
+        let recent = store.most_recent_unread().unwrap();
+        assert_eq!(recent.title, "Second");
+
+        store.mark_pane_read(20);
+        let recent = store.most_recent_unread().unwrap();
+        assert_eq!(recent.title, "First");
+
+        store.mark_pane_read(10);
+        assert!(store.most_recent_unread().is_none());
+    }
+
+    #[test]
+    fn has_unread_excluding_focused() {
+        let mut store = NotificationStore::new();
+        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
+        store.push(1, 20, 200, "B".into(), "b".into(), NotificationSource::Bell);
+
+        assert!(store.has_unread_excluding(&[10, 20], 10));
+        assert!(store.has_unread_excluding(&[10, 20], 20));
+        assert!(!store.has_unread_excluding(&[10], 10));
+    }
+
+    #[test]
+    fn workspace_unread_count() {
+        let mut store = NotificationStore::new();
+        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
+        store.push(1, 10, 101, "B".into(), "b".into(), NotificationSource::Bell);
+        store.push(1, 20, 200, "C".into(), "c".into(), NotificationSource::Toast);
+        assert_eq!(store.workspace_unread_count(&[10, 20]), 3);
+    }
+
+    #[test]
+    fn flash_pane_sets_flash() {
+        let mut store = NotificationStore::new();
+        store.flash_pane(10, FlashReason::Navigation);
+        let state = store.pane_state(10).unwrap();
+        assert_eq!(state.flash_reason, Some(FlashReason::Navigation));
+        assert!(state.flash_started_at.is_some());
+        assert_eq!(state.unread_count, 0);
+    }
+
+    #[test]
+    fn remove_pane_cleanup() {
+        let mut store = NotificationStore::new();
+        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
+        store.push(1, 20, 200, "B".into(), "b".into(), NotificationSource::Bell);
+        store.remove_pane(10);
+        assert!(store.pane_state(10).is_none());
+        assert_eq!(store.all_notifications().len(), 1);
+        assert_eq!(store.all_notifications()[0].pane_id, 20);
+    }
+
+    #[test]
+    fn remove_notification_decrements_unread() {
+        let mut store = NotificationStore::new();
+        let id = store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
+        assert_eq!(store.pane_unread(10), 1);
+        store.remove_notification(id);
+        assert_eq!(store.pane_unread(10), 0);
+        assert_eq!(store.all_notifications().len(), 0);
+    }
+
+    #[test]
+    fn workspace_status_roundtrip() {
+        let mut store = NotificationStore::new();
+        store.set_status(1, AgentState::Active, Some("Running tests".into()));
+        let status = store.workspace_status(1).unwrap();
+        assert_eq!(status.state, AgentState::Active);
+        assert_eq!(status.label.as_deref(), Some("Running tests"));
+
+        store.set_status(1, AgentState::Idle, None);
+        let status = store.workspace_status(1).unwrap();
+        assert_eq!(status.state, AgentState::Idle);
+        assert!(status.label.is_none());
+    }
+
+    #[test]
+    fn flash_alpha_pattern() {
+        // Start: 0
+        assert_eq!(flash_alpha(0.0), 0.0);
+        // Peak 1: around 0.225s
+        let a1 = flash_alpha(0.225);
+        assert!(a1 > 0.9, "first peak should be near 1.0, got {a1}");
+        // Trough: around 0.45s
+        let a2 = flash_alpha(0.45);
+        assert!(a2 < 0.1, "trough should be near 0.0, got {a2}");
+        // Peak 2: around 0.675s
+        let a3 = flash_alpha(0.675);
+        assert!(a3 > 0.9, "second peak should be near 1.0, got {a3}");
+        // End: 0
+        assert_eq!(flash_alpha(0.9), 0.0);
+        // Past end: 0
+        assert_eq!(flash_alpha(1.0), 0.0);
+    }
+
+    #[test]
+    fn clear_all_notifications() {
+        let mut store = NotificationStore::new();
+        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
+        store.push(2, 20, 200, "B".into(), "b".into(), NotificationSource::Cli);
+        store.clear_all();
+        assert_eq!(store.all_notifications().len(), 0);
+        assert_eq!(store.pane_unread(10), 0);
+        assert_eq!(store.pane_unread(20), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement full notification system matching cmux's three-layer model: persistent blue ring on unread panes, 0.9s double-pulse flash animation on arrival/dismissal, and notification panel overlay
- Navigation flash (teal) suppressed when other panes have unread notifications (cmux behavior)
- Sidebar shows unread badge (blue circle with count) and agent status pills (green=active, yellow=waiting, gray=idle)
- 4 new IPC methods (`status.set`, `notify.send`, `notify.list`, `notify.clear`) and 4 new CLI commands
- amux-notify crate with 13 unit tests covering all store operations and flash animation math

## Test plan
- [x] `cargo build --workspace` compiles
- [x] `cargo test --workspace` — 56 tests pass (13 new)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [ ] Manual: two panes, trigger bell (`echo -e '\a'`) in non-focused → blue flash + persistent ring
- [ ] Manual: click notified pane → blue dismiss flash, ring clears
- [ ] Manual: navigate with arrows → teal flash (suppressed if unread elsewhere)
- [ ] Manual: `amux notify "test message"` → ring appears
- [ ] Manual: `amux set-status active "Running tests"` → green pill in sidebar
- [ ] Manual: `Cmd+I` → notification panel with entries, click to jump
- [ ] Manual: `Cmd+Shift+U` → jumps to most recent unread
- [ ] Manual: close pane/workspace → notification state cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification panel overlay (Cmd/Ctrl+I) to view, clear, and navigate notifications
  * Added keyboard shortcut (Cmd/Ctrl+Shift+U) to jump to latest unread notification
  * Added new CLI commands: `set-status`, `notify`, `list-notifications`, and `clear-notifications` for workspace status and notification management
  * Added unread notification badges displayed on panes in the sidebar

* **UI Updates**
  * Panes now display persistent unread indicators and flash animations for new notifications
  * Added agent/status pill in sidebar with dynamic layout based on workspace status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->