### PR TITLE
Fix 20 major+medium review issues across all PRs

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1377,7 +1377,7 @@ impl AmuxApp {
         }
     }
 
-    fn create_workspace(&mut self, title: Option<String>) -> u64 {
+    fn create_workspace(&mut self, title: Option<String>) -> Option<u64> {
         let ws_id = self.next_workspace_id;
         let title = title.unwrap_or_else(|| format!("Terminal {}", self.workspaces.len() + 1));
 
@@ -1419,12 +1419,13 @@ impl AmuxApp {
 
                 self.workspaces.push(workspace);
                 self.active_workspace_idx = self.workspaces.len() - 1;
+                Some(ws_id)
             }
             Err(e) => {
                 tracing::error!("Failed to spawn pane for workspace: {}", e);
+                None
             }
         }
-        ws_id
     }
 
     fn add_surface_to_focused_pane(&mut self) -> Option<u64> {
@@ -2668,11 +2669,18 @@ impl AmuxApp {
                 }
                 match serde_json::from_value::<CreateParams>(req.params.clone()) {
                     Ok(params) => {
-                        let ws_id = self.create_workspace(params.title);
-                        Response::ok(
-                            req.id.clone(),
-                            serde_json::json!({"workspace_id": ws_id.to_string()}),
-                        )
+                        if let Some(ws_id) = self.create_workspace(params.title) {
+                            Response::ok(
+                                req.id.clone(),
+                                serde_json::json!({"workspace_id": ws_id.to_string()}),
+                            )
+                        } else {
+                            Response::err(
+                                req.id.clone(),
+                                "spawn_failed",
+                                "Failed to spawn pane for workspace",
+                            )
+                        }
                     }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
                 }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -514,7 +514,7 @@ fn spawn_surface(
     }
 
     let mut reader = pane.take_reader().expect("reader already taken");
-    let (byte_tx, byte_rx) = mpsc::channel::<Vec<u8>>();
+    let (byte_tx, byte_rx) = mpsc::sync_channel::<Vec<u8>>(64);
 
     thread::spawn(move || {
         let mut buf = [0u8; 8192];
@@ -1342,13 +1342,9 @@ impl AmuxApp {
 
     // --- Pane/Workspace management ---
 
-    fn spawn_pane_with_surface(&mut self) -> PaneId {
-        let pane_id = self.next_pane_id;
-        self.next_pane_id += 1;
-        let sf_id = self.next_surface_id;
-        self.next_surface_id += 1;
-
+    fn spawn_pane_with_surface(&mut self) -> Option<PaneId> {
         let ws_id = self.active_workspace().id;
+        let sf_id = self.next_surface_id;
 
         match spawn_surface(
             80,
@@ -1361,6 +1357,9 @@ impl AmuxApp {
             None,
         ) {
             Ok(surface) => {
+                let pane_id = self.next_pane_id;
+                self.next_pane_id += 1;
+                self.next_surface_id += 1;
                 self.panes.insert(
                     pane_id,
                     ManagedPane {
@@ -1369,24 +1368,20 @@ impl AmuxApp {
                         selection: None,
                     },
                 );
+                Some(pane_id)
             }
             Err(e) => {
                 tracing::error!("Failed to spawn pane: {}", e);
+                None
             }
         }
-        pane_id
     }
 
     fn create_workspace(&mut self, title: Option<String>) -> u64 {
         let ws_id = self.next_workspace_id;
-        self.next_workspace_id += 1;
-
         let title = title.unwrap_or_else(|| format!("Terminal {}", self.workspaces.len() + 1));
 
-        let pane_id = self.next_pane_id;
-        self.next_pane_id += 1;
         let sf_id = self.next_surface_id;
-        self.next_surface_id += 1;
 
         match spawn_surface(
             80,
@@ -1399,6 +1394,10 @@ impl AmuxApp {
             None,
         ) {
             Ok(surface) => {
+                self.next_workspace_id += 1;
+                let pane_id = self.next_pane_id;
+                self.next_pane_id += 1;
+                self.next_surface_id += 1;
                 self.panes.insert(
                     pane_id,
                     ManagedPane {
@@ -1407,25 +1406,24 @@ impl AmuxApp {
                         selection: None,
                     },
                 );
+
+                let workspace = Workspace {
+                    id: ws_id,
+                    title,
+                    tree: PaneTree::new(pane_id),
+                    focused_pane: pane_id,
+                    zoomed: None,
+                    dragging_divider: None,
+                    last_pane_sizes: HashMap::new(),
+                };
+
+                self.workspaces.push(workspace);
+                self.active_workspace_idx = self.workspaces.len() - 1;
             }
             Err(e) => {
                 tracing::error!("Failed to spawn pane for workspace: {}", e);
-                return ws_id;
             }
         }
-
-        let workspace = Workspace {
-            id: ws_id,
-            title,
-            tree: PaneTree::new(pane_id),
-            focused_pane: pane_id,
-            zoomed: None,
-            dragging_divider: None,
-            last_pane_sizes: HashMap::new(),
-        };
-
-        self.workspaces.push(workspace);
-        self.active_workspace_idx = self.workspaces.len() - 1;
         ws_id
     }
 
@@ -1673,11 +1671,16 @@ impl AmuxApp {
 
                 // --- Pane shortcuts ---
 
-                // Split right: Cmd+D / Ctrl+Shift+D
+                // Split right: Cmd+D (macOS) / Ctrl+Shift+D (other)
+                #[cfg(target_os = "macos")]
                 if is_cmd && !modifiers.shift && *key == egui::Key::D {
                     return self.do_split(SplitDirection::Horizontal);
                 }
-                // Split down: Cmd+Shift+D / Ctrl+Shift+Down
+                #[cfg(not(target_os = "macos"))]
+                if is_cmd && *key == egui::Key::D {
+                    return self.do_split(SplitDirection::Horizontal);
+                }
+                // Split down: Cmd+Shift+D (macOS) / Ctrl+Shift+Down (other)
                 #[cfg(target_os = "macos")]
                 if is_cmd && modifiers.shift && *key == egui::Key::D {
                     return self.do_split(SplitDirection::Vertical);
@@ -1783,11 +1786,18 @@ impl AmuxApp {
     }
 
     fn do_split(&mut self, direction: SplitDirection) -> bool {
-        let new_id = self.spawn_pane_with_surface();
+        let Some(new_id) = self.spawn_pane_with_surface() else {
+            return false;
+        };
         let ws = self.active_workspace_mut();
-        ws.tree.split(ws.focused_pane, direction, new_id);
-        self.set_focus(new_id);
-        true
+        if ws.tree.split(ws.focused_pane, direction, new_id) {
+            self.set_focus(new_id);
+            true
+        } else {
+            // Split failed — clean up the spawned pane
+            self.panes.remove(&new_id);
+            false
+        }
     }
 
     fn do_close_cascade(&mut self) -> bool {
@@ -2153,8 +2163,8 @@ impl AmuxApp {
             Some(m) => m,
             None => return false,
         };
-        let sel = match managed.selection.take() {
-            Some(s) => s,
+        let sel = match &managed.selection {
+            Some(s) => s.clone(),
             None => return false,
         };
 
@@ -2168,7 +2178,9 @@ impl AmuxApp {
 
         match arboard::Clipboard::new() {
             Ok(mut clipboard) => {
-                let _ = clipboard.set_text(&text);
+                if clipboard.set_text(&text).is_ok() {
+                    managed.selection = None; // Only clear on successful copy
+                }
             }
             Err(e) => {
                 tracing::warn!("Clipboard error: {}", e);
@@ -2234,6 +2246,11 @@ impl AmuxApp {
         if primary_pressed {
             if let Some(pos) = pointer_pos {
                 if !content_rect.contains(pos) {
+                    // Click outside content — clear any existing selection
+                    if let Some(m) = self.panes.get_mut(&pane_id) {
+                        m.selection = None;
+                    }
+                    ui.ctx().request_repaint();
                     return;
                 }
 
@@ -2413,9 +2430,13 @@ impl AmuxApp {
                 egui::Event::Paste(text) => {
                     surface.scroll_offset = 0;
                     surface.scroll_accum = 0.0;
-                    let _ = surface.pane.write_bytes(b"\x1b[200~");
-                    let _ = surface.pane.write_bytes(text.as_bytes());
-                    let _ = surface.pane.write_bytes(b"\x1b[201~");
+                    if surface.pane.bracketed_paste_enabled() {
+                        let _ = surface.pane.write_bytes(b"\x1b[200~");
+                        let _ = surface.pane.write_bytes(text.as_bytes());
+                        let _ = surface.pane.write_bytes(b"\x1b[201~");
+                    } else {
+                        let _ = surface.pane.write_bytes(text.as_bytes());
+                    }
                 }
                 _ => {}
             }
@@ -2529,14 +2550,30 @@ impl AmuxApp {
                             "down" | "vertical" => SplitDirection::Vertical,
                             _ => SplitDirection::Horizontal,
                         };
-                        let new_id = self.spawn_pane_with_surface();
-                        let ws = self.active_workspace_mut();
-                        ws.tree.split(ws.focused_pane, dir, new_id);
-                        self.set_focus(new_id);
-                        Response::ok(
-                            req.id.clone(),
-                            serde_json::json!({"pane_id": new_id.to_string()}),
-                        )
+                        match self.spawn_pane_with_surface() {
+                            Some(new_id) => {
+                                let ws = self.active_workspace_mut();
+                                if ws.tree.split(ws.focused_pane, dir, new_id) {
+                                    self.set_focus(new_id);
+                                    Response::ok(
+                                        req.id.clone(),
+                                        serde_json::json!({"pane_id": new_id.to_string()}),
+                                    )
+                                } else {
+                                    self.panes.remove(&new_id);
+                                    Response::err(
+                                        req.id.clone(),
+                                        "split_failed",
+                                        "failed to split pane tree",
+                                    )
+                                }
+                            }
+                            None => Response::err(
+                                req.id.clone(),
+                                "spawn_failed",
+                                "failed to spawn pane",
+                            ),
+                        }
                     }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
                 }
@@ -2829,16 +2866,26 @@ impl AmuxApp {
                 match serde_json::from_value::<FocusParams>(req.params.clone()) {
                     Ok(params) => {
                         if let Ok(sf_id) = params.surface_id.parse::<u64>() {
-                            for (pane_id, managed) in &mut self.panes {
-                                if let Some(idx) =
-                                    managed.surfaces.iter().position(|s| s.id == sf_id)
+                            // Find the pane that owns this surface
+                            let found = self.panes.iter_mut().find_map(|(pid, managed)| {
+                                managed
+                                    .surfaces
+                                    .iter()
+                                    .position(|s| s.id == sf_id)
+                                    .map(|idx| (*pid, idx))
+                            });
+                            if let Some((pid, idx)) = found {
+                                self.panes.get_mut(&pid).unwrap().active_surface_idx = idx;
+                                // Switch to the owning workspace before setting focus
+                                if let Some(ws_idx) = self
+                                    .workspaces
+                                    .iter()
+                                    .position(|ws| ws.tree.iter_panes().contains(&pid))
                                 {
-                                    managed.active_surface_idx = idx;
-                                    // Also focus the pane containing this surface
-                                    let pid = *pane_id;
-                                    self.set_focus(pid);
-                                    return Response::ok(req.id.clone(), serde_json::json!({}));
+                                    self.active_workspace_idx = ws_idx;
                                 }
+                                self.set_focus(pid);
+                                return Response::ok(req.id.clone(), serde_json::json!({}));
                             }
                             Response::err(req.id.clone(), "not_found", "surface not found")
                         } else {
@@ -3141,15 +3188,8 @@ fn render_pane(
     let origin = rect.min;
     let bg_default = srgba_to_egui(palette.background);
 
-    let terminal_rect = egui::Rect::from_min_size(
-        origin,
-        egui::vec2(
-            actual_cols as f32 * cell_width,
-            actual_rows as f32 * cell_height,
-        ),
-    );
-    let clipped_rect = terminal_rect.intersect(rect);
-    painter.rect_filled(clipped_rect, 0.0, bg_default);
+    // Fill the full allocated rect first to avoid artifacts when terminal is smaller
+    painter.rect_filled(rect, 0.0, bg_default);
 
     let total = screen.scrollback_rows();
     let end = total.saturating_sub(scroll_offset);

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -649,7 +649,7 @@ fn print_workspace_list(result: &serde_json::Value) {
             let active = ws.get("active").and_then(|v| v.as_bool()).unwrap_or(false);
             let marker = if active { " *" } else { "" };
             println!(
-                "workspace:{}{} \"{}\" ({} surface{})",
+                "workspace:{}{} \"{}\" ({} pane{})",
                 id,
                 marker,
                 title,

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -84,9 +84,9 @@ enum Command {
     /// Create a new surface (tab) in a workspace
     #[command(name = "surface-create")]
     SurfaceCreate {
-        /// Workspace ID (defaults to active)
+        /// Pane ID to add the surface to (defaults to focused pane)
         #[arg(long)]
-        workspace: Option<String>,
+        pane: Option<String>,
     },
     /// Close a surface (tab)
     #[command(name = "surface-close")]
@@ -194,6 +194,11 @@ async fn main() -> anyhow::Result<()> {
                 );
             } else if let (Some(ws_result), Some(sf_result)) = (&ws_resp.result, &sf_resp.result) {
                 print_hierarchy(ws_result, sf_result);
+            } else {
+                // Show first error found
+                let all = [&ws_resp, &sf_resp, &pane_resp];
+                let err_resp = all.iter().find(|r| !r.ok).unwrap_or(&all[0]);
+                print_response(err_resp, false);
             }
         }
         Command::Send { text, surface } => {
@@ -225,10 +230,14 @@ async fn main() -> anyhow::Result<()> {
                 .await?;
             if cli.json {
                 print_response(&resp, true);
-            } else if let Some(result) = &resp.result {
-                if let Some(text) = result.get("text").and_then(|t| t.as_str()) {
-                    println!("{}", text);
+            } else if resp.ok {
+                if let Some(result) = &resp.result {
+                    if let Some(text) = result.get("text").and_then(|t| t.as_str()) {
+                        println!("{}", text);
+                    }
                 }
+            } else {
+                print_response(&resp, false);
             }
         }
         Command::Capabilities => {
@@ -294,8 +303,12 @@ async fn main() -> anyhow::Result<()> {
             let resp = client.call("pane.list", serde_json::json!({})).await?;
             if cli.json {
                 print_response(&resp, true);
-            } else if let Some(result) = &resp.result {
-                print_pane_list(result);
+            } else if resp.ok {
+                if let Some(result) = &resp.result {
+                    print_pane_list(result);
+                }
+            } else {
+                print_response(&resp, false);
             }
         }
         // --- Workspace commands ---
@@ -368,10 +381,10 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         // --- Surface commands ---
-        Command::SurfaceCreate { workspace } => {
+        Command::SurfaceCreate { pane } => {
             let mut params = serde_json::json!({});
-            if let Some(ws) = workspace {
-                params["workspace_id"] = serde_json::json!(ws);
+            if let Some(p) = pane {
+                params["pane_id"] = serde_json::json!(p);
             }
             let resp = client.call("surface.create", params).await?;
             if cli.json {
@@ -632,10 +645,7 @@ fn print_workspace_list(result: &serde_json::Value) {
         for ws in workspaces {
             let id = ws.get("id").and_then(|v| v.as_str()).unwrap_or("?");
             let title = ws.get("title").and_then(|v| v.as_str()).unwrap_or("");
-            let count = ws
-                .get("surface_count")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0);
+            let count = ws.get("pane_count").and_then(|v| v.as_u64()).unwrap_or(0);
             let active = ws.get("active").and_then(|v| v.as_bool()).unwrap_or(false);
             let marker = if active { " *" } else { "" };
             println!(

--- a/crates/amux-ipc/src/server.rs
+++ b/crates/amux-ipc/src/server.rs
@@ -15,12 +15,14 @@ pub struct IpcCommand {
 /// Start the IPC server on a background thread.
 ///
 /// Returns the command receiver (for the main thread to drain) and the IPC address.
+/// The socket path is only written after the bind succeeds, avoiding a race where
+/// clients could discover an address that isn't ready yet.
 pub fn start_server() -> anyhow::Result<(std_mpsc::Receiver<IpcCommand>, IpcAddr)> {
     let addr = default_addr();
     cleanup_stale(&addr);
-    write_last_addr(&addr)?;
 
     let (cmd_tx, cmd_rx) = std_mpsc::channel::<IpcCommand>();
+    let (bind_tx, bind_rx) = std::sync::mpsc::channel::<Result<(), String>>();
     let addr_clone = addr.clone();
 
     std::thread::Builder::new()
@@ -30,10 +32,18 @@ pub fn start_server() -> anyhow::Result<(std_mpsc::Receiver<IpcCommand>, IpcAddr
                 .enable_all()
                 .build()
                 .expect("tokio runtime");
-            rt.block_on(run_server(addr_clone, cmd_tx));
+            rt.block_on(run_server(addr_clone, cmd_tx, bind_tx));
         })?;
 
-    Ok((cmd_rx, addr))
+    // Wait for the server thread to report bind success/failure
+    match bind_rx.recv() {
+        Ok(Ok(())) => {
+            write_last_addr(&addr)?;
+            Ok((cmd_rx, addr))
+        }
+        Ok(Err(e)) => anyhow::bail!("IPC server bind failed: {}", e),
+        Err(_) => anyhow::bail!("IPC server thread exited before binding"),
+    }
 }
 
 /// Remove a stale socket file (Unix only).
@@ -55,10 +65,24 @@ fn cleanup_stale(addr: &IpcAddr) {
 // ---------------------------------------------------------------------------
 
 #[cfg(unix)]
-async fn run_server(addr: IpcAddr, cmd_tx: std_mpsc::Sender<IpcCommand>) {
+async fn run_server(
+    addr: IpcAddr,
+    cmd_tx: std_mpsc::Sender<IpcCommand>,
+    bind_tx: std_mpsc::Sender<Result<(), String>>,
+) {
     let IpcAddr::Unix(ref path) = addr;
-    let listener = tokio::net::UnixListener::bind(path).expect("bind unix socket");
-    tracing::info!("IPC server listening on {}", path.display());
+    let listener = match tokio::net::UnixListener::bind(path) {
+        Ok(l) => {
+            tracing::info!("IPC server listening on {}", path.display());
+            let _ = bind_tx.send(Ok(()));
+            l
+        }
+        Err(e) => {
+            tracing::error!("failed to bind IPC socket at {}: {}", path.display(), e);
+            let _ = bind_tx.send(Err(e.to_string()));
+            return;
+        }
+    };
 
     loop {
         match listener.accept().await {
@@ -79,15 +103,26 @@ async fn run_server(addr: IpcAddr, cmd_tx: std_mpsc::Sender<IpcCommand>) {
 // ---------------------------------------------------------------------------
 
 #[cfg(windows)]
-async fn run_server(addr: IpcAddr, cmd_tx: std_mpsc::Sender<IpcCommand>) {
+async fn run_server(
+    addr: IpcAddr,
+    cmd_tx: std_mpsc::Sender<IpcCommand>,
+    bind_tx: std_mpsc::Sender<Result<(), String>>,
+) {
     use tokio::net::windows::named_pipe::ServerOptions;
 
     let IpcAddr::NamedPipe(ref name) = addr;
-    let mut server = ServerOptions::new()
-        .first_pipe_instance(true)
-        .create(name)
-        .expect("create named pipe");
-    tracing::info!("IPC server listening on {}", name);
+    let mut server = match ServerOptions::new().first_pipe_instance(true).create(name) {
+        Ok(s) => {
+            tracing::info!("IPC server listening on {}", name);
+            let _ = bind_tx.send(Ok(()));
+            s
+        }
+        Err(e) => {
+            tracing::error!("failed to create named pipe {}: {}", name, e);
+            let _ = bind_tx.send(Err(e.to_string()));
+            return;
+        }
+    };
 
     loop {
         // Wait for a client to connect to the current pipe instance.
@@ -98,9 +133,13 @@ async fn run_server(addr: IpcAddr, cmd_tx: std_mpsc::Sender<IpcCommand>) {
 
         let connected = server;
         // Create a new pipe instance for the next client BEFORE handling this one.
-        server = ServerOptions::new()
-            .create(name)
-            .expect("create next named pipe instance");
+        server = match ServerOptions::new().create(name) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!("failed to create next named pipe instance: {}", e);
+                return;
+            }
+        };
 
         let tx = cmd_tx.clone();
         let (reader, writer) = tokio::io::split(connected);

--- a/crates/amux-layout/src/lib.rs
+++ b/crates/amux-layout/src/lib.rs
@@ -270,12 +270,19 @@ impl PaneTree {
             let old_ratio = *ratio;
             let min_r = MIN_PANE_PX / new_span;
             let max_r = 1.0 - min_r;
+            // When span is too small for two panes, skip min/max enforcement
+            let do_clamp = min_r < max_r;
 
             match stable_side {
                 0 => {
                     // Keep first child at its original pixel size.
                     let old_first = old_span * old_ratio;
-                    *ratio = (old_first / new_span).clamp(min_r, max_r);
+                    let new_r = old_first / new_span;
+                    *ratio = if do_clamp {
+                        new_r.clamp(min_r, max_r)
+                    } else {
+                        new_r.clamp(0.0, 1.0)
+                    };
                     // Second child absorbed the change — recurse keeping *its* first stable.
                     let old_second = old_span * (1.0 - old_ratio);
                     let new_second = new_span * (1.0 - *ratio);
@@ -284,7 +291,12 @@ impl PaneTree {
                 1 => {
                     // Keep second child at its original pixel size.
                     let old_second = old_span * (1.0 - old_ratio);
-                    *ratio = (1.0 - old_second / new_span).clamp(min_r, max_r);
+                    let new_r = 1.0 - old_second / new_span;
+                    *ratio = if do_clamp {
+                        new_r.clamp(min_r, max_r)
+                    } else {
+                        new_r.clamp(0.0, 1.0)
+                    };
                     // First child absorbed the change — recurse keeping *its* second stable.
                     let old_first = old_span * old_ratio;
                     let new_first = new_span * *ratio;
@@ -321,7 +333,12 @@ impl PaneTree {
                     let new_ratio = (*ratio + delta / span).clamp(0.0, 1.0);
                     let min_ratio = MIN_PANE_PX / span;
                     let max_ratio = 1.0 - min_ratio;
-                    *ratio = new_ratio.clamp(min_ratio, max_ratio);
+                    // When span is too small for two panes, skip min/max enforcement
+                    *ratio = if min_ratio < max_ratio {
+                        new_ratio.clamp(min_ratio, max_ratio)
+                    } else {
+                        new_ratio
+                    };
 
                     // Stabilize children: only the two panes directly adjacent
                     // to this divider should change size. Non-adjacent panes

--- a/crates/amux-layout/src/lib.rs
+++ b/crates/amux-layout/src/lib.rs
@@ -540,4 +540,19 @@ mod tests {
             pane3_after.width()
         );
     }
+
+    #[test]
+    fn resize_divider_tiny_span_no_panic() {
+        // When the available span is smaller than 2*MIN_PANE_PX,
+        // the min/max clamp guard should prevent a panic.
+        let mut tree = PaneTree::new(1);
+        tree.split(1, SplitDirection::Horizontal, 2);
+        // Rect width (10px) < 2 * MIN_PANE_PX (40px)
+        let tiny_rect = Rect::from_min_size(egui::pos2(0.0, 0.0), egui::vec2(10.0, 600.0));
+        // Should not panic
+        tree.resize_divider(&[], 5.0, tiny_rect);
+        if let PaneTree::Split { ratio, .. } = &tree {
+            assert!(*ratio >= 0.0 && *ratio <= 1.0);
+        }
+    }
 }

--- a/crates/amux-term/src/mouse_encoder.rs
+++ b/crates/amux-term/src/mouse_encoder.rs
@@ -310,4 +310,25 @@ mod tests {
         // 7.9, 15.9 -> still cell (1,1)
         assert_eq!(enc.pixel_to_cell(7.9, 15.9), (1, 1));
     }
+
+    #[test]
+    fn new_sanitizes_zero_dimensions() {
+        let enc = MouseEncoder::new(0.0, 0.0);
+        assert_eq!(enc.cell_width, 1.0);
+        assert_eq!(enc.cell_height, 1.0);
+    }
+
+    #[test]
+    fn new_sanitizes_negative_dimensions() {
+        let enc = MouseEncoder::new(-5.0, -10.0);
+        assert_eq!(enc.cell_width, 1.0);
+        assert_eq!(enc.cell_height, 1.0);
+    }
+
+    #[test]
+    fn new_preserves_positive_dimensions() {
+        let enc = MouseEncoder::new(8.0, 16.0);
+        assert_eq!(enc.cell_width, 8.0);
+        assert_eq!(enc.cell_height, 16.0);
+    }
 }

--- a/crates/amux-term/src/mouse_encoder.rs
+++ b/crates/amux-term/src/mouse_encoder.rs
@@ -40,8 +40,9 @@ impl MouseEncoder {
         Self {
             tracking_mode: MouseTrackingMode::None,
             encoding_format: MouseEncodingFormat::Sgr,
-            cell_width,
-            cell_height,
+            // Guard against zero/negative dimensions to prevent division by zero
+            cell_width: if cell_width > 0.0 { cell_width } else { 1.0 },
+            cell_height: if cell_height > 0.0 { cell_height } else { 1.0 },
         }
     }
 

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -33,11 +33,11 @@ struct SharedWriter(Arc<Mutex<Box<dyn Write + Send>>>);
 
 impl Write for SharedWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.lock().unwrap().write(buf)
+        self.0.lock().unwrap_or_else(|e| e.into_inner()).write(buf)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        self.0.lock().unwrap().flush()
+        self.0.lock().unwrap_or_else(|e| e.into_inner()).flush()
     }
 }
 
@@ -129,6 +129,7 @@ impl TerminalPane {
                 AdvanceResult::Read(n)
             }
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => AdvanceResult::WouldBlock,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => AdvanceResult::WouldBlock,
             Err(_) => AdvanceResult::Eof,
         }
     }
@@ -156,7 +157,7 @@ impl TerminalPane {
 
     /// Write bytes to the PTY (i.e. simulate keyboard input).
     pub fn write_bytes(&mut self, data: &[u8]) -> anyhow::Result<()> {
-        let mut writer = self.writer.lock().unwrap();
+        let mut writer = self.writer.lock().unwrap_or_else(|e| e.into_inner());
         writer.write_all(data)?;
         Ok(())
     }
@@ -184,6 +185,11 @@ impl TerminalPane {
     /// Whether the alternate screen buffer is active.
     pub fn is_alt_screen_active(&self) -> bool {
         self.terminal.is_alt_screen_active()
+    }
+
+    /// Whether the terminal has enabled bracketed paste mode (DECSET 2004).
+    pub fn bracketed_paste_enabled(&self) -> bool {
+        self.terminal.bracketed_paste_enabled()
     }
 
     /// Get the window title (set by OSC 0/2).


### PR DESCRIPTION
## Summary

Addresses all major and medium severity issues from cumulative Copilot and CodeRabbit reviews across PRs #1–#8.

### Major fixes (8)
- **spawn_pane/do_split/pane.split**: `spawn_pane_with_surface` returns `Option`, IDs only increment on success. `do_split` and IPC `pane.split` validate results and clean up on failure.
- **Layout clamp panic**: Guard against `min_ratio > max_ratio` when span < 2×MIN_PANE_PX in both `resize_inner` and `stabilize_after_resize`
- **surface.focus wrong workspace**: Switches `active_workspace_idx` to owning workspace before calling `set_focus`
- **Non-macOS split-right unreachable**: Platform-specific `#[cfg]` guards so `Ctrl+Shift+D` works
- **IPC server bind panic**: Uses `match` instead of `expect()`, reports bind failure via channel
- **Write-before-bind race**: Socket path only written after successful bind

### Medium fixes (12)
- **workspace.list field mismatch**: CLI reads `pane_count` to match server
- **CLI error handling**: `ListPanes`, `Tree`, `ReadScreen` show errors in non-JSON mode
- **surface-create CLI**: Sends `pane_id` instead of unused `workspace_id`
- **copy_selection**: Only clears selection on successful clipboard write
- **Click outside content_rect**: Clears existing selection
- **render_pane artifacts**: Fills full allocated rect background
- **Bracketed paste**: Only wraps in CSI 200~/201~ when DECSET 2004 is enabled
- **Unbounded PTY channel**: Uses `sync_channel(64)` for backpressure
- **SharedWriter panic**: Recovers from poisoned mutex via `into_inner()`
- **advance() Interrupted**: Retries instead of treating as EOF
- **Mouse encoder div-by-zero**: Guards against zero cell dimensions in constructor

### Deferred minor items (12)

These are low-severity, theoretical, or cosmetic issues deferred for future work:

| Issue | File(s) | Severity | Reason deferred |
|---|---|---|---|
| Validate split ratios on session load | `amux-session/src/lib.rs` | Minor | Only triggered by hand-editing `session.json`; produces bad layout, not a crash |
| `get_cwd_from_pid` blocks UI thread (no timeout) | `amux-app/src/main.rs` | Minor | macOS only; `lsof` is fast in practice; proper fix needs async spawn with deadline |
| Underline Curly/Dotted/Dashed dropped in scrollback | `amux-term/src/pane.rs` | Minor | Cosmetic; affects scrollback restore fidelity for uncommon underline styles |
| Hardcoded `surface_id: 0` in `notify.send` | `amux-app/src/main.rs` | Minor | Limits jump-to-surface precision; navigation still works at pane level |
| `NotifyListEntry.created_at_ms` defined but not populated | `amux-ipc/src/methods.rs` | Minor | Unused struct field; no consumers rely on it yet |
| Redundant nested `i > 0` check in newline logic | `amux-app/src/main.rs` | Trivial | Cosmetic; no behavioral impact |
| Unix socket in `temp_dir` is world-accessible | `amux-ipc/src/socket_path.rs` | Minor/Security | Fallback path only (when `XDG_RUNTIME_DIR` unset); needs per-user subdir with 0700 |
| `last-socket-path` file has default permissions | `amux-ipc/src/socket_path.rs` | Minor/Security | Leaks socket address; needs 0600 permissions on Unix |
| IPC protocol doesn't follow JSON-RPC 2.0 | `amux-ipc/src/protocol.rs` | Minor/Docs | Design decision; custom protocol works; rename docs or add `jsonrpc` field |
| `blend_pixel` doc says premultiplied but uses straight alpha | `amux-render-soft/src/lib.rs` | Minor/Docs | Misleading comment; no behavioral impact |
| `get_or_rasterize` clones entire bitmap on cache hit | `amux-render-soft/src/lib.rs` | Minor/Perf | Should use `Arc<CachedGlyph>` for cheap clones; soft renderer being replaced by GPU renderer |
| Missing tests for `take_reader`/`advance` threading model | `amux-term/src/pane.rs` | Minor/Tests | `advance()` no longer used in production; threading covered by integration tests |

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bracketed paste escape sequences
  * Updated pane split shortcuts: `Cmd+D` on macOS, `Ctrl+Shift+D` on other platforms for horizontal split

* **Bug Fixes**
  * Fixed background rendering artifacts in pane display
  * Prevented crashes from invalid cell dimensions and poisoned mutexes
  * Improved error resilience for split and pane spawn operations
  * Enhanced selection and clipboard behavior
  * Better error reporting for failed operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->