### PR TITLE
Phase 7: Session persistence with bug fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ cargo fmt --check              # Check formatting without modifying
 
 Requirements: Rust 1.80+, C compiler, platform graphics drivers. Windows needs MSVC toolchain.
 
+**Before pushing any commit**, always run `cargo fmt --check` and `cargo clippy --workspace -- -D warnings` to catch lint and formatting issues locally. CI will reject PRs that fail these checks.
+
 ## Workspace Structure
 
 Cargo workspace with 9 crates under `crates/`:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,11 @@ dependencies = [
  "amux-ipc",
  "amux-layout",
  "amux-notify",
+ "amux-session",
  "amux-term",
  "anyhow",
  "arboard",
+ "dirs",
  "eframe",
  "egui",
  "portable-pty",
@@ -113,6 +115,7 @@ name = "amux-cli"
 version = "0.1.0"
 dependencies = [
  "amux-ipc",
+ "amux-session",
  "anyhow",
  "clap",
  "serde_json",
@@ -163,6 +166,14 @@ dependencies = [
 [[package]]
 name = "amux-session"
 version = "0.1.0"
+dependencies = [
+ "amux-layout",
+ "anyhow",
+ "dirs",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "amux-term"
@@ -1184,6 +1195,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fax"
@@ -3693,6 +3710,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ dirs = "6"
 # Error handling
 anyhow = "1"
 
+# Testing
+tempfile = "3"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -19,5 +19,7 @@ portable-pty = { workspace = true }
 amux-ipc = { workspace = true }
 amux-layout = { workspace = true }
 amux-notify = { workspace = true }
+amux-session = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+dirs = { workspace = true }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -18,6 +18,43 @@ use portable_pty::CommandBuilder;
 use wezterm_surface::{CursorShape, CursorVisibility};
 use wezterm_term::color::SrgbaTuple;
 
+/// Try to get the current working directory of a process by PID.
+/// Falls back across platform-specific mechanisms.
+fn get_cwd_from_pid(pid: u32) -> Option<String> {
+    // Linux: readlink /proc/{pid}/cwd
+    #[cfg(target_os = "linux")]
+    {
+        let link = std::fs::read_link(format!("/proc/{}/cwd", pid)).ok()?;
+        return Some(link.to_string_lossy().to_string());
+    }
+
+    // macOS: use lsof to query the cwd
+    #[cfg(target_os = "macos")]
+    {
+        let output = std::process::Command::new("lsof")
+            .args(["-a", "-d", "cwd", "-p", &pid.to_string(), "-Fn"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let text = String::from_utf8_lossy(&output.stdout);
+        // lsof -Fn outputs lines like "p1234\nn/path/to/dir"
+        for line in text.lines() {
+            if let Some(path) = line.strip_prefix('n') {
+                if path.starts_with('/') {
+                    return Some(path.to_string());
+                }
+            }
+        }
+        return None;
+    }
+
+    // Windows / other: no fallback yet
+    #[allow(unreachable_code)]
+    None
+}
+
 const FONT_SIZE: f32 = 14.0;
 const DEFAULT_SIDEBAR_WIDTH: f32 = 200.0;
 const TAB_BAR_HEIGHT: f32 = 24.0;
@@ -547,7 +584,11 @@ impl AmuxApp {
                                 .pane
                                 .working_dir()
                                 .and_then(|url| url.to_file_path().ok())
-                                .map(|p| p.to_string_lossy().to_string());
+                                .map(|p| p.to_string_lossy().to_string())
+                                .or_else(|| {
+                                    // Fallback: query the child process's cwd via OS APIs
+                                    sf.pane.child_pid().and_then(get_cwd_from_pid)
+                                });
                             let scrollback = sf.pane.read_scrollback_text(4096);
                             let (cols, rows) = sf.pane.dimensions();
                             amux_session::SavedSurface {

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -961,9 +961,10 @@ impl AmuxApp {
                 let label = if raw_title.is_empty() {
                     format!("tab {}", idx + 1)
                 } else {
-                    // Truncate long titles
-                    if raw_title.len() > 20 {
-                        format!("{}...", &raw_title[..17])
+                    // Truncate long titles (char-safe for UTF-8)
+                    if raw_title.chars().count() > 20 {
+                        let prefix: String = raw_title.chars().take(17).collect();
+                        format!("{prefix}...")
                     } else {
                         raw_title.to_string()
                     }
@@ -1807,12 +1808,22 @@ impl AmuxApp {
         true
     }
 
-    /// Close a pane entirely. If it's the last pane in the workspace,
-    /// close the workspace too.
+    /// Close a pane entirely. Finds the owning workspace (not necessarily the
+    /// active one). If it's the last pane in that workspace, close the workspace.
     fn close_pane(&mut self, pane_id: PaneId) {
-        let pane_count = self.active_workspace().tree.iter_panes().len();
+        // Find the workspace that owns this pane
+        let ws_idx = match self
+            .workspaces
+            .iter()
+            .position(|ws| ws.tree.iter_panes().contains(&pane_id))
+        {
+            Some(idx) => idx,
+            None => return, // pane not in any workspace
+        };
+
+        let pane_count = self.workspaces[ws_idx].tree.iter_panes().len();
         if pane_count > 1 {
-            let ws = self.active_workspace_mut();
+            let ws = &mut self.workspaces[ws_idx];
             if let Some(new_focus) = ws.tree.close(pane_id) {
                 ws.last_pane_sizes.remove(&pane_id);
                 if ws.zoomed == Some(pane_id) {
@@ -1820,11 +1831,12 @@ impl AmuxApp {
                 }
                 self.panes.remove(&pane_id);
                 self.notifications.remove_pane(pane_id);
-                self.set_focus(new_focus);
+                if ws_idx == self.active_workspace_idx {
+                    self.set_focus(new_focus);
+                }
             }
         } else {
             // Last pane in workspace -> close workspace
-            let ws_idx = self.active_workspace_idx;
             self.close_workspace_at(ws_idx);
         }
     }
@@ -2706,33 +2718,44 @@ impl AmuxApp {
                             .and_then(|s| s.parse::<PaneId>().ok())
                             .unwrap_or(self.focused_pane_id());
 
-                        let sf_id = self.next_surface_id;
-                        self.next_surface_id += 1;
-                        let ws_id = self.active_workspace().id;
+                        // Validate pane exists before spawning a surface
+                        if !self.panes.contains_key(&target_pane) {
+                            Response::err(req.id.clone(), "not_found", "pane not found")
+                        } else {
+                            // Find the workspace that owns this pane
+                            let ws_id = self
+                                .workspaces
+                                .iter()
+                                .find(|ws| ws.tree.iter_panes().contains(&target_pane))
+                                .map(|ws| ws.id)
+                                .unwrap_or_else(|| self.active_workspace().id);
 
-                        match spawn_surface(
-                            80,
-                            24,
-                            &self.socket_addr,
-                            &self.config,
-                            ws_id,
-                            sf_id,
-                            None,
-                            None,
-                        ) {
-                            Ok(surface) => {
-                                if let Some(managed) = self.panes.get_mut(&target_pane) {
+                            let sf_id = self.next_surface_id;
+                            self.next_surface_id += 1;
+
+                            match spawn_surface(
+                                80,
+                                24,
+                                &self.socket_addr,
+                                &self.config,
+                                ws_id,
+                                sf_id,
+                                None,
+                                None,
+                            ) {
+                                Ok(surface) => {
+                                    let managed = self.panes.get_mut(&target_pane).unwrap();
                                     managed.surfaces.push(surface);
                                     managed.active_surface_idx = managed.surfaces.len() - 1;
                                     Response::ok(
                                         req.id.clone(),
                                         serde_json::json!({"surface_id": sf_id.to_string()}),
                                     )
-                                } else {
-                                    Response::err(req.id.clone(), "not_found", "pane not found")
+                                }
+                                Err(e) => {
+                                    Response::err(req.id.clone(), "spawn_error", &e.to_string())
                                 }
                             }
-                            Err(e) => Response::err(req.id.clone(), "spawn_error", &e.to_string()),
                         }
                     }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -115,6 +115,7 @@ fn main() -> anyhow::Result<()> {
                 last_click_time: Instant::now(),
                 last_click_pos: egui::Pos2::ZERO,
                 click_count: 0,
+                wants_exit: false,
             }))
         }),
     )
@@ -154,7 +155,7 @@ fn fresh_startup(
 
     let workspace = Workspace {
         id: 0,
-        title: "default".to_string(),
+        title: "Terminal 1".to_string(),
         tree: PaneTree::new(initial_pane_id),
         focused_pane: initial_pane_id,
         zoomed: None,
@@ -534,6 +535,7 @@ struct AmuxApp {
     last_click_time: Instant,
     last_click_pos: egui::Pos2,
     click_count: u32,
+    wants_exit: bool,
 }
 
 impl AmuxApp {
@@ -736,6 +738,11 @@ fn chrono_now() -> String {
 
 impl eframe::App for AmuxApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        if self.wants_exit {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+            return;
+        }
+
         // Drain PTY output from all surfaces in all panes
         let mut got_data = false;
         for managed in self.panes.values_mut() {
@@ -863,9 +870,17 @@ impl eframe::App for AmuxApp {
     }
 
     fn on_exit(&mut self) {
-        let data = self.build_session_data();
-        if let Err(e) = amux_session::save(&data) {
-            tracing::error!("Session save failed: {}", e);
+        if self.wants_exit {
+            // User explicitly closed everything — clear session so next
+            // launch starts fresh instead of restoring an empty state.
+            if let Err(e) = amux_session::clear() {
+                tracing::error!("Session clear failed: {}", e);
+            }
+        } else {
+            let data = self.build_session_data();
+            if let Err(e) = amux_session::save(&data) {
+                tracing::error!("Session save failed: {}", e);
+            }
         }
     }
 }
@@ -906,15 +921,15 @@ impl AmuxApp {
 
             for (idx, surface) in managed.surfaces.iter().enumerate() {
                 let is_active = idx == active_idx;
-                let label = surface.pane.title();
-                let label = if label.is_empty() {
+                let raw_title = surface.pane.title();
+                let label = if raw_title.is_empty() {
                     format!("tab {}", idx + 1)
                 } else {
                     // Truncate long titles
-                    if label.len() > 20 {
-                        format!("{}...", &label[..17])
+                    if raw_title.len() > 20 {
+                        format!("{}...", &raw_title[..17])
                     } else {
-                        label.to_string()
+                        raw_title.to_string()
                     }
                 };
 
@@ -968,7 +983,7 @@ impl AmuxApp {
                 // Hit testing
                 if ui.input(|i| i.pointer.any_pressed()) {
                     if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
-                        if close_rect.contains(pos) && managed.surfaces.len() > 1 {
+                        if close_rect.contains(pos) {
                             close_tab = Some(idx);
                         } else if this_tab.contains(pos) && !is_active {
                             switch_to = Some(idx);
@@ -1019,15 +1034,21 @@ impl AmuxApp {
             }
 
             // Apply tab switch/close (need to re-borrow managed)
-            let managed = self.panes.get_mut(&pane_id).unwrap();
-            if let Some(idx) = switch_to {
-                managed.active_surface_idx = idx;
-            }
             if let Some(idx) = close_tab {
+                let is_last = self.panes.get(&pane_id)
+                    .is_some_and(|m| m.surfaces.len() <= 1);
+                if is_last {
+                    self.close_pane(pane_id);
+                    return;
+                }
+                let managed = self.panes.get_mut(&pane_id).unwrap();
                 managed.surfaces.remove(idx);
                 if managed.active_surface_idx >= managed.surfaces.len() {
                     managed.active_surface_idx = managed.surfaces.len() - 1;
                 }
+            } else if let Some(idx) = switch_to {
+                let managed = self.panes.get_mut(&pane_id).unwrap();
+                managed.active_surface_idx = idx;
             }
         }
 
@@ -1321,7 +1342,7 @@ impl AmuxApp {
         let ws_id = self.next_workspace_id;
         self.next_workspace_id += 1;
 
-        let title = title.unwrap_or_else(|| format!("workspace-{}", ws_id));
+        let title = title.unwrap_or_else(|| format!("Terminal {}", self.workspaces.len() + 1));
 
         let pane_id = self.next_pane_id;
         self.next_pane_id += 1;
@@ -1402,10 +1423,18 @@ impl AmuxApp {
     }
 
     fn close_workspace_at(&mut self, ws_idx: usize) {
+        let ws_id = self.workspaces[ws_idx].id;
         if self.workspaces.len() <= 1 {
+            // Last workspace — clean up and signal exit
+            let pane_ids: Vec<PaneId> = self.workspaces[ws_idx].tree.iter_panes();
+            for id in &pane_ids {
+                self.panes.remove(id);
+                self.notifications.remove_pane(*id);
+            }
+            self.notifications.remove_workspace(ws_id);
+            self.wants_exit = true;
             return;
         }
-        let ws_id = self.workspaces[ws_idx].id;
         let pane_ids: Vec<PaneId> = self.workspaces[ws_idx].tree.iter_panes();
         for id in &pane_ids {
             self.panes.remove(id);
@@ -1675,20 +1704,35 @@ impl AmuxApp {
             }
         }
 
-        // Mouse wheel scrolling
+        // Mouse wheel scrolling — scroll the pane under the cursor
         let scroll_delta = ctx.input(|i| i.smooth_scroll_delta.y);
         if scroll_delta != 0.0 {
-            let focused_id = self.focused_pane_id();
-            if let Some(managed) = self.panes.get_mut(&focused_id) {
-                let surface = managed.active_surface_mut();
-                let font_id = egui::FontId::monospace(FONT_SIZE);
-                let cell_height = ctx.fonts(|f| f.row_height(&font_id));
+            let hover_pos = ctx.input(|i| i.pointer.hover_pos());
+            let target_pane = hover_pos.and_then(|pos| {
+                let panel_rect = self.last_panel_rect?;
+                let ws = self.active_workspace();
+                if let Some(zoomed_id) = ws.zoomed {
+                    // In zoomed mode, only the zoomed pane is visible
+                    if panel_rect.contains(pos) {
+                        return Some(zoomed_id);
+                    }
+                    return None;
+                }
+                let layout = ws.tree.layout(panel_rect);
+                layout.iter().find(|(_, rect)| rect.contains(pos)).map(|(id, _)| *id)
+            });
+            if let Some(pane_id) = target_pane {
+                if let Some(managed) = self.panes.get_mut(&pane_id) {
+                    let surface = managed.active_surface_mut();
+                    let font_id = egui::FontId::monospace(FONT_SIZE);
+                    let cell_height = ctx.fonts(|f| f.row_height(&font_id));
 
-                surface.scroll_accum += -scroll_delta / cell_height;
-                let whole_lines = surface.scroll_accum.trunc() as isize;
-                if whole_lines != 0 {
-                    surface.scroll_accum -= whole_lines as f32;
-                    self.do_scroll_lines(whole_lines);
+                    surface.scroll_accum += -scroll_delta / cell_height;
+                    let whole_lines = surface.scroll_accum.trunc() as isize;
+                    if whole_lines != 0 {
+                        surface.scroll_accum -= whole_lines as f32;
+                        self.do_scroll_lines_for(pane_id, whole_lines);
+                    }
                 }
             }
         }
@@ -1718,26 +1762,30 @@ impl AmuxApp {
             }
         }
 
-        // Then close pane if >1 pane
+        self.close_pane(focused_id);
+        true
+    }
+
+    /// Close a pane entirely. If it's the last pane in the workspace,
+    /// close the workspace too.
+    fn close_pane(&mut self, pane_id: PaneId) {
         let pane_count = self.active_workspace().tree.iter_panes().len();
         if pane_count > 1 {
             let ws = self.active_workspace_mut();
-            if let Some(new_focus) = ws.tree.close(focused_id) {
-                ws.last_pane_sizes.remove(&focused_id);
-                if ws.zoomed == Some(focused_id) {
+            if let Some(new_focus) = ws.tree.close(pane_id) {
+                ws.last_pane_sizes.remove(&pane_id);
+                if ws.zoomed == Some(pane_id) {
                     ws.zoomed = None;
                 }
-                self.panes.remove(&focused_id);
-                self.notifications.remove_pane(focused_id);
+                self.panes.remove(&pane_id);
+                self.notifications.remove_pane(pane_id);
                 self.set_focus(new_focus);
             }
-            return true;
+        } else {
+            // Last pane in workspace -> close workspace
+            let ws_idx = self.active_workspace_idx;
+            self.close_workspace_at(ws_idx);
         }
-
-        // Last pane in workspace -> close workspace
-        let ws_idx = self.active_workspace_idx;
-        self.close_workspace_at(ws_idx);
-        true
     }
 
     fn do_navigate(&mut self, dir: NavDirection) -> bool {
@@ -1777,9 +1825,8 @@ impl AmuxApp {
         true
     }
 
-    fn do_scroll_lines(&mut self, lines: isize) {
-        let focused_id = self.focused_pane_id();
-        if let Some(managed) = self.panes.get_mut(&focused_id) {
+    fn do_scroll_lines_for(&mut self, pane_id: PaneId, lines: isize) {
+        if let Some(managed) = self.panes.get_mut(&pane_id) {
             let surface = managed.active_surface_mut();
             let (_, rows) = surface.pane.dimensions();
             let total = surface.pane.screen().scrollback_rows();
@@ -2662,25 +2709,24 @@ impl AmuxApp {
                         if let Some(sf_id_str) = params.surface_id {
                             // Find and close the specific surface
                             if let Ok(sf_id) = sf_id_str.parse::<u64>() {
-                                for managed in self.panes.values_mut() {
-                                    if let Some(idx) =
-                                        managed.surfaces.iter().position(|s| s.id == sf_id)
-                                    {
-                                        if managed.surfaces.len() <= 1 {
-                                            return Response::err(
-                                                req.id.clone(),
-                                                "last_surface",
-                                                "cannot close the last surface in a pane",
-                                            );
-                                        }
+                                // Find which pane owns this surface
+                                let target = self.panes.iter().find_map(|(&pid, m)| {
+                                    m.surfaces.iter().position(|s| s.id == sf_id).map(|idx| (pid, idx))
+                                });
+                                if let Some((pane_id, idx)) = target {
+                                    let managed = self.panes.get_mut(&pane_id).unwrap();
+                                    if managed.surfaces.len() <= 1 {
+                                        self.close_pane(pane_id);
+                                    } else {
                                         managed.surfaces.remove(idx);
                                         if managed.active_surface_idx >= managed.surfaces.len() {
                                             managed.active_surface_idx = managed.surfaces.len() - 1;
                                         }
-                                        return Response::ok(req.id.clone(), serde_json::json!({}));
                                     }
+                                    Response::ok(req.id.clone(), serde_json::json!({}))
+                                } else {
+                                    Response::err(req.id.clone(), "not_found", "surface not found")
                                 }
-                                Response::err(req.id.clone(), "not_found", "surface not found")
                             } else {
                                 Response::err(
                                     req.id.clone(),
@@ -2692,15 +2738,12 @@ impl AmuxApp {
                             // Close active surface in focused pane
                             if let Some(managed) = self.panes.get_mut(&focused) {
                                 if managed.surfaces.len() <= 1 {
-                                    return Response::err(
-                                        req.id.clone(),
-                                        "last_surface",
-                                        "cannot close the last surface in a pane",
-                                    );
-                                }
-                                managed.surfaces.remove(managed.active_surface_idx);
-                                if managed.active_surface_idx >= managed.surfaces.len() {
-                                    managed.active_surface_idx = managed.surfaces.len() - 1;
+                                    self.close_pane(focused);
+                                } else {
+                                    managed.surfaces.remove(managed.active_surface_idx);
+                                    if managed.active_surface_idx >= managed.surfaces.len() {
+                                        managed.active_surface_idx = managed.surfaces.len() - 1;
+                                    }
                                 }
                                 Response::ok(req.id.clone(), serde_json::json!({}))
                             } else {

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -9,6 +9,7 @@ use amux_layout::{NavDirection, PaneId, PaneTree, SplitDirection};
 use amux_notify::{
     flash_alpha, FlashReason, NotificationSource, NotificationStore, FLASH_DURATION,
 };
+use amux_session::SessionData;
 use amux_term::color::resolve_color;
 use amux_term::config::AmuxTermConfig;
 use amux_term::osc::NotificationEvent;
@@ -29,27 +30,23 @@ fn main() -> anyhow::Result<()> {
 
     let config = Arc::new(AmuxTermConfig::default());
 
-    // Spawn initial pane with one surface
-    let initial_pane_id: PaneId = 0;
-    let surface = spawn_surface(80, 24, &ipc_addr, &config, 0, 0)?;
-
-    let managed = ManagedPane {
-        surfaces: vec![surface],
-        active_surface_idx: 0,
-        selection: None,
+    // Try to restore a previous session
+    let restored = match amux_session::load() {
+        Ok(Some(session)) => {
+            tracing::info!("Restoring session from {}", session.saved_at);
+            Some(session)
+        }
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!("Failed to load session, starting fresh: {}", e);
+            None
+        }
     };
 
-    let mut panes = HashMap::new();
-    panes.insert(initial_pane_id, managed);
-
-    let initial_workspace = Workspace {
-        id: 0,
-        title: "default".to_string(),
-        tree: PaneTree::new(initial_pane_id),
-        focused_pane: initial_pane_id,
-        zoomed: None,
-        dragging_divider: None,
-        last_pane_sizes: HashMap::new(),
+    let state = if let Some(session) = restored {
+        restore_session(&session, &ipc_addr, &config)
+    } else {
+        fresh_startup(&ipc_addr, &config)?
     };
 
     let options = eframe::NativeOptions {
@@ -65,21 +62,18 @@ fn main() -> anyhow::Result<()> {
         options,
         Box::new(move |_cc| {
             Ok(Box::new(AmuxApp {
-                workspaces: vec![initial_workspace],
+                workspaces: state.workspaces,
                 active_workspace_idx: 0,
-                panes,
-                next_pane_id: 1,
-                next_workspace_id: 1,
-                next_surface_id: 1,
-                sidebar: SidebarState {
-                    visible: true,
-                    width: DEFAULT_SIDEBAR_WIDTH,
-                },
+                panes: state.panes,
+                next_pane_id: state.next_pane_id,
+                next_workspace_id: state.next_workspace_id,
+                next_surface_id: state.next_surface_id,
+                sidebar: state.sidebar,
                 ipc_rx,
                 socket_addr: ipc_addr,
                 config,
                 last_panel_rect: None,
-                notifications: NotificationStore::new(),
+                notifications: state.notifications,
                 show_notification_panel: false,
                 last_click_time: Instant::now(),
                 last_click_pos: egui::Pos2::ZERO,
@@ -91,6 +85,204 @@ fn main() -> anyhow::Result<()> {
 
     cleanup_addr(&ipc_addr_cleanup);
     result
+}
+
+/// Bundled startup state to avoid complex return tuples.
+struct StartupState {
+    workspaces: Vec<Workspace>,
+    panes: HashMap<PaneId, ManagedPane>,
+    next_pane_id: PaneId,
+    next_workspace_id: u64,
+    next_surface_id: u64,
+    sidebar: SidebarState,
+    notifications: NotificationStore,
+}
+
+/// Create a fresh default startup (one workspace, one pane).
+fn fresh_startup(
+    ipc_addr: &amux_ipc::IpcAddr,
+    config: &Arc<AmuxTermConfig>,
+) -> anyhow::Result<StartupState> {
+    let initial_pane_id: PaneId = 0;
+    let surface = spawn_surface(80, 24, ipc_addr, config, 0, 0, None, None)?;
+
+    let managed = ManagedPane {
+        surfaces: vec![surface],
+        active_surface_idx: 0,
+        selection: None,
+    };
+
+    let mut panes = HashMap::new();
+    panes.insert(initial_pane_id, managed);
+
+    let workspace = Workspace {
+        id: 0,
+        title: "default".to_string(),
+        tree: PaneTree::new(initial_pane_id),
+        focused_pane: initial_pane_id,
+        zoomed: None,
+        dragging_divider: None,
+        last_pane_sizes: HashMap::new(),
+    };
+
+    Ok(StartupState {
+        workspaces: vec![workspace],
+        panes,
+        next_pane_id: 1,
+        next_workspace_id: 1,
+        next_surface_id: 1,
+        sidebar: SidebarState {
+            visible: true,
+            width: DEFAULT_SIDEBAR_WIDTH,
+        },
+        notifications: NotificationStore::new(),
+    })
+}
+
+/// Restore app state from a saved session. Falls back to fresh startup on any failure.
+fn restore_session(
+    session: &SessionData,
+    ipc_addr: &amux_ipc::IpcAddr,
+    config: &Arc<AmuxTermConfig>,
+) -> StartupState {
+    let mut workspaces = Vec::new();
+    let mut panes: HashMap<PaneId, ManagedPane> = HashMap::new();
+
+    for saved_ws in &session.workspaces {
+        let mut ws_ok = true;
+
+        for (&pane_id, saved_pane) in &saved_ws.panes {
+            let mut surfaces = Vec::new();
+            for saved_sf in &saved_pane.surfaces {
+                let cwd = saved_sf.working_dir.as_deref();
+                let scrollback = if saved_sf.scrollback.is_empty() {
+                    None
+                } else {
+                    Some(saved_sf.scrollback.as_str())
+                };
+
+                match spawn_surface(
+                    saved_sf.cols,
+                    saved_sf.rows,
+                    ipc_addr,
+                    config,
+                    saved_ws.id,
+                    saved_sf.id,
+                    cwd,
+                    scrollback,
+                ) {
+                    Ok(surface) => surfaces.push(surface),
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to restore surface {} in pane {}: {}",
+                            saved_sf.id,
+                            pane_id,
+                            e
+                        );
+                    }
+                }
+            }
+
+            if surfaces.is_empty() {
+                tracing::warn!("All surfaces failed for pane {}, skipping", pane_id);
+                ws_ok = false;
+                continue;
+            }
+
+            let active_idx = saved_pane
+                .active_surface_idx
+                .min(surfaces.len().saturating_sub(1));
+            panes.insert(
+                pane_id,
+                ManagedPane {
+                    surfaces,
+                    active_surface_idx: active_idx,
+                    selection: None,
+                },
+            );
+        }
+
+        if !ws_ok && saved_ws.panes.len() == 1 {
+            tracing::warn!("Skipping workspace {} (no panes restored)", saved_ws.title);
+            continue;
+        }
+
+        workspaces.push(Workspace {
+            id: saved_ws.id,
+            title: saved_ws.title.clone(),
+            tree: saved_ws.tree.clone(),
+            focused_pane: saved_ws.focused_pane,
+            zoomed: saved_ws.zoomed,
+            dragging_divider: None,
+            last_pane_sizes: HashMap::new(),
+        });
+    }
+
+    // If nothing restored, fall back to fresh
+    if workspaces.is_empty() {
+        tracing::warn!("Session restore produced no workspaces, starting fresh");
+        return match fresh_startup(ipc_addr, config) {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::error!("Fresh startup also failed: {}", e);
+                panic!("Cannot start amux: {}", e);
+            }
+        };
+    }
+
+    let sidebar = SidebarState {
+        visible: session.sidebar.visible,
+        width: session.sidebar.width,
+    };
+
+    // Restore notifications (without Instant-dependent fields)
+    let mut store = NotificationStore::new();
+    for saved_n in &session.notifications {
+        let source = match saved_n.source.as_str() {
+            "toast" => NotificationSource::Toast,
+            "bell" => NotificationSource::Bell,
+            _ => NotificationSource::Cli,
+        };
+        if saved_n.read {
+            store.push_read(
+                saved_n.workspace_id,
+                saved_n.pane_id,
+                saved_n.surface_id,
+                saved_n.title.clone(),
+                saved_n.body.clone(),
+                source,
+            );
+        } else {
+            store.push(
+                saved_n.workspace_id,
+                saved_n.pane_id,
+                saved_n.surface_id,
+                saved_n.title.clone(),
+                saved_n.body.clone(),
+                source,
+            );
+        }
+    }
+
+    // Restore workspace statuses
+    for (ws_id, saved_status) in &session.workspace_statuses {
+        let state = match saved_status.state.as_str() {
+            "active" => amux_notify::AgentState::Active,
+            "waiting" => amux_notify::AgentState::Waiting,
+            _ => amux_notify::AgentState::Idle,
+        };
+        store.set_status(*ws_id, state, saved_status.label.clone());
+    }
+
+    StartupState {
+        workspaces,
+        panes,
+        next_pane_id: session.next_pane_id,
+        next_workspace_id: session.next_workspace_id,
+        next_surface_id: session.next_surface_id,
+        sidebar,
+        notifications: store,
+    }
 }
 
 fn default_shell() -> String {
@@ -216,6 +408,7 @@ impl SelectionState {
 /// Word boundary delimiters for double-click selection.
 const WORD_DELIMITERS: &str = " \t\n()[]{}'\"|<>&;:,.`~!@#$%^*-+=?/\\";
 
+#[allow(clippy::too_many_arguments)]
 fn spawn_surface(
     cols: u16,
     rows: u16,
@@ -223,6 +416,8 @@ fn spawn_surface(
     config: &Arc<AmuxTermConfig>,
     workspace_id: u64,
     surface_id: u64,
+    cwd: Option<&str>,
+    scrollback: Option<&str>,
 ) -> anyhow::Result<PaneSurface> {
     let shell = default_shell();
     let mut cmd = CommandBuilder::new(&shell);
@@ -231,7 +426,31 @@ fn spawn_surface(
     cmd.env("AMUX_SURFACE_ID", surface_id.to_string());
     cmd.env("TERM", "xterm-256color");
 
+    if let Some(dir) = cwd {
+        let path = std::path::Path::new(dir);
+        if path.is_dir() {
+            cmd.cwd(path);
+        } else {
+            tracing::warn!("Saved working dir no longer exists: {}", dir);
+            if let Some(home) = dirs::home_dir() {
+                cmd.cwd(home);
+            }
+        }
+    }
+
     let mut pane = TerminalPane::spawn(cols, rows, cmd, config.clone())?;
+
+    // Inject scrollback text before starting the reader thread.
+    // feed_bytes writes directly to the terminal state machine, not through the PTY.
+    if let Some(text) = scrollback {
+        if !text.is_empty() {
+            // Convert newlines to \r\n for proper terminal processing
+            for line in text.split('\n') {
+                pane.feed_bytes(line.as_bytes());
+                pane.feed_bytes(b"\r\n");
+            }
+        }
+    }
 
     let mut reader = pane.take_reader().expect("reader already taken");
     let (byte_tx, byte_rx) = mpsc::channel::<Vec<u8>>();
@@ -313,6 +532,165 @@ impl AmuxApp {
     fn focused_pane_id(&self) -> PaneId {
         self.active_workspace().focused_pane
     }
+
+    fn build_session_data(&self) -> SessionData {
+        let mut saved_workspaces = Vec::new();
+        for ws in &self.workspaces {
+            let mut saved_panes = std::collections::HashMap::new();
+            for &pane_id in &ws.tree.iter_panes() {
+                if let Some(managed) = self.panes.get(&pane_id) {
+                    let surfaces: Vec<amux_session::SavedSurface> = managed
+                        .surfaces
+                        .iter()
+                        .map(|sf| {
+                            let working_dir = sf
+                                .pane
+                                .working_dir()
+                                .and_then(|url| url.to_file_path().ok())
+                                .map(|p| p.to_string_lossy().to_string());
+                            let scrollback = sf.pane.read_scrollback_text(4096);
+                            let (cols, rows) = sf.pane.dimensions();
+                            amux_session::SavedSurface {
+                                id: sf.id,
+                                title: sf.pane.title().to_string(),
+                                working_dir,
+                                scrollback,
+                                cols: cols as u16,
+                                rows: rows as u16,
+                            }
+                        })
+                        .collect();
+                    saved_panes.insert(
+                        pane_id,
+                        amux_session::SavedManagedPane {
+                            surfaces,
+                            active_surface_idx: managed.active_surface_idx,
+                        },
+                    );
+                }
+            }
+            saved_workspaces.push(amux_session::SavedWorkspace {
+                id: ws.id,
+                title: ws.title.clone(),
+                tree: ws.tree.clone(),
+                focused_pane: ws.focused_pane,
+                zoomed: ws.zoomed,
+                panes: saved_panes,
+            });
+        }
+
+        let notifications: Vec<amux_session::SavedNotification> = self
+            .notifications
+            .all_notifications()
+            .iter()
+            .map(|n| amux_session::SavedNotification {
+                id: n.id,
+                workspace_id: n.workspace_id,
+                pane_id: n.pane_id,
+                surface_id: n.surface_id,
+                title: n.title.clone(),
+                body: n.body.clone(),
+                source: match n.source {
+                    NotificationSource::Toast => "toast",
+                    NotificationSource::Bell => "bell",
+                    NotificationSource::Cli => "cli",
+                }
+                .to_string(),
+                read: n.read,
+            })
+            .collect();
+
+        let workspace_statuses: std::collections::HashMap<u64, amux_session::SavedWorkspaceStatus> =
+            self.workspaces
+                .iter()
+                .filter_map(|ws| {
+                    self.notifications.workspace_status(ws.id).map(|status| {
+                        (
+                            ws.id,
+                            amux_session::SavedWorkspaceStatus {
+                                state: match status.state {
+                                    amux_notify::AgentState::Active => "active",
+                                    amux_notify::AgentState::Waiting => "waiting",
+                                    amux_notify::AgentState::Idle => "idle",
+                                }
+                                .to_string(),
+                                label: status.label.clone(),
+                            },
+                        )
+                    })
+                })
+                .collect();
+
+        SessionData {
+            version: 1,
+            saved_at: chrono_now(),
+            workspaces: saved_workspaces,
+            active_workspace_idx: self.active_workspace_idx,
+            next_pane_id: self.next_pane_id,
+            next_workspace_id: self.next_workspace_id,
+            next_surface_id: self.next_surface_id,
+            sidebar: amux_session::SavedSidebar {
+                visible: self.sidebar.visible,
+                width: self.sidebar.width,
+            },
+            notifications,
+            workspace_statuses,
+        }
+    }
+}
+
+/// Simple ISO 8601 timestamp without a chrono dependency.
+fn chrono_now() -> String {
+    let dur = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs();
+    // Approximate UTC datetime (good enough for session metadata)
+    let days = secs / 86400;
+    let time_secs = secs % 86400;
+    let hours = time_secs / 3600;
+    let mins = (time_secs % 3600) / 60;
+    let s = time_secs % 60;
+    // Simple days-since-epoch to date (approximate, ignoring leap seconds)
+    let mut y = 1970i64;
+    let mut remaining_days = days as i64;
+    loop {
+        let year_days = if y % 4 == 0 && (y % 100 != 0 || y % 400 == 0) {
+            366
+        } else {
+            365
+        };
+        if remaining_days < year_days {
+            break;
+        }
+        remaining_days -= year_days;
+        y += 1;
+    }
+    let leap = y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+    let month_days = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut m = 0;
+    for (i, &md) in month_days.iter().enumerate() {
+        if remaining_days < md as i64 {
+            m = i + 1;
+            break;
+        }
+        remaining_days -= md as i64;
+    }
+    let d = remaining_days + 1;
+    format!("{y:04}-{m:02}-{d:02}T{hours:02}:{mins:02}:{s:02}Z")
 }
 
 impl eframe::App for AmuxApp {
@@ -440,6 +818,13 @@ impl eframe::App for AmuxApp {
             ctx.request_repaint();
         } else {
             ctx.request_repaint_after(Duration::from_millis(50));
+        }
+    }
+
+    fn on_exit(&mut self) {
+        let data = self.build_session_data();
+        if let Err(e) = amux_session::save(&data) {
+            tracing::error!("Session save failed: {}", e);
         }
     }
 }
@@ -571,9 +956,16 @@ impl AmuxApp {
                         let ws_id = self.active_workspace().id;
                         let sf_id = self.next_surface_id;
                         self.next_surface_id += 1;
-                        if let Ok(surface) =
-                            spawn_surface(80, 24, &self.socket_addr, &self.config, ws_id, sf_id)
-                        {
+                        if let Ok(surface) = spawn_surface(
+                            80,
+                            24,
+                            &self.socket_addr,
+                            &self.config,
+                            ws_id,
+                            sf_id,
+                            None,
+                            None,
+                        ) {
                             // Re-borrow managed after spawn_surface
                             if let Some(m) = self.panes.get_mut(&pane_id) {
                                 m.surfaces.push(surface);
@@ -857,7 +1249,16 @@ impl AmuxApp {
 
         let ws_id = self.active_workspace().id;
 
-        match spawn_surface(80, 24, &self.socket_addr, &self.config, ws_id, sf_id) {
+        match spawn_surface(
+            80,
+            24,
+            &self.socket_addr,
+            &self.config,
+            ws_id,
+            sf_id,
+            None,
+            None,
+        ) {
             Ok(surface) => {
                 self.panes.insert(
                     pane_id,
@@ -886,7 +1287,16 @@ impl AmuxApp {
         let sf_id = self.next_surface_id;
         self.next_surface_id += 1;
 
-        match spawn_surface(80, 24, &self.socket_addr, &self.config, ws_id, sf_id) {
+        match spawn_surface(
+            80,
+            24,
+            &self.socket_addr,
+            &self.config,
+            ws_id,
+            sf_id,
+            None,
+            None,
+        ) {
             Ok(surface) => {
                 self.panes.insert(
                     pane_id,
@@ -924,7 +1334,16 @@ impl AmuxApp {
         let ws_id = self.active_workspace().id;
         let focused = self.focused_pane_id();
 
-        match spawn_surface(80, 24, &self.socket_addr, &self.config, ws_id, sf_id) {
+        match spawn_surface(
+            80,
+            24,
+            &self.socket_addr,
+            &self.config,
+            ws_id,
+            sf_id,
+            None,
+            None,
+        ) {
             Ok(surface) => {
                 if let Some(managed) = self.panes.get_mut(&focused) {
                     managed.surfaces.push(surface);
@@ -2162,7 +2581,16 @@ impl AmuxApp {
                         self.next_surface_id += 1;
                         let ws_id = self.active_workspace().id;
 
-                        match spawn_surface(80, 24, &self.socket_addr, &self.config, ws_id, sf_id) {
+                        match spawn_surface(
+                            80,
+                            24,
+                            &self.socket_addr,
+                            &self.config,
+                            ws_id,
+                            sf_id,
+                            None,
+                            None,
+                        ) {
                             Ok(surface) => {
                                 if let Some(managed) = self.panes.get_mut(&target_pane) {
                                     managed.surfaces.push(surface);
@@ -2340,6 +2768,16 @@ impl AmuxApp {
             "notify.clear" => {
                 self.notifications.clear_all();
                 Response::ok(req.id.clone(), serde_json::json!({}))
+            }
+            "session.save" => {
+                let data = self.build_session_data();
+                match amux_session::save(&data) {
+                    Ok(()) => Response::ok(
+                        req.id.clone(),
+                        serde_json::json!({"path": amux_session::session_path().to_string_lossy()}),
+                    ),
+                    Err(e) => Response::err(req.id.clone(), "save_failed", &e.to_string()),
+                }
             }
             _ => Response::err(
                 req.id.clone(),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> anyhow::Result<()> {
         Box::new(move |_cc| {
             Ok(Box::new(AmuxApp {
                 workspaces: state.workspaces,
-                active_workspace_idx: 0,
+                active_workspace_idx: state.active_workspace_idx,
                 panes: state.panes,
                 next_pane_id: state.next_pane_id,
                 next_workspace_id: state.next_workspace_id,
@@ -128,6 +128,7 @@ fn main() -> anyhow::Result<()> {
 /// Bundled startup state to avoid complex return tuples.
 struct StartupState {
     workspaces: Vec<Workspace>,
+    active_workspace_idx: usize,
     panes: HashMap<PaneId, ManagedPane>,
     next_pane_id: PaneId,
     next_workspace_id: u64,
@@ -165,6 +166,7 @@ fn fresh_startup(
 
     Ok(StartupState {
         workspaces: vec![workspace],
+        active_workspace_idx: 0,
         panes,
         next_pane_id: 1,
         next_workspace_id: 1,
@@ -187,8 +189,6 @@ fn restore_session(
     let mut panes: HashMap<PaneId, ManagedPane> = HashMap::new();
 
     for saved_ws in &session.workspaces {
-        let mut ws_ok = true;
-
         for (&pane_id, saved_pane) in &saved_ws.panes {
             let mut surfaces = Vec::new();
             for saved_sf in &saved_pane.surfaces {
@@ -223,7 +223,6 @@ fn restore_session(
 
             if surfaces.is_empty() {
                 tracing::warn!("All surfaces failed for pane {}, skipping", pane_id);
-                ws_ok = false;
                 continue;
             }
 
@@ -240,17 +239,33 @@ fn restore_session(
             );
         }
 
-        if !ws_ok && saved_ws.panes.len() == 1 {
-            tracing::warn!("Skipping workspace {} (no panes restored)", saved_ws.title);
+        // Verify all pane IDs in the tree were actually restored
+        let tree_pane_ids = saved_ws.tree.iter_panes();
+        let all_panes_restored = tree_pane_ids.iter().all(|id| panes.contains_key(id));
+        if !all_panes_restored {
+            tracing::warn!(
+                "Skipping workspace {} (tree references missing panes)",
+                saved_ws.title
+            );
+            // Clean up any panes we did restore for this workspace
+            for id in &tree_pane_ids {
+                panes.remove(id);
+            }
             continue;
         }
+
+        let focused = if panes.contains_key(&saved_ws.focused_pane) {
+            saved_ws.focused_pane
+        } else {
+            *tree_pane_ids.first().unwrap_or(&0)
+        };
 
         workspaces.push(Workspace {
             id: saved_ws.id,
             title: saved_ws.title.clone(),
             tree: saved_ws.tree.clone(),
-            focused_pane: saved_ws.focused_pane,
-            zoomed: saved_ws.zoomed,
+            focused_pane: focused,
+            zoomed: saved_ws.zoomed.filter(|z| panes.contains_key(z)),
             dragging_divider: None,
             last_pane_sizes: HashMap::new(),
         });
@@ -312,8 +327,13 @@ fn restore_session(
         store.set_status(*ws_id, state, saved_status.label.clone());
     }
 
+    let active_idx = session
+        .active_workspace_idx
+        .min(workspaces.len().saturating_sub(1));
+
     StartupState {
         workspaces,
+        active_workspace_idx: active_idx,
         panes,
         next_pane_id: session.next_pane_id,
         next_workspace_id: session.next_workspace_id,
@@ -482,9 +502,12 @@ fn spawn_surface(
     // feed_bytes writes directly to the terminal state machine, not through the PTY.
     if let Some(text) = scrollback {
         if !text.is_empty() {
-            // Convert newlines to \r\n for proper terminal processing
-            for line in text.split('\n') {
-                pane.feed_bytes(line.as_bytes());
+            // Convert \n to \r\n for terminal processing, avoiding extra trailing blank line.
+            let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+            let trimmed = normalized.trim_end_matches('\n');
+            let buffer = trimmed.replace('\n', "\r\n");
+            if !buffer.is_empty() {
+                pane.feed_bytes(buffer.as_bytes());
                 pane.feed_bytes(b"\r\n");
             }
         }
@@ -570,6 +593,18 @@ impl AmuxApp {
 
     fn focused_pane_id(&self) -> PaneId {
         self.active_workspace().focused_pane
+    }
+
+    /// Drain any pending PTY bytes into the terminal state machine so that
+    /// title, working directory, and scrollback are up to date before save.
+    fn flush_pending_io(&mut self) {
+        for managed in self.panes.values_mut() {
+            for surface in &mut managed.surfaces {
+                while let Ok(bytes) = surface.byte_rx.try_recv() {
+                    surface.pane.feed_bytes(&bytes);
+                }
+            }
+        }
     }
 
     fn build_session_data(&self) -> SessionData {
@@ -877,6 +912,7 @@ impl eframe::App for AmuxApp {
                 tracing::error!("Session clear failed: {}", e);
             }
         } else {
+            self.flush_pending_io();
             let data = self.build_session_data();
             if let Err(e) = amux_session::save(&data) {
                 tracing::error!("Session save failed: {}", e);
@@ -2854,6 +2890,7 @@ impl AmuxApp {
                 Response::ok(req.id.clone(), serde_json::json!({}))
             }
             "session.save" => {
+                self.flush_pending_io();
                 let data = self.build_session_data();
                 match amux_session::save(&data) {
                     Ok(()) => Response::ok(

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1071,7 +1071,9 @@ impl AmuxApp {
 
             // Apply tab switch/close (need to re-borrow managed)
             if let Some(idx) = close_tab {
-                let is_last = self.panes.get(&pane_id)
+                let is_last = self
+                    .panes
+                    .get(&pane_id)
                     .is_some_and(|m| m.surfaces.len() <= 1);
                 if is_last {
                     self.close_pane(pane_id);
@@ -1755,7 +1757,10 @@ impl AmuxApp {
                     return None;
                 }
                 let layout = ws.tree.layout(panel_rect);
-                layout.iter().find(|(_, rect)| rect.contains(pos)).map(|(id, _)| *id)
+                layout
+                    .iter()
+                    .find(|(_, rect)| rect.contains(pos))
+                    .map(|(id, _)| *id)
             });
             if let Some(pane_id) = target_pane {
                 if let Some(managed) = self.panes.get_mut(&pane_id) {
@@ -2747,7 +2752,10 @@ impl AmuxApp {
                             if let Ok(sf_id) = sf_id_str.parse::<u64>() {
                                 // Find which pane owns this surface
                                 let target = self.panes.iter().find_map(|(&pid, m)| {
-                                    m.surfaces.iter().position(|s| s.id == sf_id).map(|idx| (pid, idx))
+                                    m.surfaces
+                                        .iter()
+                                        .position(|s| s.id == sf_id)
+                                        .map(|idx| (pid, idx))
                                 });
                                 if let Some((pane_id, idx)) = target {
                                     let managed = self.panes.get_mut(&pane_id).unwrap();

--- a/crates/amux-cli/Cargo.toml
+++ b/crates/amux-cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 amux-ipc = { workspace = true }
+amux-session = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -143,6 +143,31 @@ enum Command {
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    // SessionClear is a direct filesystem operation — handle before IPC connection
+    // so it works even when the server isn't running.
+    if matches!(cli.command, Command::SessionClear) {
+        match amux_session::clear() {
+            Ok(()) => {
+                if cli.json {
+                    println!("{}", serde_json::json!({"ok": true}));
+                } else {
+                    println!("Session cleared");
+                }
+            }
+            Err(e) => {
+                if cli.json {
+                    println!(
+                        "{}",
+                        serde_json::json!({"ok": false, "error": e.to_string()})
+                    );
+                } else {
+                    eprintln!("Error: {}", e);
+                }
+            }
+        }
+        return Ok(());
+    }
+
     let addr = resolve_addr(&cli)?;
     let mut client = IpcClient::connect(&addr).await?;
 
@@ -477,26 +502,7 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Command::SessionClear => {
-            // Direct filesystem operation, no IPC needed
-            match amux_session::clear() {
-                Ok(()) => {
-                    if cli.json {
-                        println!("{{\"ok\":true}}");
-                    } else {
-                        println!("Session cleared");
-                    }
-                }
-                Err(e) => {
-                    if cli.json {
-                        println!(
-                            "{{\"ok\":false,\"error\":\"{}\"}}",
-                            e.to_string().replace('"', "\\\"")
-                        );
-                    } else {
-                        eprintln!("Error: {}", e);
-                    }
-                }
-            }
+            unreachable!("handled before IPC connection");
         }
     }
     Ok(())

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -131,6 +131,12 @@ enum Command {
     /// Clear all notifications
     #[command(name = "clear-notifications")]
     ClearNotifications,
+    /// Save the current session
+    #[command(name = "session-save")]
+    SessionSave,
+    /// Clear saved session data
+    #[command(name = "session-clear")]
+    SessionClear,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -452,6 +458,44 @@ async fn main() -> anyhow::Result<()> {
                 println!("Notifications cleared");
             } else {
                 print_response(&resp, false);
+            }
+        }
+        Command::SessionSave => {
+            let resp = client.call("session.save", serde_json::json!({})).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                let path = resp
+                    .result
+                    .as_ref()
+                    .and_then(|r| r.get("path"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("(unknown)");
+                println!("Session saved to {}", path);
+            } else {
+                print_response(&resp, false);
+            }
+        }
+        Command::SessionClear => {
+            // Direct filesystem operation, no IPC needed
+            match amux_session::clear() {
+                Ok(()) => {
+                    if cli.json {
+                        println!("{{\"ok\":true}}");
+                    } else {
+                        println!("Session cleared");
+                    }
+                }
+                Err(e) => {
+                    if cli.json {
+                        println!(
+                            "{{\"ok\":false,\"error\":\"{}\"}}",
+                            e.to_string().replace('"', "\\\"")
+                        );
+                    } else {
+                        eprintln!("Error: {}", e);
+                    }
+                }
             }
         }
     }

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -23,6 +23,7 @@ pub const METHODS: &[&str] = &[
     "notify.send",
     "notify.list",
     "notify.clear",
+    "session.save",
 ];
 
 // --- Params ---

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -17,7 +17,7 @@ pub enum AgentState {
 }
 
 /// What triggered the notification.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum NotificationSource {
     Toast,

--- a/crates/amux-session/Cargo.toml
+++ b/crates/amux-session/Cargo.toml
@@ -6,3 +6,11 @@ license.workspace = true
 description = "amux session persistence (save/restore JSON)"
 
 [dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+dirs = { workspace = true }
+anyhow = { workspace = true }
+amux-layout = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/amux-session/Cargo.toml
+++ b/crates/amux-session/Cargo.toml
@@ -13,4 +13,4 @@ anyhow = { workspace = true }
 amux-layout = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -114,6 +114,13 @@ pub fn load() -> anyhow::Result<Option<SessionData>> {
         anyhow::bail!("unsupported session version: {}", data.version);
     }
 
+    // Reject empty sessions (no workspaces, or all workspaces have no panes)
+    if data.workspaces.is_empty()
+        || data.workspaces.iter().all(|ws| ws.panes.is_empty())
+    {
+        return Ok(None);
+    }
+
     Ok(Some(data))
 }
 

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -120,9 +120,7 @@ fn load_from_path(path: &std::path::Path) -> anyhow::Result<Option<SessionData>>
     }
 
     // Reject empty sessions (no workspaces, or all workspaces have no panes)
-    if data.workspaces.is_empty()
-        || data.workspaces.iter().all(|ws| ws.panes.is_empty())
-    {
+    if data.workspaces.is_empty() || data.workspaces.iter().all(|ws| ws.panes.is_empty()) {
         return Ok(None);
     }
 

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -1,1 +1,224 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
 
+use amux_layout::PaneTree;
+use serde::{Deserialize, Serialize};
+
+// --- Data Model ---
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SessionData {
+    pub version: u32,
+    pub saved_at: String,
+    pub workspaces: Vec<SavedWorkspace>,
+    pub active_workspace_idx: usize,
+    pub next_pane_id: u64,
+    pub next_workspace_id: u64,
+    pub next_surface_id: u64,
+    pub sidebar: SavedSidebar,
+    #[serde(default)]
+    pub notifications: Vec<SavedNotification>,
+    #[serde(default)]
+    pub workspace_statuses: HashMap<u64, SavedWorkspaceStatus>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SavedWorkspace {
+    pub id: u64,
+    pub title: String,
+    pub tree: PaneTree,
+    pub focused_pane: u64,
+    #[serde(default)]
+    pub zoomed: Option<u64>,
+    pub panes: HashMap<u64, SavedManagedPane>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SavedManagedPane {
+    pub surfaces: Vec<SavedSurface>,
+    pub active_surface_idx: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SavedSurface {
+    pub id: u64,
+    pub title: String,
+    #[serde(default)]
+    pub working_dir: Option<String>,
+    #[serde(default)]
+    pub scrollback: String,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SavedSidebar {
+    pub visible: bool,
+    pub width: f32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SavedNotification {
+    pub id: u64,
+    pub workspace_id: u64,
+    pub pane_id: u64,
+    pub surface_id: u64,
+    pub title: String,
+    pub body: String,
+    pub source: String,
+    pub read: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SavedWorkspaceStatus {
+    pub state: String,
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+// --- File Operations ---
+
+/// Returns the path to the session file: `{data_dir}/amux/session.json`
+pub fn session_path() -> PathBuf {
+    let base = dirs::data_dir().unwrap_or_else(|| PathBuf::from("."));
+    base.join("amux").join("session.json")
+}
+
+/// Save session data to disk using atomic write (write to .tmp, then rename).
+pub fn save(data: &SessionData) -> anyhow::Result<()> {
+    let path = session_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let json = serde_json::to_string_pretty(data)?;
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, json)?;
+    fs::rename(&tmp_path, &path)?;
+
+    Ok(())
+}
+
+/// Load session data from disk. Returns `None` if the file does not exist.
+pub fn load() -> anyhow::Result<Option<SessionData>> {
+    let path = session_path();
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&path)?;
+    let data: SessionData = serde_json::from_str(&content)?;
+
+    if data.version != 1 {
+        anyhow::bail!("unsupported session version: {}", data.version);
+    }
+
+    Ok(Some(data))
+}
+
+/// Delete the session file.
+pub fn clear() -> anyhow::Result<()> {
+    let path = session_path();
+    if path.exists() {
+        fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use amux_layout::PaneTree;
+
+    fn minimal_session() -> SessionData {
+        let tree = PaneTree::new(0);
+        let mut panes = HashMap::new();
+        panes.insert(
+            0,
+            SavedManagedPane {
+                surfaces: vec![SavedSurface {
+                    id: 0,
+                    title: "zsh".to_string(),
+                    working_dir: Some("/tmp".to_string()),
+                    scrollback: "$ echo hello\nhello\n".to_string(),
+                    cols: 80,
+                    rows: 24,
+                }],
+                active_surface_idx: 0,
+            },
+        );
+
+        SessionData {
+            version: 1,
+            saved_at: "2026-03-24T00:00:00Z".to_string(),
+            workspaces: vec![SavedWorkspace {
+                id: 0,
+                title: "default".to_string(),
+                tree,
+                focused_pane: 0,
+                zoomed: None,
+                panes,
+            }],
+            active_workspace_idx: 0,
+            next_pane_id: 1,
+            next_workspace_id: 1,
+            next_surface_id: 1,
+            sidebar: SavedSidebar {
+                visible: true,
+                width: 200.0,
+            },
+            notifications: vec![],
+            workspace_statuses: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn round_trip_serde() {
+        let session = minimal_session();
+        let json = serde_json::to_string(&session).unwrap();
+        let restored: SessionData = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.version, 1);
+        assert_eq!(restored.workspaces.len(), 1);
+        assert_eq!(restored.workspaces[0].title, "default");
+        assert_eq!(
+            restored.workspaces[0].panes[&0].surfaces[0].scrollback,
+            "$ echo hello\nhello\n"
+        );
+    }
+
+    #[test]
+    fn load_missing_file_returns_none() {
+        // Use a temporary directory to ensure no session file exists
+        let _dir = tempfile::tempdir().unwrap();
+        // Since session_path() uses dirs::data_dir(), this test just verifies
+        // the function handles non-existent paths correctly by testing the logic
+        let path = PathBuf::from("/tmp/amux-test-nonexistent/session.json");
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.json");
+
+        let session = minimal_session();
+        let json = serde_json::to_string_pretty(&session).unwrap();
+        fs::write(&path, &json).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let restored: SessionData = serde_json::from_str(&content).unwrap();
+        assert_eq!(restored.workspaces[0].panes.len(), 1);
+    }
+
+    #[test]
+    fn corrupt_json_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.json");
+        fs::write(&path, "not valid json").unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let result = serde_json::from_str::<SessionData>(&content);
+        assert!(result.is_err());
+    }
+}

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -85,29 +85,34 @@ pub fn session_path() -> PathBuf {
     base.join("amux").join("session.json")
 }
 
-/// Save session data to disk using atomic write (write to .tmp, then rename).
-pub fn save(data: &SessionData) -> anyhow::Result<()> {
-    let path = session_path();
+/// Save session data to the given path using atomic write (write to .tmp, then rename).
+fn save_to_path(data: &SessionData, path: &std::path::Path) -> anyhow::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
 
     let json = serde_json::to_string_pretty(data)?;
     let tmp_path = path.with_extension("json.tmp");
-    fs::write(&tmp_path, json)?;
-    fs::rename(&tmp_path, &path)?;
+    fs::write(&tmp_path, &json)?;
+
+    // On Windows, fs::rename fails if the destination exists.
+    #[cfg(windows)]
+    {
+        let _ = fs::remove_file(path);
+    }
+
+    fs::rename(&tmp_path, path)?;
 
     Ok(())
 }
 
-/// Load session data from disk. Returns `None` if the file does not exist.
-pub fn load() -> anyhow::Result<Option<SessionData>> {
-    let path = session_path();
+/// Load session data from the given path. Returns `None` if the file does not exist.
+fn load_from_path(path: &std::path::Path) -> anyhow::Result<Option<SessionData>> {
     if !path.exists() {
         return Ok(None);
     }
 
-    let content = fs::read_to_string(&path)?;
+    let content = fs::read_to_string(path)?;
     let data: SessionData = serde_json::from_str(&content)?;
 
     if data.version != 1 {
@@ -124,13 +129,27 @@ pub fn load() -> anyhow::Result<Option<SessionData>> {
     Ok(Some(data))
 }
 
-/// Delete the session file.
-pub fn clear() -> anyhow::Result<()> {
-    let path = session_path();
+/// Delete the given session file.
+fn clear_path(path: &std::path::Path) -> anyhow::Result<()> {
     if path.exists() {
-        fs::remove_file(&path)?;
+        fs::remove_file(path)?;
     }
     Ok(())
+}
+
+/// Save session data to the default session file.
+pub fn save(data: &SessionData) -> anyhow::Result<()> {
+    save_to_path(data, &session_path())
+}
+
+/// Load session data from the default session file.
+pub fn load() -> anyhow::Result<Option<SessionData>> {
+    load_from_path(&session_path())
+}
+
+/// Delete the default session file.
+pub fn clear() -> anyhow::Result<()> {
+    clear_path(&session_path())
 }
 
 #[cfg(test)]
@@ -196,12 +215,10 @@ mod tests {
 
     #[test]
     fn load_missing_file_returns_none() {
-        // Use a temporary directory to ensure no session file exists
-        let _dir = tempfile::tempdir().unwrap();
-        // Since session_path() uses dirs::data_dir(), this test just verifies
-        // the function handles non-existent paths correctly by testing the logic
-        let path = PathBuf::from("/tmp/amux-test-nonexistent/session.json");
-        assert!(!path.exists());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.json");
+        let result = load_from_path(&path).unwrap();
+        assert!(result.is_none());
     }
 
     #[test]
@@ -210,12 +227,14 @@ mod tests {
         let path = dir.path().join("session.json");
 
         let session = minimal_session();
-        let json = serde_json::to_string_pretty(&session).unwrap();
-        fs::write(&path, &json).unwrap();
+        save_to_path(&session, &path).unwrap();
 
-        let content = fs::read_to_string(&path).unwrap();
-        let restored: SessionData = serde_json::from_str(&content).unwrap();
+        let restored = load_from_path(&path).unwrap().unwrap();
         assert_eq!(restored.workspaces[0].panes.len(), 1);
+        assert_eq!(
+            restored.workspaces[0].panes[&0].surfaces[0].scrollback,
+            "$ echo hello\nhello\n"
+        );
     }
 
     #[test]
@@ -224,8 +243,32 @@ mod tests {
         let path = dir.path().join("session.json");
         fs::write(&path, "not valid json").unwrap();
 
-        let content = fs::read_to_string(&path).unwrap();
-        let result = serde_json::from_str::<SessionData>(&content);
+        let result = load_from_path(&path);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn clear_removes_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.json");
+
+        save_to_path(&minimal_session(), &path).unwrap();
+        assert!(path.exists());
+
+        clear_path(&path).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn load_rejects_empty_workspaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.json");
+
+        let mut session = minimal_session();
+        session.workspaces.clear();
+        save_to_path(&session, &path).unwrap();
+
+        let result = load_from_path(&path).unwrap();
+        assert!(result.is_none());
     }
 }

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -192,6 +192,11 @@ impl TerminalPane {
         self.terminal.get_current_dir()
     }
 
+    /// Get the child process ID, if available.
+    pub fn child_pid(&self) -> Option<u32> {
+        self.child.process_id()
+    }
+
     /// Check whether the child process is still alive.
     pub fn is_alive(&mut self) -> bool {
         // try_wait returns Ok(Some(status)) if exited, Ok(None) if still running

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -94,6 +94,10 @@ impl TerminalPane {
             Box::new(terminal_writer),
         );
 
+        // Override wezterm-term's default "wezterm" title with empty string.
+        // The shell will set the real title via OSC 0/2 once it starts.
+        terminal.advance_bytes(b"\x1b]2;\x07");
+
         let (tx, rx) = mpsc::channel();
         terminal.set_notification_handler(Box::new(ChannelAlertHandler::new(tx)));
 
@@ -286,30 +290,142 @@ impl TerminalPane {
         result
     }
 
-    /// Read scrollback + visible screen as text, up to `max_lines` lines.
-    /// Unlike `read_screen_text` which only reads the visible viewport,
-    /// this captures the full scrollback buffer for session persistence.
+    /// Read scrollback + visible screen as text with ANSI escape sequences,
+    /// up to `max_lines` lines. Preserves colors and formatting for session
+    /// persistence. Trailing empty lines are trimmed.
     pub fn read_scrollback_text(&self, max_lines: usize) -> String {
+        use wezterm_term::{CellAttributes, Intensity, Underline};
+
         let (cols, _) = self.dimensions();
         let screen = self.terminal.screen();
         let total = screen.scrollback_rows();
         let start = total.saturating_sub(max_lines);
         let lines = screen.lines_in_phys_range(start..total);
 
-        let mut result = String::new();
-        for (i, line) in lines.iter().enumerate() {
-            if i > 0 {
-                result.push('\n');
-            }
-            let mut line_text = String::new();
+        // Build lines with ANSI formatting, collecting into a Vec
+        // so we can trim trailing empty lines.
+        let mut output_lines: Vec<String> = Vec::with_capacity(lines.len());
+        let default_attrs = CellAttributes::blank();
+
+        for line in &lines {
+            let mut line_buf = String::new();
+            let mut prev_attrs = default_attrs.clone();
+
             for cell in line.visible_cells() {
                 if cell.cell_index() >= cols {
                     break;
                 }
-                line_text.push_str(cell.str());
+                let attrs = cell.attrs();
+                // Emit SGR sequences when attributes change
+                if attrs != &prev_attrs {
+                    let mut sgr_params: Vec<u8> = Vec::new();
+
+                    // Reset first, then set active attributes.
+                    // This is simpler and more reliable than computing diffs.
+                    sgr_params.push(0);
+
+                    // Intensity (bold/dim)
+                    match attrs.intensity() {
+                        Intensity::Bold => sgr_params.push(1),
+                        Intensity::Half => sgr_params.push(2),
+                        Intensity::Normal => {}
+                    }
+
+                    if attrs.italic() {
+                        sgr_params.push(3);
+                    }
+
+                    match attrs.underline() {
+                        Underline::Single => sgr_params.push(4),
+                        Underline::Double => sgr_params.push(21),
+                        Underline::Curly => { /* CSI 4:3 m - handle below */ }
+                        Underline::Dotted => { /* CSI 4:4 m */ }
+                        Underline::Dashed => { /* CSI 4:5 m */ }
+                        Underline::None => {}
+                    }
+
+                    if attrs.reverse() {
+                        sgr_params.push(7);
+                    }
+
+                    if attrs.invisible() {
+                        sgr_params.push(8);
+                    }
+
+                    if attrs.strikethrough() {
+                        sgr_params.push(9);
+                    }
+
+                    if attrs.overline() {
+                        sgr_params.push(53);
+                    }
+
+                    // Build the SGR sequence
+                    line_buf.push_str("\x1b[");
+                    for (i, p) in sgr_params.iter().enumerate() {
+                        if i > 0 {
+                            line_buf.push(';');
+                        }
+                        line_buf.push_str(&p.to_string());
+                    }
+
+                    // Foreground color
+                    emit_color_sgr(&mut line_buf, attrs.foreground(), true);
+
+                    // Background color
+                    emit_color_sgr(&mut line_buf, attrs.background(), false);
+
+                    line_buf.push('m');
+
+                    prev_attrs = attrs.clone();
+                }
+                line_buf.push_str(cell.str());
             }
-            result.push_str(line_text.trim_end());
+
+            // Reset at end of line if we had non-default attributes
+            if prev_attrs != default_attrs {
+                line_buf.push_str("\x1b[0m");
+            }
+
+            // Trim trailing whitespace from the plain-text portion
+            // (but preserve escape sequences)
+            let trimmed = line_buf.trim_end();
+            output_lines.push(trimmed.to_string());
         }
-        result
+
+        // Trim trailing empty lines
+        while output_lines.last().is_some_and(|l| l.is_empty()) {
+            output_lines.pop();
+        }
+
+        output_lines.join("\n")
+    }
+}
+
+/// Append an SGR color parameter to an in-progress SGR sequence.
+/// `is_fg` selects foreground (38) vs background (48).
+fn emit_color_sgr(buf: &mut String, color: wezterm_term::color::ColorAttribute, is_fg: bool) {
+    use wezterm_term::color::ColorAttribute;
+    match color {
+        ColorAttribute::Default => {}
+        ColorAttribute::PaletteIndex(idx) => {
+            // Standard 16 colors use compact codes; 256-color uses extended form
+            let base = if is_fg { 30 } else { 40 };
+            if idx < 8 {
+                buf.push_str(&format!(";{}", base + idx as u16));
+            } else if idx < 16 {
+                buf.push_str(&format!(";{}", base + 60 + (idx - 8) as u16));
+            } else {
+                buf.push_str(&format!(";{};5;{}", if is_fg { 38 } else { 48 }, idx));
+            }
+        }
+        ColorAttribute::TrueColorWithDefaultFallback(srgba) => {
+            let (r, g, b, _) = srgba.to_srgb_u8();
+            buf.push_str(&format!(";{};2;{};{};{}", if is_fg { 38 } else { 48 }, r, g, b));
+        }
+        ColorAttribute::TrueColorWithPaletteFallback(srgba, _) => {
+            let (r, g, b, _) = srgba.to_srgb_u8();
+            buf.push_str(&format!(";{};2;{};{};{}", if is_fg { 38 } else { 48 }, r, g, b));
+        }
     }
 }

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -421,11 +421,23 @@ fn emit_color_sgr(buf: &mut String, color: wezterm_term::color::ColorAttribute, 
         }
         ColorAttribute::TrueColorWithDefaultFallback(srgba) => {
             let (r, g, b, _) = srgba.to_srgb_u8();
-            buf.push_str(&format!(";{};2;{};{};{}", if is_fg { 38 } else { 48 }, r, g, b));
+            buf.push_str(&format!(
+                ";{};2;{};{};{}",
+                if is_fg { 38 } else { 48 },
+                r,
+                g,
+                b
+            ));
         }
         ColorAttribute::TrueColorWithPaletteFallback(srgba, _) => {
             let (r, g, b, _) = srgba.to_srgb_u8();
-            buf.push_str(&format!(";{};2;{};{};{}", if is_fg { 38 } else { 48 }, r, g, b));
+            buf.push_str(&format!(
+                ";{};2;{};{};{}",
+                if is_fg { 38 } else { 48 },
+                r,
+                g,
+                b
+            ));
         }
     }
 }

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -280,4 +280,31 @@ impl TerminalPane {
         }
         result
     }
+
+    /// Read scrollback + visible screen as text, up to `max_lines` lines.
+    /// Unlike `read_screen_text` which only reads the visible viewport,
+    /// this captures the full scrollback buffer for session persistence.
+    pub fn read_scrollback_text(&self, max_lines: usize) -> String {
+        let (cols, _) = self.dimensions();
+        let screen = self.terminal.screen();
+        let total = screen.scrollback_rows();
+        let start = total.saturating_sub(max_lines);
+        let lines = screen.lines_in_phys_range(start..total);
+
+        let mut result = String::new();
+        for (i, line) in lines.iter().enumerate() {
+            if i > 0 {
+                result.push('\n');
+            }
+            let mut line_text = String::new();
+            for cell in line.visible_cells() {
+                if cell.cell_index() >= cols {
+                    break;
+                }
+                line_text.push_str(cell.str());
+            }
+            result.push_str(line_text.trim_end());
+        }
+        result
+    }
 }


### PR DESCRIPTION
## Summary

- **Session persistence**: Save and restore workspace layout, scrollback (up to 4k lines with ANSI formatting), working directories, notification history, and sidebar state across restarts. Auto-save on exit via `on_exit()`, auto-restore on startup. Atomic write (`session.json.tmp` + rename) to prevent corruption.
- **CLI commands**: `amux session save` (IPC) and `amux session clear` (direct file delete)
- **Working directory fix**: OSC 7 is the primary source; falls back to OS-level process introspection (`/proc/{pid}/cwd` on Linux, `lsof` on macOS) when shells don't emit OSC 7
- **Scrollback formatting**: Captures ANSI escape sequences (colors, bold, italic, underline, etc.) via SGR codes instead of plain text; trims trailing empty lines to avoid saving unused pane area
- **Mouse scroll targeting**: Scroll wheel now targets the pane under the cursor, not always the focused pane; no scroll if cursor is outside any pane
- **Close last tab**: Closing the final tab in a pane now closes the pane, cascading to workspace close and app exit as needed (matching cmux behavior)
- **App exit on empty**: Closing the last workspace exits the app and clears the session file; load-time validation rejects empty sessions as defense-in-depth
- **Naming conventions**: Workspace names use "Terminal N" (cmux style); tab names fall back to "tab N"; wezterm's default "wezterm" title is overridden at the source via OSC 2

## Crates changed

| Crate | Changes |
|---|---|
| `amux-session` | New: session data model, save/load/clear, load-time validation, 4 unit tests |
| `amux-app` | spawn_surface cwd/scrollback params, build_session_data, on_exit, startup restore, scroll targeting, close cascade, exit handling, naming |
| `amux-term` | read_scrollback_text with ANSI escapes, trailing line trim, child_pid(), OSC 2 title override |
| `amux-ipc` | Added `session.save` method |
| `amux-cli` | Added `session save` and `session clear` subcommands |
| `amux-notify` | Added `Deserialize` to `NotificationSource` |

## Test plan

- [x] `cargo build --workspace` compiles
- [x] `cargo test --workspace` passes (60 tests including 4 new amux-session tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [ ] Launch amux, create workspaces/splits/tabs, type commands → close → relaunch → layout, scrollback (with colors), and working directories restored
- [ ] Close all tabs → app exits → relaunch → starts fresh with "Terminal 1"
- [ ] Mouse scroll targets pane under cursor, not focused pane
- [ ] `amux session save` / `amux session clear` work as expected
- [ ] New workspaces named "Terminal N", tabs named "tab N" (not "wezterm")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic session persistence: save/restore workspaces, panes, terminal content, sidebar, notifications, and workspace status.
  * Manual session controls: CLI commands and an IPC trigger to save or clear the persisted session.
  * Terminal APIs: terminals expose child PID and provide scrollback-reading; scrollback is restored on startup.

* **Behavior Changes**
  * Mouse-wheel scrolling targets the pane under the cursor; pane/tab/workspace closing cascades consistently.
  * New workspaces default to "Terminal {n}"; tab title truncation uses raw surface titles.

* **Documentation**
  * New pre-push formatting and lint checks documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->