### PR TITLE
Phase 8: GPU-accelerated terminal renderer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,11 @@ egui = "0.31"
 # Font rendering
 cosmic-text = "0.12"
 
+# GPU rendering
+wgpu = "24.0"
+egui-wgpu = "0.31"
+bytemuck = { version = "1", features = ["derive"] }
+
 # Clipboard
 arboard = "3"
 

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -5,8 +5,13 @@ edition.workspace = true
 license.workspace = true
 description = "amux main binary: GUI + event loop"
 
+[features]
+default = ["gpu-renderer"]
+gpu-renderer = ["dep:amux-render-gpu"]
+
 [dependencies]
 amux-term = { workspace = true }
+amux-render-gpu = { workspace = true, optional = true }
 wezterm-term = { workspace = true }
 wezterm-surface = { workspace = true }
 eframe = { workspace = true }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -3218,6 +3218,10 @@ fn render_pane(
         let palette = pane.palette();
         let cursor = pane.cursor();
         let screen = pane.screen();
+        let gpu_selection = selection.map(|sel| {
+            let (start, end) = sel.normalized();
+            amux_render_gpu::snapshot::SelectionRange { start, end }
+        });
         let snapshot = amux_render_gpu::TerminalSnapshot::from_screen(
             screen,
             &palette,
@@ -3225,6 +3229,8 @@ fn render_pane(
             actual_cols,
             actual_rows,
             scroll_offset,
+            is_focused,
+            gpu_selection,
         );
         let pixels_per_point = ui.ctx().pixels_per_point();
         let callback = gpu.paint_callback(rect, snapshot, pixels_per_point);

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -926,6 +926,13 @@ impl eframe::App for AmuxApp {
             }
         }
 
+        // Clean up GPU resources for closed panes.
+        #[cfg(feature = "gpu-renderer")]
+        if let Some(ref gpu) = self.gpu_renderer {
+            let live_ids: Vec<u64> = self.panes.keys().copied().collect();
+            gpu.retain_panes(&live_ids);
+        }
+
         // Smart repaint
         if got_data {
             ctx.request_repaint();

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1137,6 +1137,8 @@ impl AmuxApp {
             selection.as_ref(),
             #[cfg(feature = "gpu-renderer")]
             self.gpu_renderer.as_ref(),
+            #[cfg(feature = "gpu-renderer")]
+            pane_id,
         );
 
         // Notification ring + flash animation (matching cmux)
@@ -3199,6 +3201,7 @@ fn line_text_string(pane: &TerminalPane, stable_row: usize, cols: usize) -> Stri
 
 // --- Rendering ---
 
+#[allow(clippy::too_many_arguments)]
 fn render_pane(
     ui: &mut egui::Ui,
     pane: &mut TerminalPane,
@@ -3207,6 +3210,7 @@ fn render_pane(
     scroll_offset: usize,
     selection: Option<&SelectionState>,
     #[cfg(feature = "gpu-renderer")] gpu_renderer: Option<&GpuRenderer>,
+    #[cfg(feature = "gpu-renderer")] pane_id: u64,
 ) {
     // GPU renderer path: build snapshot, emit a paint callback, and return early.
     #[cfg(feature = "gpu-renderer")]
@@ -3222,6 +3226,7 @@ fn render_pane(
             let (start, end) = sel.normalized();
             amux_render_gpu::snapshot::SelectionRange { start, end }
         });
+        let seqno = pane.current_seqno();
         let snapshot = amux_render_gpu::TerminalSnapshot::from_screen(
             screen,
             &palette,
@@ -3231,6 +3236,8 @@ fn render_pane(
             scroll_offset,
             is_focused,
             gpu_selection,
+            pane_id,
+            seqno,
         );
         let pixels_per_point = ui.ctx().pixels_per_point();
         let callback = gpu.paint_callback(rect, snapshot, pixels_per_point);

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -3195,10 +3195,30 @@ fn render_pane(
     selection: Option<&SelectionState>,
     #[cfg(feature = "gpu-renderer")] gpu_renderer: Option<&GpuRenderer>,
 ) {
-    // GPU renderer path: emit a paint callback and return early.
+    // GPU renderer path: build snapshot, emit a paint callback, and return early.
     #[cfg(feature = "gpu-renderer")]
     if let Some(gpu) = gpu_renderer {
-        let callback = gpu.paint_callback(rect);
+        let (actual_cols, actual_rows) = pane.dimensions();
+        if actual_cols == 0 || actual_rows == 0 {
+            return;
+        }
+        let font_id = egui::FontId::monospace(FONT_SIZE);
+        let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
+        let cell_height = ui.fonts(|f| f.row_height(&font_id));
+        let palette = pane.palette();
+        let cursor = pane.cursor();
+        let screen = pane.screen();
+        let snapshot = amux_render_gpu::TerminalSnapshot::from_screen(
+            screen,
+            &palette,
+            &cursor,
+            actual_cols,
+            actual_rows,
+            scroll_offset,
+        );
+        let pixels_per_point = ui.ctx().pixels_per_point();
+        let callback =
+            gpu.paint_callback(rect, snapshot, cell_width, cell_height, pixels_per_point);
         ui.painter().add(egui::Shape::Callback(callback));
         return;
     }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -18,6 +18,9 @@ use portable_pty::CommandBuilder;
 use wezterm_surface::{CursorShape, CursorVisibility};
 use wezterm_term::color::SrgbaTuple;
 
+#[cfg(feature = "gpu-renderer")]
+use amux_render_gpu::GpuRenderer;
+
 /// Try to get the current working directory of a process by PID.
 /// Falls back across platform-specific mechanisms.
 fn get_cwd_from_pid(pid: u32) -> Option<String> {
@@ -98,6 +101,12 @@ fn main() -> anyhow::Result<()> {
         "amux",
         options,
         Box::new(move |_cc| {
+            #[cfg(feature = "gpu-renderer")]
+            let gpu_renderer = _cc.wgpu_render_state.as_ref().map(|rs| {
+                tracing::info!("GPU renderer initialized (wgpu backend)");
+                GpuRenderer::new(rs.clone())
+            });
+
             Ok(Box::new(AmuxApp {
                 workspaces: state.workspaces,
                 active_workspace_idx: state.active_workspace_idx,
@@ -116,6 +125,8 @@ fn main() -> anyhow::Result<()> {
                 last_click_pos: egui::Pos2::ZERO,
                 click_count: 0,
                 wants_exit: false,
+                #[cfg(feature = "gpu-renderer")]
+                gpu_renderer,
             }))
         }),
     )
@@ -559,6 +570,8 @@ struct AmuxApp {
     last_click_pos: egui::Pos2,
     click_count: u32,
     wants_exit: bool,
+    #[cfg(feature = "gpu-renderer")]
+    gpu_renderer: Option<GpuRenderer>,
 }
 
 impl AmuxApp {
@@ -1105,6 +1118,8 @@ impl AmuxApp {
             is_focused,
             surface.scroll_offset,
             selection.as_ref(),
+            #[cfg(feature = "gpu-renderer")]
+            self.gpu_renderer.as_ref(),
         );
 
         // Notification ring + flash animation (matching cmux)
@@ -3178,7 +3193,16 @@ fn render_pane(
     is_focused: bool,
     scroll_offset: usize,
     selection: Option<&SelectionState>,
+    #[cfg(feature = "gpu-renderer")] gpu_renderer: Option<&GpuRenderer>,
 ) {
+    // GPU renderer path: emit a paint callback and return early.
+    #[cfg(feature = "gpu-renderer")]
+    if let Some(gpu) = gpu_renderer {
+        let callback = gpu.paint_callback(rect);
+        ui.painter().add(egui::Shape::Callback(callback));
+        return;
+    }
+
     let font_id = egui::FontId::monospace(FONT_SIZE);
     let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
     let cell_height = ui.fonts(|f| f.row_height(&font_id));

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -104,7 +104,7 @@ fn main() -> anyhow::Result<()> {
             #[cfg(feature = "gpu-renderer")]
             let gpu_renderer = _cc.wgpu_render_state.as_ref().map(|rs| {
                 tracing::info!("GPU renderer initialized (wgpu backend)");
-                GpuRenderer::new(rs.clone())
+                GpuRenderer::new(rs.clone(), FONT_SIZE)
             });
 
             Ok(Box::new(AmuxApp {
@@ -575,6 +575,23 @@ struct AmuxApp {
 }
 
 impl AmuxApp {
+    /// Get cell dimensions in logical points, using GPU renderer measurements
+    /// when available, falling back to egui font measurements.
+    fn cell_dimensions(&self, ui: &egui::Ui) -> (f32, f32) {
+        #[cfg(feature = "gpu-renderer")]
+        if let Some(gpu) = &self.gpu_renderer {
+            let cw = gpu.cell_width();
+            let ch = gpu.cell_height();
+            if cw > 0.0 && ch > 0.0 {
+                return (cw, ch);
+            }
+        }
+        let font_id = egui::FontId::monospace(FONT_SIZE);
+        let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
+        let cell_height = ui.fonts(|f| f.row_height(&font_id));
+        (cell_width, cell_height)
+    }
+
     fn active_workspace(&self) -> &Workspace {
         &self.workspaces[self.active_workspace_idx]
     }
@@ -1330,9 +1347,7 @@ impl AmuxApp {
     // --- Resize ---
 
     fn resize_pane_if_needed(&mut self, id: PaneId, rect: egui::Rect, ui: &egui::Ui) {
-        let font_id = egui::FontId::monospace(FONT_SIZE);
-        let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
-        let cell_height = ui.fonts(|f| f.row_height(&font_id));
+        let (cell_width, cell_height) = self.cell_dimensions(ui);
 
         // Account for tab bar height (always shown)
         let content_height = rect.height() - TAB_BAR_HEIGHT;
@@ -2236,9 +2251,7 @@ impl AmuxApp {
     // --- Selection Mouse ---
 
     fn handle_selection_mouse(&mut self, ui: &egui::Ui, pane_id: PaneId, content_rect: egui::Rect) {
-        let font_id = egui::FontId::monospace(FONT_SIZE);
-        let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
-        let cell_height = ui.fonts(|f| f.row_height(&font_id));
+        let (cell_width, cell_height) = self.cell_dimensions(ui);
 
         let managed = match self.panes.get(&pane_id) {
             Some(m) => m,
@@ -3202,9 +3215,6 @@ fn render_pane(
         if actual_cols == 0 || actual_rows == 0 {
             return;
         }
-        let font_id = egui::FontId::monospace(FONT_SIZE);
-        let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
-        let cell_height = ui.fonts(|f| f.row_height(&font_id));
         let palette = pane.palette();
         let cursor = pane.cursor();
         let screen = pane.screen();
@@ -3217,8 +3227,7 @@ fn render_pane(
             scroll_offset,
         );
         let pixels_per_point = ui.ctx().pixels_per_point();
-        let callback =
-            gpu.paint_callback(rect, snapshot, cell_width, cell_height, pixels_per_point);
+        let callback = gpu.paint_callback(rect, snapshot, pixels_per_point);
         ui.painter().add(egui::Shape::Callback(callback));
         return;
     }

--- a/crates/amux-render-gpu/Cargo.toml
+++ b/crates/amux-render-gpu/Cargo.toml
@@ -10,5 +10,6 @@ wgpu = { workspace = true }
 egui-wgpu = { workspace = true }
 egui = { workspace = true }
 wezterm-term = { workspace = true }
+cosmic-text = { workspace = true }
 bytemuck = { workspace = true }
 tracing = { workspace = true }

--- a/crates/amux-render-gpu/Cargo.toml
+++ b/crates/amux-render-gpu/Cargo.toml
@@ -13,3 +13,4 @@ wezterm-term = { workspace = true }
 cosmic-text = { workspace = true }
 bytemuck = { workspace = true }
 tracing = { workspace = true }
+wezterm-surface = { workspace = true }

--- a/crates/amux-render-gpu/Cargo.toml
+++ b/crates/amux-render-gpu/Cargo.toml
@@ -6,3 +6,9 @@ license.workspace = true
 description = "amux wgpu + cosmic-text GPU renderer"
 
 [dependencies]
+wgpu = { workspace = true }
+egui-wgpu = { workspace = true }
+egui = { workspace = true }
+wezterm-term = { workspace = true }
+bytemuck = { workspace = true }
+tracing = { workspace = true }

--- a/crates/amux-render-gpu/src/atlas.rs
+++ b/crates/amux-render-gpu/src/atlas.rs
@@ -247,7 +247,7 @@ impl GlyphAtlas {
             } else {
                 // Monochrome glyph: store alpha data in the mono atlas.
                 let alpha_data = match img.content {
-                    SwashContent::Mask => img.data.clone(),
+                    SwashContent::Mask => img.data,
                     SwashContent::SubpixelMask => img
                         .data
                         .chunks(3)

--- a/crates/amux-render-gpu/src/atlas.rs
+++ b/crates/amux-render-gpu/src/atlas.rs
@@ -94,25 +94,54 @@ impl AtlasPage {
     }
 
     fn upload_region(&self, queue: &wgpu::Queue, x: u32, y: u32, w: u32, h: u32, data: &[u8]) {
-        queue.write_texture(
-            wgpu::TexelCopyTextureInfo {
-                texture: &self.texture,
-                mip_level: 0,
-                origin: wgpu::Origin3d { x, y, z: 0 },
-                aspect: wgpu::TextureAspect::All,
-            },
-            data,
-            wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(w * self.bytes_per_pixel),
-                rows_per_image: Some(h),
-            },
-            wgpu::Extent3d {
-                width: w,
-                height: h,
-                depth_or_array_layers: 1,
-            },
-        );
+        let unpadded_bytes_per_row = w * self.bytes_per_pixel;
+        let alignment = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(alignment) * alignment;
+
+        let copy_info = wgpu::TexelCopyTextureInfo {
+            texture: &self.texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d { x, y, z: 0 },
+            aspect: wgpu::TextureAspect::All,
+        };
+        let extent = wgpu::Extent3d {
+            width: w,
+            height: h,
+            depth_or_array_layers: 1,
+        };
+
+        if padded_bytes_per_row == unpadded_bytes_per_row || h <= 1 {
+            // Data is already aligned or single row — upload directly.
+            queue.write_texture(
+                copy_info,
+                data,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bytes_per_row),
+                    rows_per_image: Some(h),
+                },
+                extent,
+            );
+        } else {
+            // Pad each row to satisfy wgpu alignment requirements.
+            let mut padded = vec![0u8; (padded_bytes_per_row * h) as usize];
+            let row_size = unpadded_bytes_per_row as usize;
+            let padded_row_size = padded_bytes_per_row as usize;
+            for row in 0..h as usize {
+                padded[row * padded_row_size..row * padded_row_size + row_size]
+                    .copy_from_slice(&data[row * row_size..row * row_size + row_size]);
+            }
+            queue.write_texture(
+                copy_info,
+                &padded,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bytes_per_row),
+                    rows_per_image: Some(h),
+                },
+                extent,
+            );
+        }
     }
 }
 
@@ -170,18 +199,19 @@ impl GlyphAtlas {
         &self.color.texture_view
     }
 
-    /// Look up or rasterize a glyph, returning its atlas entry.
+    /// Look up or rasterize a glyph, returning `(entry, newly_inserted)`.
     ///
     /// Returns `None` for glyphs that can't be rasterized (e.g., spaces, missing glyphs).
+    /// `newly_inserted` is true only when a new glyph was uploaded to the atlas texture.
     pub fn get_or_insert(
         &mut self,
         queue: &wgpu::Queue,
         font_system: &mut FontSystem,
         swash_cache: &mut SwashCache,
         cache_key: CacheKey,
-    ) -> Option<AtlasEntry> {
+    ) -> (Option<AtlasEntry>, bool) {
         if let Some(entry) = self.cache.get(&cache_key) {
-            return *entry;
+            return (*entry, false);
         }
 
         let image: Option<SwashImage> = swash_cache.get_image_uncached(font_system, cache_key);
@@ -245,7 +275,8 @@ impl GlyphAtlas {
             }
         });
 
+        let newly_inserted = entry.is_some();
         self.cache.insert(cache_key, entry);
-        entry
+        (entry, newly_inserted)
     }
 }

--- a/crates/amux-render-gpu/src/atlas.rs
+++ b/crates/amux-render-gpu/src/atlas.rs
@@ -14,6 +14,8 @@ pub struct AtlasEntry {
     /// Glyph pixel dimensions.
     pub width: u32,
     pub height: u32,
+    /// Whether this glyph is a color glyph (emoji) vs monochrome.
+    pub is_color: bool,
 }
 
 /// Shelf in the shelf-packing algorithm.
@@ -23,24 +25,25 @@ struct Shelf {
     x_cursor: u32,
 }
 
-/// GPU glyph atlas using shelf-packing.
-///
-/// Rasterizes glyphs via cosmic-text/swash and uploads them to a GPU texture.
-/// Currently uses a single R8Unorm texture for monochrome glyphs.
-pub struct GlyphAtlas {
+/// A single atlas page (texture + shelf packer).
+struct AtlasPage {
     texture: wgpu::Texture,
-    pub texture_view: wgpu::TextureView,
-    pub sampler: wgpu::Sampler,
+    texture_view: wgpu::TextureView,
     size: u32,
     shelves: Vec<Shelf>,
-    cache: HashMap<CacheKey, Option<AtlasEntry>>,
+    bytes_per_pixel: u32,
 }
 
-impl GlyphAtlas {
-    /// Create a new glyph atlas with the given texture size.
-    pub fn new(device: &wgpu::Device, size: u32) -> Self {
+impl AtlasPage {
+    fn new(
+        device: &wgpu::Device,
+        size: u32,
+        format: wgpu::TextureFormat,
+        label: &str,
+        bytes_per_pixel: u32,
+    ) -> Self {
         let texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("glyph_atlas"),
+            label: Some(label),
             size: wgpu::Extent3d {
                 width: size,
                 height: size,
@@ -49,12 +52,98 @@ impl GlyphAtlas {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::R8Unorm,
+            format,
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
             view_formats: &[],
         });
-
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        Self {
+            texture,
+            texture_view,
+            size,
+            shelves: Vec::new(),
+            bytes_per_pixel,
+        }
+    }
+
+    fn allocate(&mut self, w: u32, h: u32) -> Option<(u32, u32)> {
+        // Try to fit in an existing shelf.
+        for shelf in &mut self.shelves {
+            if h <= shelf.height && shelf.x_cursor + w <= self.size {
+                let x = shelf.x_cursor;
+                let y = shelf.y;
+                shelf.x_cursor += w + 1;
+                return Some((x, y));
+            }
+        }
+
+        // Create a new shelf.
+        let shelf_y = self.shelves.last().map(|s| s.y + s.height + 1).unwrap_or(0);
+
+        if shelf_y + h > self.size || w > self.size {
+            tracing::warn!("Atlas page full, cannot allocate {}x{}", w, h);
+            return None;
+        }
+
+        self.shelves.push(Shelf {
+            y: shelf_y,
+            height: h,
+            x_cursor: w + 1,
+        });
+        Some((0, shelf_y))
+    }
+
+    fn upload_region(&self, queue: &wgpu::Queue, x: u32, y: u32, w: u32, h: u32, data: &[u8]) {
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d { x, y, z: 0 },
+                aspect: wgpu::TextureAspect::All,
+            },
+            data,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(w * self.bytes_per_pixel),
+                rows_per_image: Some(h),
+            },
+            wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
+}
+
+/// GPU glyph atlas using shelf-packing with dual textures.
+///
+/// Monochrome glyphs use an R8Unorm texture (alpha-only).
+/// Color glyphs (emoji) use an Rgba8UnormSrgb texture.
+pub struct GlyphAtlas {
+    mono: AtlasPage,
+    color: AtlasPage,
+    pub sampler: wgpu::Sampler,
+    cache: HashMap<CacheKey, Option<AtlasEntry>>,
+}
+
+impl GlyphAtlas {
+    /// Create a new glyph atlas with the given texture size.
+    pub fn new(device: &wgpu::Device, size: u32) -> Self {
+        let mono = AtlasPage::new(
+            device,
+            size,
+            wgpu::TextureFormat::R8Unorm,
+            "glyph_atlas_mono",
+            1,
+        );
+        let color = AtlasPage::new(
+            device,
+            size,
+            wgpu::TextureFormat::Rgba8UnormSrgb,
+            "glyph_atlas_color",
+            4,
+        );
 
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("glyph_atlas_sampler"),
@@ -64,13 +153,21 @@ impl GlyphAtlas {
         });
 
         Self {
-            texture,
-            texture_view,
+            mono,
+            color,
             sampler,
-            size,
-            shelves: Vec::new(),
             cache: HashMap::new(),
         }
+    }
+
+    /// Get the monochrome atlas texture view.
+    pub fn mono_texture_view(&self) -> &wgpu::TextureView {
+        &self.mono.texture_view
+    }
+
+    /// Get the color atlas texture view.
+    pub fn color_texture_view(&self) -> &wgpu::TextureView {
+        &self.color.texture_view
     }
 
     /// Look up or rasterize a glyph, returning its atlas entry.
@@ -94,100 +191,61 @@ impl GlyphAtlas {
                 return None;
             }
 
-            // Only handle monochrome glyphs for now (color emoji in PR 8f).
-            let alpha_data = match img.content {
-                SwashContent::Mask => img.data.clone(),
-                SwashContent::Color => {
-                    // Extract alpha channel from RGBA data.
-                    img.data.iter().skip(3).step_by(4).copied().collect()
-                }
-                SwashContent::SubpixelMask => {
-                    // Use luminance of subpixel data as alpha.
-                    img.data
-                        .chunks(3)
-                        .map(|rgb| ((rgb[0] as u16 + rgb[1] as u16 + rgb[2] as u16) / 3) as u8)
-                        .collect()
-                }
-            };
-
             let w = img.placement.width;
             let h = img.placement.height;
 
-            let (x, y) = self.allocate(w, h)?;
-            self.upload_region(queue, x, y, w, h, &alpha_data);
+            let is_color = matches!(img.content, SwashContent::Color);
 
-            let s = self.size as f32;
-            Some(AtlasEntry {
-                uv: [
-                    x as f32 / s,
-                    y as f32 / s,
-                    (x + w) as f32 / s,
-                    (y + h) as f32 / s,
-                ],
-                placement_left: img.placement.left,
-                placement_top: img.placement.top,
-                width: w,
-                height: h,
-            })
+            if is_color {
+                // Color glyph: store RGBA data in the color atlas.
+                let (x, y) = self.color.allocate(w, h)?;
+                self.color.upload_region(queue, x, y, w, h, &img.data);
+                let s = self.color.size as f32;
+                Some(AtlasEntry {
+                    uv: [
+                        x as f32 / s,
+                        y as f32 / s,
+                        (x + w) as f32 / s,
+                        (y + h) as f32 / s,
+                    ],
+                    placement_left: img.placement.left,
+                    placement_top: img.placement.top,
+                    width: w,
+                    height: h,
+                    is_color: true,
+                })
+            } else {
+                // Monochrome glyph: store alpha data in the mono atlas.
+                let alpha_data = match img.content {
+                    SwashContent::Mask => img.data.clone(),
+                    SwashContent::SubpixelMask => img
+                        .data
+                        .chunks(3)
+                        .map(|rgb| ((rgb[0] as u16 + rgb[1] as u16 + rgb[2] as u16) / 3) as u8)
+                        .collect(),
+                    SwashContent::Color => unreachable!(),
+                };
+
+                let (x, y) = self.mono.allocate(w, h)?;
+                self.mono.upload_region(queue, x, y, w, h, &alpha_data);
+                let s = self.mono.size as f32;
+                Some(AtlasEntry {
+                    uv: [
+                        x as f32 / s,
+                        y as f32 / s,
+                        (x + w) as f32 / s,
+                        (y + h) as f32 / s,
+                    ],
+                    placement_left: img.placement.left,
+                    placement_top: img.placement.top,
+                    width: w,
+                    height: h,
+                    is_color: false,
+                })
+            }
         });
 
         self.cache.insert(cache_key, entry);
         entry
-    }
-
-    /// Allocate space for a glyph in the atlas using shelf-packing.
-    fn allocate(&mut self, w: u32, h: u32) -> Option<(u32, u32)> {
-        // Try to fit in an existing shelf.
-        for shelf in &mut self.shelves {
-            if h <= shelf.height && shelf.x_cursor + w <= self.size {
-                let x = shelf.x_cursor;
-                let y = shelf.y;
-                shelf.x_cursor += w + 1; // 1px padding
-                return Some((x, y));
-            }
-        }
-
-        // Create a new shelf.
-        let shelf_y = self
-            .shelves
-            .last()
-            .map(|s| s.y + s.height + 1) // 1px padding between shelves
-            .unwrap_or(0);
-
-        if shelf_y + h > self.size || w > self.size {
-            tracing::warn!("Glyph atlas full, cannot allocate {}x{}", w, h);
-            return None;
-        }
-
-        let x = 0;
-        self.shelves.push(Shelf {
-            y: shelf_y,
-            height: h,
-            x_cursor: w + 1,
-        });
-        Some((x, shelf_y))
-    }
-
-    /// Upload glyph alpha data to a region of the atlas texture.
-    fn upload_region(&self, queue: &wgpu::Queue, x: u32, y: u32, w: u32, h: u32, data: &[u8]) {
-        queue.write_texture(
-            wgpu::TexelCopyTextureInfo {
-                texture: &self.texture,
-                mip_level: 0,
-                origin: wgpu::Origin3d { x, y, z: 0 },
-                aspect: wgpu::TextureAspect::All,
-            },
-            data,
-            wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(w),
-                rows_per_image: Some(h),
-            },
-            wgpu::Extent3d {
-                width: w,
-                height: h,
-                depth_or_array_layers: 1,
-            },
-        );
     }
 }

--- a/crates/amux-render-gpu/src/atlas.rs
+++ b/crates/amux-render-gpu/src/atlas.rs
@@ -1,0 +1,193 @@
+use std::collections::HashMap;
+
+use cosmic_text::{CacheKey, FontSystem, SwashCache, SwashContent, SwashImage};
+use egui_wgpu::wgpu;
+
+/// A single glyph's location in the atlas texture.
+#[derive(Clone, Copy)]
+pub struct AtlasEntry {
+    /// UV coordinates in the atlas: [u_min, v_min, u_max, v_max] in 0..1 range.
+    pub uv: [f32; 4],
+    /// Glyph placement offset from cell origin (in pixels).
+    pub placement_left: i32,
+    pub placement_top: i32,
+    /// Glyph pixel dimensions.
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Shelf in the shelf-packing algorithm.
+struct Shelf {
+    y: u32,
+    height: u32,
+    x_cursor: u32,
+}
+
+/// GPU glyph atlas using shelf-packing.
+///
+/// Rasterizes glyphs via cosmic-text/swash and uploads them to a GPU texture.
+/// Currently uses a single R8Unorm texture for monochrome glyphs.
+pub struct GlyphAtlas {
+    texture: wgpu::Texture,
+    pub texture_view: wgpu::TextureView,
+    pub sampler: wgpu::Sampler,
+    size: u32,
+    shelves: Vec<Shelf>,
+    cache: HashMap<CacheKey, Option<AtlasEntry>>,
+}
+
+impl GlyphAtlas {
+    /// Create a new glyph atlas with the given texture size.
+    pub fn new(device: &wgpu::Device, size: u32) -> Self {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("glyph_atlas"),
+            size: wgpu::Extent3d {
+                width: size,
+                height: size,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::R8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+
+        let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("glyph_atlas_sampler"),
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            ..Default::default()
+        });
+
+        Self {
+            texture,
+            texture_view,
+            sampler,
+            size,
+            shelves: Vec::new(),
+            cache: HashMap::new(),
+        }
+    }
+
+    /// Look up or rasterize a glyph, returning its atlas entry.
+    ///
+    /// Returns `None` for glyphs that can't be rasterized (e.g., spaces, missing glyphs).
+    pub fn get_or_insert(
+        &mut self,
+        queue: &wgpu::Queue,
+        font_system: &mut FontSystem,
+        swash_cache: &mut SwashCache,
+        cache_key: CacheKey,
+    ) -> Option<AtlasEntry> {
+        if let Some(entry) = self.cache.get(&cache_key) {
+            return *entry;
+        }
+
+        let image: Option<SwashImage> = swash_cache.get_image_uncached(font_system, cache_key);
+
+        let entry = image.and_then(|img| {
+            if img.placement.width == 0 || img.placement.height == 0 {
+                return None;
+            }
+
+            // Only handle monochrome glyphs for now (color emoji in PR 8f).
+            let alpha_data = match img.content {
+                SwashContent::Mask => img.data.clone(),
+                SwashContent::Color => {
+                    // Extract alpha channel from RGBA data.
+                    img.data.iter().skip(3).step_by(4).copied().collect()
+                }
+                SwashContent::SubpixelMask => {
+                    // Use luminance of subpixel data as alpha.
+                    img.data
+                        .chunks(3)
+                        .map(|rgb| ((rgb[0] as u16 + rgb[1] as u16 + rgb[2] as u16) / 3) as u8)
+                        .collect()
+                }
+            };
+
+            let w = img.placement.width;
+            let h = img.placement.height;
+
+            let (x, y) = self.allocate(w, h)?;
+            self.upload_region(queue, x, y, w, h, &alpha_data);
+
+            let s = self.size as f32;
+            Some(AtlasEntry {
+                uv: [
+                    x as f32 / s,
+                    y as f32 / s,
+                    (x + w) as f32 / s,
+                    (y + h) as f32 / s,
+                ],
+                placement_left: img.placement.left,
+                placement_top: img.placement.top,
+                width: w,
+                height: h,
+            })
+        });
+
+        self.cache.insert(cache_key, entry);
+        entry
+    }
+
+    /// Allocate space for a glyph in the atlas using shelf-packing.
+    fn allocate(&mut self, w: u32, h: u32) -> Option<(u32, u32)> {
+        // Try to fit in an existing shelf.
+        for shelf in &mut self.shelves {
+            if h <= shelf.height && shelf.x_cursor + w <= self.size {
+                let x = shelf.x_cursor;
+                let y = shelf.y;
+                shelf.x_cursor += w + 1; // 1px padding
+                return Some((x, y));
+            }
+        }
+
+        // Create a new shelf.
+        let shelf_y = self
+            .shelves
+            .last()
+            .map(|s| s.y + s.height + 1) // 1px padding between shelves
+            .unwrap_or(0);
+
+        if shelf_y + h > self.size || w > self.size {
+            tracing::warn!("Glyph atlas full, cannot allocate {}x{}", w, h);
+            return None;
+        }
+
+        let x = 0;
+        self.shelves.push(Shelf {
+            y: shelf_y,
+            height: h,
+            x_cursor: w + 1,
+        });
+        Some((x, shelf_y))
+    }
+
+    /// Upload glyph alpha data to a region of the atlas texture.
+    fn upload_region(&self, queue: &wgpu::Queue, x: u32, y: u32, w: u32, h: u32, data: &[u8]) {
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d { x, y, z: 0 },
+                aspect: wgpu::TextureAspect::All,
+            },
+            data,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(w),
+                rows_per_image: Some(h),
+            },
+            wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
+}

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -1,7 +1,9 @@
+use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, SwashCache};
 use egui_wgpu::wgpu;
 use egui_wgpu::{CallbackResources, CallbackTrait, ScreenDescriptor};
 
-use crate::pipeline::{BackgroundPipeline, CellBgInstance};
+use crate::atlas::GlyphAtlas;
+use crate::pipeline::{BackgroundPipeline, CellBgInstance, CellFgInstance, ForegroundPipeline};
 use crate::snapshot::TerminalSnapshot;
 
 /// Resources stored in egui's `CallbackResources` for the terminal renderer.
@@ -9,7 +11,14 @@ use crate::snapshot::TerminalSnapshot;
 /// Created once during `GpuRenderer::new()` and retrieved during prepare/paint.
 pub struct TerminalGpuResources {
     pub bg_pipeline: BackgroundPipeline,
+    pub fg_pipeline: ForegroundPipeline,
+    pub atlas: GlyphAtlas,
+    pub font_system: FontSystem,
+    pub swash_cache: SwashCache,
+    pub metrics: Metrics,
     pub bg_instance_count: u32,
+    pub fg_instance_count: u32,
+    pub atlas_bind_group_dirty: bool,
 }
 
 /// Paint callback for a single terminal pane.
@@ -47,18 +56,22 @@ impl CallbackTrait for TerminalPaintCallback {
 
         let snap = &self.snapshot;
 
-        // Build background instances: one quad per cell with non-default background.
-        let mut bg_instances = Vec::with_capacity(snap.cells.len());
+        // Build background instances
+        let mut bg_instances = Vec::with_capacity(snap.cells.len() + 1);
+
+        // Full-rect background quad
+        bg_instances.push(CellBgInstance {
+            pos: [self.phys_rect.x, self.phys_rect.y],
+            size: [self.phys_rect.width, self.phys_rect.height],
+            color: snap.default_bg,
+        });
 
         for cell in &snap.cells {
-            // Skip cells with default background (they're already cleared by egui).
             if cell.bg == snap.default_bg {
                 continue;
             }
-
             let px = self.phys_rect.x + cell.col as f32 * self.cell_width;
             let py = self.phys_rect.y + cell.row as f32 * self.cell_height;
-
             bg_instances.push(CellBgInstance {
                 pos: [px, py],
                 size: [self.cell_width, self.cell_height],
@@ -66,17 +79,80 @@ impl CallbackTrait for TerminalPaintCallback {
             });
         }
 
-        // Also draw the default background as a full-rect quad so the pane
-        // has a solid background even when egui's background differs.
-        // Insert it first so it's drawn behind cell-specific backgrounds.
-        bg_instances.insert(
-            0,
-            CellBgInstance {
-                pos: [self.phys_rect.x, self.phys_rect.y],
-                size: [self.phys_rect.width, self.phys_rect.height],
-                color: snap.default_bg,
-            },
-        );
+        // Build foreground instances (glyphs)
+        let mut fg_instances = Vec::with_capacity(snap.cells.len());
+
+        for cell in &snap.cells {
+            if cell.text.is_empty() || cell.text == " " {
+                continue;
+            }
+
+            // Shape the glyph with cosmic-text to get the cache key
+            let weight = if cell.bold {
+                cosmic_text::Weight::BOLD
+            } else {
+                cosmic_text::Weight::NORMAL
+            };
+            let style = if cell.italic {
+                cosmic_text::Style::Italic
+            } else {
+                cosmic_text::Style::Normal
+            };
+            let attrs = Attrs::new()
+                .family(cosmic_text::fontdb::Family::Monospace)
+                .weight(weight)
+                .style(style);
+
+            let mut buffer = Buffer::new_empty(resources.metrics);
+            {
+                let mut borrowed = buffer.borrow_with(&mut resources.font_system);
+                borrowed.set_size(Some(self.cell_width * 2.0), Some(self.cell_height));
+                borrowed.set_text(&cell.text, attrs, Shaping::Advanced);
+                borrowed.shape_until_scroll(true);
+            }
+
+            for run in buffer.layout_runs() {
+                for glyph in run.glyphs.iter() {
+                    let physical = glyph.physical((0.0, 0.0), 1.0);
+
+                    let entry = resources.atlas.get_or_insert(
+                        queue,
+                        &mut resources.font_system,
+                        &mut resources.swash_cache,
+                        physical.cache_key,
+                    );
+
+                    if let Some(entry) = entry {
+                        let cell_px = self.phys_rect.x + cell.col as f32 * self.cell_width;
+                        let cell_py = self.phys_rect.y + cell.row as f32 * self.cell_height;
+
+                        let gx = cell_px + physical.x as f32 + entry.placement_left as f32;
+                        let gy =
+                            cell_py + run.line_top + physical.y as f32 - entry.placement_top as f32;
+
+                        fg_instances.push(CellFgInstance {
+                            pos: [gx, gy],
+                            size: [entry.width as f32, entry.height as f32],
+                            uv_min: [entry.uv[0], entry.uv[1]],
+                            uv_max: [entry.uv[2], entry.uv[3]],
+                            color: cell.fg,
+                        });
+
+                        resources.atlas_bind_group_dirty = true;
+                    }
+                }
+            }
+        }
+
+        // Update atlas bind group if glyphs were added
+        if resources.atlas_bind_group_dirty {
+            resources.fg_pipeline.update_atlas_bind_group(
+                device,
+                &resources.atlas.texture_view,
+                &resources.atlas.sampler,
+            );
+            resources.atlas_bind_group_dirty = false;
+        }
 
         let viewport_width = screen_descriptor.size_in_pixels[0] as f32;
         let viewport_height = screen_descriptor.size_in_pixels[1] as f32;
@@ -85,6 +161,14 @@ impl CallbackTrait for TerminalPaintCallback {
             device,
             queue,
             &bg_instances,
+            viewport_width,
+            viewport_height,
+        );
+
+        resources.fg_instance_count = resources.fg_pipeline.upload(
+            device,
+            queue,
+            &fg_instances,
             viewport_width,
             viewport_height,
         );
@@ -102,8 +186,12 @@ impl CallbackTrait for TerminalPaintCallback {
             .get::<TerminalGpuResources>()
             .expect("TerminalGpuResources not initialized");
 
+        // Draw backgrounds first, then glyphs on top.
         resources
             .bg_pipeline
             .draw(render_pass, resources.bg_instance_count);
+        resources
+            .fg_pipeline
+            .draw(render_pass, resources.fg_instance_count);
     }
 }

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -1,0 +1,109 @@
+use egui_wgpu::wgpu;
+use egui_wgpu::{CallbackResources, CallbackTrait, ScreenDescriptor};
+
+use crate::pipeline::{BackgroundPipeline, CellBgInstance};
+use crate::snapshot::TerminalSnapshot;
+
+/// Resources stored in egui's `CallbackResources` for the terminal renderer.
+///
+/// Created once during `GpuRenderer::new()` and retrieved during prepare/paint.
+pub struct TerminalGpuResources {
+    pub bg_pipeline: BackgroundPipeline,
+    pub bg_instance_count: u32,
+}
+
+/// Paint callback for a single terminal pane.
+///
+/// Built per-frame with a fresh `TerminalSnapshot`. Implements `CallbackTrait`
+/// to prepare GPU buffers and draw instanced quads in egui's render pass.
+pub struct TerminalPaintCallback {
+    pub snapshot: TerminalSnapshot,
+    /// Rect in physical pixels (already scaled by pixels_per_point).
+    pub phys_rect: PhysRect,
+    pub cell_width: f32,
+    pub cell_height: f32,
+}
+
+/// Physical pixel rectangle for the pane area.
+pub struct PhysRect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+impl CallbackTrait for TerminalPaintCallback {
+    fn prepare(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        screen_descriptor: &ScreenDescriptor,
+        _egui_encoder: &mut wgpu::CommandEncoder,
+        callback_resources: &mut CallbackResources,
+    ) -> Vec<wgpu::CommandBuffer> {
+        let resources = callback_resources
+            .get_mut::<TerminalGpuResources>()
+            .expect("TerminalGpuResources not initialized");
+
+        let snap = &self.snapshot;
+
+        // Build background instances: one quad per cell with non-default background.
+        let mut bg_instances = Vec::with_capacity(snap.cells.len());
+
+        for cell in &snap.cells {
+            // Skip cells with default background (they're already cleared by egui).
+            if cell.bg == snap.default_bg {
+                continue;
+            }
+
+            let px = self.phys_rect.x + cell.col as f32 * self.cell_width;
+            let py = self.phys_rect.y + cell.row as f32 * self.cell_height;
+
+            bg_instances.push(CellBgInstance {
+                pos: [px, py],
+                size: [self.cell_width, self.cell_height],
+                color: cell.bg,
+            });
+        }
+
+        // Also draw the default background as a full-rect quad so the pane
+        // has a solid background even when egui's background differs.
+        // Insert it first so it's drawn behind cell-specific backgrounds.
+        bg_instances.insert(
+            0,
+            CellBgInstance {
+                pos: [self.phys_rect.x, self.phys_rect.y],
+                size: [self.phys_rect.width, self.phys_rect.height],
+                color: snap.default_bg,
+            },
+        );
+
+        let viewport_width = screen_descriptor.size_in_pixels[0] as f32;
+        let viewport_height = screen_descriptor.size_in_pixels[1] as f32;
+
+        resources.bg_instance_count = resources.bg_pipeline.upload(
+            device,
+            queue,
+            &bg_instances,
+            viewport_width,
+            viewport_height,
+        );
+
+        Vec::new()
+    }
+
+    fn paint(
+        &self,
+        _info: egui::PaintCallbackInfo,
+        render_pass: &mut wgpu::RenderPass<'static>,
+        callback_resources: &CallbackResources,
+    ) {
+        let resources = callback_resources
+            .get::<TerminalGpuResources>()
+            .expect("TerminalGpuResources not initialized");
+
+        resources
+            .bg_pipeline
+            .draw(render_pass, resources.bg_instance_count);
+    }
+}

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -13,13 +13,21 @@ use crate::snapshot::TerminalSnapshot;
 
 /// Per-pane GPU state: instance buffers and dirty-tracking fingerprint.
 pub struct PaneRenderState {
-    // Dirty-tracking fields
+    // Dirty-tracking fields — terminal state
     seqno: usize,
     cursor_x: usize,
     cursor_y: i64,
     scroll_offset: usize,
     is_focused: bool,
-    has_selection: bool,
+    selection_range: Option<((usize, usize), (usize, usize))>,
+
+    // Dirty-tracking fields — geometry (pane position/size, cell dimensions)
+    rect_x: f32,
+    rect_y: f32,
+    rect_w: f32,
+    rect_h: f32,
+    cell_width: f32,
+    cell_height: f32,
 
     // Per-pane GPU instance buffers
     pub bg_buffer: wgpu::Buffer,
@@ -51,7 +59,13 @@ impl PaneRenderState {
             cursor_y: 0,
             scroll_offset: 0,
             is_focused: false,
-            has_selection: false,
+            selection_range: None,
+            rect_x: 0.0,
+            rect_y: 0.0,
+            rect_w: 0.0,
+            rect_h: 0.0,
+            cell_width: 0.0,
+            cell_height: 0.0,
             bg_buffer,
             bg_capacity: initial_capacity,
             bg_count: 0,
@@ -61,24 +75,42 @@ impl PaneRenderState {
         }
     }
 
-    /// Check if the pane content has changed since last render.
-    fn is_dirty(&self, snap: &TerminalSnapshot) -> bool {
+    /// Check if the pane content or geometry has changed since last render.
+    fn is_dirty(&self, snap: &TerminalSnapshot, rect: &PhysRect, cell_w: f32, cell_h: f32) -> bool {
         self.seqno != snap.seqno
             || self.cursor_x != snap.cursor.x
             || self.cursor_y != snap.cursor.y
             || self.scroll_offset != snap.scroll_offset
             || self.is_focused != snap.is_focused
-            || self.has_selection != snap.has_selection
+            || self.selection_range != snap.selection_range
+            || self.rect_x != rect.x
+            || self.rect_y != rect.y
+            || self.rect_w != rect.width
+            || self.rect_h != rect.height
+            || self.cell_width != cell_w
+            || self.cell_height != cell_h
     }
 
-    /// Update the fingerprint to match the current snapshot.
-    fn update_fingerprint(&mut self, snap: &TerminalSnapshot) {
+    /// Update the fingerprint to match the current state.
+    fn update_fingerprint(
+        &mut self,
+        snap: &TerminalSnapshot,
+        rect: &PhysRect,
+        cell_w: f32,
+        cell_h: f32,
+    ) {
         self.seqno = snap.seqno;
         self.cursor_x = snap.cursor.x;
         self.cursor_y = snap.cursor.y;
         self.scroll_offset = snap.scroll_offset;
         self.is_focused = snap.is_focused;
-        self.has_selection = snap.has_selection;
+        self.selection_range = snap.selection_range;
+        self.rect_x = rect.x;
+        self.rect_y = rect.y;
+        self.rect_w = rect.width;
+        self.rect_h = rect.height;
+        self.cell_width = cell_w;
+        self.cell_height = cell_h;
     }
 }
 
@@ -93,6 +125,13 @@ pub struct TerminalGpuResources {
     pub atlas_bind_group_dirty: bool,
     /// Per-pane render state (instance buffers + dirty tracking).
     pub pane_states: HashMap<u64, PaneRenderState>,
+}
+
+impl TerminalGpuResources {
+    /// Remove render state for panes that are no longer alive.
+    pub fn retain_panes(&mut self, live_pane_ids: &[u64]) {
+        self.pane_states.retain(|id, _| live_pane_ids.contains(id));
+    }
 }
 
 /// Paint callback for a single terminal pane.
@@ -141,7 +180,12 @@ impl CallbackTrait for TerminalPaintCallback {
             .or_insert_with(|| PaneRenderState::new(device));
 
         // Skip expensive instance rebuild if nothing changed.
-        if !pane_state.is_dirty(&self.snapshot) {
+        if !pane_state.is_dirty(
+            &self.snapshot,
+            &self.phys_rect,
+            self.cell_width,
+            self.cell_height,
+        ) {
             return Vec::new();
         }
 
@@ -300,7 +344,12 @@ impl CallbackTrait for TerminalPaintCallback {
         }
         pane_state.fg_count = fg_instances.len() as u32;
 
-        pane_state.update_fingerprint(&self.snapshot);
+        pane_state.update_fingerprint(
+            &self.snapshot,
+            &self.phys_rect,
+            self.cell_width,
+            self.cell_height,
+        );
 
         Vec::new()
     }
@@ -371,7 +420,7 @@ fn shape_and_rasterize(
         for glyph in run.glyphs.iter() {
             let physical = glyph.physical((0.0, 0.0), 1.0);
 
-            let entry = resources.atlas.get_or_insert(
+            let (entry, newly_inserted) = resources.atlas.get_or_insert(
                 queue,
                 &mut resources.font_system,
                 &mut resources.swash_cache,
@@ -392,7 +441,9 @@ fn shape_and_rasterize(
                     _pad: [0.0; 3],
                 });
 
-                resources.atlas_bind_group_dirty = true;
+                if newly_inserted {
+                    resources.atlas_bind_group_dirty = true;
+                }
             }
         }
     }

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -1,11 +1,86 @@
+use std::collections::HashMap;
+
 use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, SwashCache};
 use egui_wgpu::wgpu;
 use egui_wgpu::{CallbackResources, CallbackTrait, ScreenDescriptor};
 use wezterm_surface::{CursorShape, CursorVisibility};
 
 use crate::atlas::GlyphAtlas;
-use crate::pipeline::{BackgroundPipeline, CellBgInstance, CellFgInstance, ForegroundPipeline};
+use crate::pipeline::{
+    ensure_instance_buffer, BackgroundPipeline, CellBgInstance, CellFgInstance, ForegroundPipeline,
+};
 use crate::snapshot::TerminalSnapshot;
+
+/// Per-pane GPU state: instance buffers and dirty-tracking fingerprint.
+pub struct PaneRenderState {
+    // Dirty-tracking fields
+    seqno: usize,
+    cursor_x: usize,
+    cursor_y: i64,
+    scroll_offset: usize,
+    is_focused: bool,
+    has_selection: bool,
+
+    // Per-pane GPU instance buffers
+    pub bg_buffer: wgpu::Buffer,
+    pub bg_capacity: usize,
+    pub bg_count: u32,
+    pub fg_buffer: wgpu::Buffer,
+    pub fg_capacity: usize,
+    pub fg_count: u32,
+}
+
+impl PaneRenderState {
+    fn new(device: &wgpu::Device) -> Self {
+        let initial_capacity = 1024;
+        let bg_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pane_bg_instance_buffer"),
+            size: (initial_capacity * std::mem::size_of::<CellBgInstance>()) as u64,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let fg_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pane_fg_instance_buffer"),
+            size: (initial_capacity * std::mem::size_of::<CellFgInstance>()) as u64,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        Self {
+            seqno: 0,
+            cursor_x: 0,
+            cursor_y: 0,
+            scroll_offset: 0,
+            is_focused: false,
+            has_selection: false,
+            bg_buffer,
+            bg_capacity: initial_capacity,
+            bg_count: 0,
+            fg_buffer,
+            fg_capacity: initial_capacity,
+            fg_count: 0,
+        }
+    }
+
+    /// Check if the pane content has changed since last render.
+    fn is_dirty(&self, snap: &TerminalSnapshot) -> bool {
+        self.seqno != snap.seqno
+            || self.cursor_x != snap.cursor.x
+            || self.cursor_y != snap.cursor.y
+            || self.scroll_offset != snap.scroll_offset
+            || self.is_focused != snap.is_focused
+            || self.has_selection != snap.has_selection
+    }
+
+    /// Update the fingerprint to match the current snapshot.
+    fn update_fingerprint(&mut self, snap: &TerminalSnapshot) {
+        self.seqno = snap.seqno;
+        self.cursor_x = snap.cursor.x;
+        self.cursor_y = snap.cursor.y;
+        self.scroll_offset = snap.scroll_offset;
+        self.is_focused = snap.is_focused;
+        self.has_selection = snap.has_selection;
+    }
+}
 
 /// Resources stored in egui's `CallbackResources` for the terminal renderer.
 pub struct TerminalGpuResources {
@@ -15,13 +90,14 @@ pub struct TerminalGpuResources {
     pub font_system: FontSystem,
     pub swash_cache: SwashCache,
     pub metrics: Metrics,
-    pub bg_instance_count: u32,
-    pub fg_instance_count: u32,
     pub atlas_bind_group_dirty: bool,
+    /// Per-pane render state (instance buffers + dirty tracking).
+    pub pane_states: HashMap<u64, PaneRenderState>,
 }
 
 /// Paint callback for a single terminal pane.
 pub struct TerminalPaintCallback {
+    pub pane_id: u64,
     pub snapshot: TerminalSnapshot,
     pub phys_rect: PhysRect,
     pub cell_width: f32,
@@ -48,6 +124,26 @@ impl CallbackTrait for TerminalPaintCallback {
         let resources = callback_resources
             .get_mut::<TerminalGpuResources>()
             .expect("TerminalGpuResources not initialized");
+
+        let viewport_width = screen_descriptor.size_in_pixels[0] as f32;
+        let viewport_height = screen_descriptor.size_in_pixels[1] as f32;
+        resources
+            .bg_pipeline
+            .upload_viewport(queue, viewport_width, viewport_height);
+        resources
+            .fg_pipeline
+            .upload_viewport(queue, viewport_width, viewport_height);
+
+        // Get or create per-pane state.
+        let pane_state = resources
+            .pane_states
+            .entry(self.pane_id)
+            .or_insert_with(|| PaneRenderState::new(device));
+
+        // Skip expensive instance rebuild if nothing changed.
+        if !pane_state.is_dirty(&self.snapshot) {
+            return Vec::new();
+        }
 
         let snap = &self.snapshot;
 
@@ -125,13 +221,11 @@ impl CallbackTrait for TerminalPaintCallback {
                     });
                 }
                 CursorShape::Default | CursorShape::BlinkingBlock | CursorShape::SteadyBlock => {
-                    // Block cursor background
                     bg_instances.push(CellBgInstance {
                         pos: [cx, cy],
                         size: [self.cell_width, self.cell_height],
                         color: snap.cursor_bg,
                     });
-                    // Re-draw the character under cursor with cursor foreground color
                     if !snap.cursor_text.is_empty() {
                         shape_and_rasterize(
                             &snap.cursor_text,
@@ -161,24 +255,51 @@ impl CallbackTrait for TerminalPaintCallback {
             resources.atlas_bind_group_dirty = false;
         }
 
-        let viewport_width = screen_descriptor.size_in_pixels[0] as f32;
-        let viewport_height = screen_descriptor.size_in_pixels[1] as f32;
+        // --- Upload to per-pane buffers ---
+        // Re-borrow pane_state after releasing the mutable borrow on resources.
+        let pane_state = resources.pane_states.get_mut(&self.pane_id).unwrap();
 
-        resources.bg_instance_count = resources.bg_pipeline.upload(
+        // Grow bg buffer if needed.
+        if let Some((buf, cap)) = ensure_instance_buffer::<CellBgInstance>(
             device,
-            queue,
-            &bg_instances,
-            viewport_width,
-            viewport_height,
-        );
+            Some(&pane_state.bg_buffer),
+            pane_state.bg_capacity,
+            bg_instances.len(),
+            "pane_bg_instance_buffer",
+        ) {
+            pane_state.bg_buffer = buf;
+            pane_state.bg_capacity = cap;
+        }
+        if !bg_instances.is_empty() {
+            queue.write_buffer(
+                &pane_state.bg_buffer,
+                0,
+                bytemuck::cast_slice(&bg_instances),
+            );
+        }
+        pane_state.bg_count = bg_instances.len() as u32;
 
-        resources.fg_instance_count = resources.fg_pipeline.upload(
+        // Grow fg buffer if needed.
+        if let Some((buf, cap)) = ensure_instance_buffer::<CellFgInstance>(
             device,
-            queue,
-            &fg_instances,
-            viewport_width,
-            viewport_height,
-        );
+            Some(&pane_state.fg_buffer),
+            pane_state.fg_capacity,
+            fg_instances.len(),
+            "pane_fg_instance_buffer",
+        ) {
+            pane_state.fg_buffer = buf;
+            pane_state.fg_capacity = cap;
+        }
+        if !fg_instances.is_empty() {
+            queue.write_buffer(
+                &pane_state.fg_buffer,
+                0,
+                bytemuck::cast_slice(&fg_instances),
+            );
+        }
+        pane_state.fg_count = fg_instances.len() as u32;
+
+        pane_state.update_fingerprint(&self.snapshot);
 
         Vec::new()
     }
@@ -193,12 +314,16 @@ impl CallbackTrait for TerminalPaintCallback {
             .get::<TerminalGpuResources>()
             .expect("TerminalGpuResources not initialized");
 
+        let Some(pane_state) = resources.pane_states.get(&self.pane_id) else {
+            return;
+        };
+
         resources
             .bg_pipeline
-            .draw(render_pass, resources.bg_instance_count);
+            .draw(render_pass, &pane_state.bg_buffer, pane_state.bg_count);
         resources
             .fg_pipeline
-            .draw(render_pass, resources.fg_instance_count);
+            .draw(render_pass, &pane_state.fg_buffer, pane_state.fg_count);
     }
 }
 

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -1,14 +1,13 @@
 use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, SwashCache};
 use egui_wgpu::wgpu;
 use egui_wgpu::{CallbackResources, CallbackTrait, ScreenDescriptor};
+use wezterm_surface::{CursorShape, CursorVisibility};
 
 use crate::atlas::GlyphAtlas;
 use crate::pipeline::{BackgroundPipeline, CellBgInstance, CellFgInstance, ForegroundPipeline};
 use crate::snapshot::TerminalSnapshot;
 
 /// Resources stored in egui's `CallbackResources` for the terminal renderer.
-///
-/// Created once during `GpuRenderer::new()` and retrieved during prepare/paint.
 pub struct TerminalGpuResources {
     pub bg_pipeline: BackgroundPipeline,
     pub fg_pipeline: ForegroundPipeline,
@@ -22,12 +21,8 @@ pub struct TerminalGpuResources {
 }
 
 /// Paint callback for a single terminal pane.
-///
-/// Built per-frame with a fresh `TerminalSnapshot`. Implements `CallbackTrait`
-/// to prepare GPU buffers and draw instanced quads in egui's render pass.
 pub struct TerminalPaintCallback {
     pub snapshot: TerminalSnapshot,
-    /// Rect in physical pixels (already scaled by pixels_per_point).
     pub phys_rect: PhysRect,
     pub cell_width: f32,
     pub cell_height: f32,
@@ -56,7 +51,7 @@ impl CallbackTrait for TerminalPaintCallback {
 
         let snap = &self.snapshot;
 
-        // Build background instances
+        // --- Background instances ---
         let mut bg_instances = Vec::with_capacity(snap.cells.len() + 1);
 
         // Full-rect background quad
@@ -79,7 +74,7 @@ impl CallbackTrait for TerminalPaintCallback {
             });
         }
 
-        // Build foreground instances (glyphs)
+        // --- Foreground instances (glyphs) ---
         let mut fg_instances = Vec::with_capacity(snap.cells.len());
 
         for cell in &snap.cells {
@@ -87,64 +82,76 @@ impl CallbackTrait for TerminalPaintCallback {
                 continue;
             }
 
-            // Shape the glyph with cosmic-text to get the cache key
-            let weight = if cell.bold {
-                cosmic_text::Weight::BOLD
-            } else {
-                cosmic_text::Weight::NORMAL
-            };
-            let style = if cell.italic {
-                cosmic_text::Style::Italic
-            } else {
-                cosmic_text::Style::Normal
-            };
-            let attrs = Attrs::new()
-                .family(cosmic_text::fontdb::Family::Monospace)
-                .weight(weight)
-                .style(style);
+            shape_and_rasterize(
+                &cell.text,
+                cell.bold,
+                cell.italic,
+                cell.fg,
+                self.phys_rect.x + cell.col as f32 * self.cell_width,
+                self.phys_rect.y + cell.row as f32 * self.cell_height,
+                self.cell_width,
+                self.cell_height,
+                resources,
+                queue,
+                &mut fg_instances,
+            );
+        }
 
-            let mut buffer = Buffer::new_empty(resources.metrics);
-            {
-                let mut borrowed = buffer.borrow_with(&mut resources.font_system);
-                borrowed.set_size(Some(self.cell_width * 2.0), Some(self.cell_height));
-                borrowed.set_text(&cell.text, attrs, Shaping::Advanced);
-                borrowed.shape_until_scroll(true);
-            }
+        // --- Cursor ---
+        let cursor = &snap.cursor;
+        if snap.is_focused
+            && snap.scroll_offset == 0
+            && cursor.visibility == CursorVisibility::Visible
+            && cursor.y >= 0
+            && (cursor.y as usize) < snap.rows
+            && cursor.x < snap.cols
+        {
+            let cx = self.phys_rect.x + cursor.x as f32 * self.cell_width;
+            let cy = self.phys_rect.y + cursor.y as f32 * self.cell_height;
 
-            for run in buffer.layout_runs() {
-                for glyph in run.glyphs.iter() {
-                    let physical = glyph.physical((0.0, 0.0), 1.0);
-
-                    let entry = resources.atlas.get_or_insert(
-                        queue,
-                        &mut resources.font_system,
-                        &mut resources.swash_cache,
-                        physical.cache_key,
-                    );
-
-                    if let Some(entry) = entry {
-                        let cell_px = self.phys_rect.x + cell.col as f32 * self.cell_width;
-                        let cell_py = self.phys_rect.y + cell.row as f32 * self.cell_height;
-
-                        let gx = cell_px + physical.x as f32 + entry.placement_left as f32;
-                        let gy =
-                            cell_py + run.line_top + physical.y as f32 - entry.placement_top as f32;
-
-                        fg_instances.push(CellFgInstance {
-                            pos: [gx, gy],
-                            size: [entry.width as f32, entry.height as f32],
-                            uv_min: [entry.uv[0], entry.uv[1]],
-                            uv_max: [entry.uv[2], entry.uv[3]],
-                            color: cell.fg,
-                        });
-
-                        resources.atlas_bind_group_dirty = true;
+            match cursor.shape {
+                CursorShape::BlinkingBar | CursorShape::SteadyBar => {
+                    bg_instances.push(CellBgInstance {
+                        pos: [cx, cy],
+                        size: [2.0, self.cell_height],
+                        color: snap.cursor_bg,
+                    });
+                }
+                CursorShape::BlinkingUnderline | CursorShape::SteadyUnderline => {
+                    bg_instances.push(CellBgInstance {
+                        pos: [cx, cy + self.cell_height - 2.0],
+                        size: [self.cell_width, 2.0],
+                        color: snap.cursor_bg,
+                    });
+                }
+                CursorShape::Default | CursorShape::BlinkingBlock | CursorShape::SteadyBlock => {
+                    // Block cursor background
+                    bg_instances.push(CellBgInstance {
+                        pos: [cx, cy],
+                        size: [self.cell_width, self.cell_height],
+                        color: snap.cursor_bg,
+                    });
+                    // Re-draw the character under cursor with cursor foreground color
+                    if !snap.cursor_text.is_empty() {
+                        shape_and_rasterize(
+                            &snap.cursor_text,
+                            snap.cursor_text_bold,
+                            false,
+                            snap.cursor_fg,
+                            cx,
+                            cy,
+                            self.cell_width,
+                            self.cell_height,
+                            resources,
+                            queue,
+                            &mut fg_instances,
+                        );
                     }
                 }
             }
         }
 
-        // Update atlas bind group if glyphs were added
+        // --- Update atlas bind group if glyphs were added ---
         if resources.atlas_bind_group_dirty {
             resources.fg_pipeline.update_atlas_bind_group(
                 device,
@@ -186,12 +193,79 @@ impl CallbackTrait for TerminalPaintCallback {
             .get::<TerminalGpuResources>()
             .expect("TerminalGpuResources not initialized");
 
-        // Draw backgrounds first, then glyphs on top.
         resources
             .bg_pipeline
             .draw(render_pass, resources.bg_instance_count);
         resources
             .fg_pipeline
             .draw(render_pass, resources.fg_instance_count);
+    }
+}
+
+/// Shape text with cosmic-text and rasterize glyphs into the atlas,
+/// appending foreground instances for each glyph.
+#[allow(clippy::too_many_arguments)]
+fn shape_and_rasterize(
+    text: &str,
+    bold: bool,
+    italic: bool,
+    color: [f32; 4],
+    cell_px: f32,
+    cell_py: f32,
+    cell_width: f32,
+    cell_height: f32,
+    resources: &mut TerminalGpuResources,
+    queue: &wgpu::Queue,
+    fg_instances: &mut Vec<CellFgInstance>,
+) {
+    let weight = if bold {
+        cosmic_text::Weight::BOLD
+    } else {
+        cosmic_text::Weight::NORMAL
+    };
+    let style = if italic {
+        cosmic_text::Style::Italic
+    } else {
+        cosmic_text::Style::Normal
+    };
+    let attrs = Attrs::new()
+        .family(cosmic_text::fontdb::Family::Monospace)
+        .weight(weight)
+        .style(style);
+
+    let mut buffer = Buffer::new_empty(resources.metrics);
+    {
+        let mut borrowed = buffer.borrow_with(&mut resources.font_system);
+        borrowed.set_size(Some(cell_width * 2.0), Some(cell_height));
+        borrowed.set_text(text, attrs, Shaping::Advanced);
+        borrowed.shape_until_scroll(true);
+    }
+
+    for run in buffer.layout_runs() {
+        for glyph in run.glyphs.iter() {
+            let physical = glyph.physical((0.0, 0.0), 1.0);
+
+            let entry = resources.atlas.get_or_insert(
+                queue,
+                &mut resources.font_system,
+                &mut resources.swash_cache,
+                physical.cache_key,
+            );
+
+            if let Some(entry) = entry {
+                let gx = cell_px + physical.x as f32 + entry.placement_left as f32;
+                let gy = cell_py + run.line_top + physical.y as f32 - entry.placement_top as f32;
+
+                fg_instances.push(CellFgInstance {
+                    pos: [gx, gy],
+                    size: [entry.width as f32, entry.height as f32],
+                    uv_min: [entry.uv[0], entry.uv[1]],
+                    uv_max: [entry.uv[2], entry.uv[3]],
+                    color,
+                });
+
+                resources.atlas_bind_group_dirty = true;
+            }
+        }
     }
 }

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -13,6 +13,8 @@ use crate::snapshot::TerminalSnapshot;
 
 /// Per-pane GPU state: instance buffers and dirty-tracking fingerprint.
 pub struct PaneRenderState {
+    /// False until first successful prepare; forces initial rebuild.
+    initialized: bool,
     // Dirty-tracking fields — terminal state
     seqno: usize,
     cursor_x: usize,
@@ -54,6 +56,7 @@ impl PaneRenderState {
             mapped_at_creation: false,
         });
         Self {
+            initialized: false,
             seqno: 0,
             cursor_x: 0,
             cursor_y: 0,
@@ -77,7 +80,8 @@ impl PaneRenderState {
 
     /// Check if the pane content or geometry has changed since last render.
     fn is_dirty(&self, snap: &TerminalSnapshot, rect: &PhysRect, cell_w: f32, cell_h: f32) -> bool {
-        self.seqno != snap.seqno
+        !self.initialized
+            || self.seqno != snap.seqno
             || self.cursor_x != snap.cursor.x
             || self.cursor_y != snap.cursor.y
             || self.scroll_offset != snap.scroll_offset
@@ -99,6 +103,7 @@ impl PaneRenderState {
         cell_w: f32,
         cell_h: f32,
     ) {
+        self.initialized = true;
         self.seqno = snap.seqno;
         self.cursor_x = snap.cursor.x;
         self.cursor_y = snap.cursor.y;
@@ -274,7 +279,7 @@ impl CallbackTrait for TerminalPaintCallback {
                         shape_and_rasterize(
                             &snap.cursor_text,
                             snap.cursor_text_bold,
-                            false,
+                            snap.cursor_text_italic,
                             snap.cursor_fg,
                             cx,
                             cy,

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -249,7 +249,8 @@ impl CallbackTrait for TerminalPaintCallback {
         if resources.atlas_bind_group_dirty {
             resources.fg_pipeline.update_atlas_bind_group(
                 device,
-                &resources.atlas.texture_view,
+                resources.atlas.mono_texture_view(),
+                resources.atlas.color_texture_view(),
                 &resources.atlas.sampler,
             );
             resources.atlas_bind_group_dirty = false;
@@ -387,6 +388,8 @@ fn shape_and_rasterize(
                     uv_min: [entry.uv[0], entry.uv[1]],
                     uv_max: [entry.uv[2], entry.uv[3]],
                     color,
+                    is_color: if entry.is_color { 1.0 } else { 0.0 },
+                    _pad: [0.0; 3],
                 });
 
                 resources.atlas_bind_group_dirty = true;

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -109,6 +109,19 @@ impl GpuRenderer {
     pub fn cell_height(&self) -> f32 {
         self.cell_height
     }
+
+    /// Remove cached render state for panes that no longer exist.
+    pub fn retain_panes(&self, live_pane_ids: &[u64]) {
+        if let Some(r) = self
+            .render_state
+            .renderer
+            .write()
+            .callback_resources
+            .get_mut::<TerminalGpuResources>()
+        {
+            r.retain_panes(live_pane_ids);
+        }
+    }
 }
 
 /// Measure monospace cell width by laying out "M" and reading the advance.

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -59,9 +59,8 @@ impl GpuRenderer {
                 font_system,
                 swash_cache,
                 metrics,
-                bg_instance_count: 0,
-                fg_instance_count: 0,
                 atlas_bind_group_dirty: true,
+                pane_states: std::collections::HashMap::new(),
             });
 
         Self {
@@ -85,7 +84,9 @@ impl GpuRenderer {
         let phys_cell_w = self.cell_width * pixels_per_point;
         let phys_cell_h = self.cell_height * pixels_per_point;
 
+        let pane_id = snapshot.pane_id;
         let callback = TerminalPaintCallback {
+            pane_id,
             snapshot,
             phys_rect: PhysRect {
                 x: rect.min.x * pixels_per_point,

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -1,63 +1,95 @@
-use egui_wgpu::wgpu;
-use egui_wgpu::{CallbackResources, CallbackTrait, ScreenDescriptor};
+mod callback;
+mod pipeline;
+pub mod snapshot;
+
+use callback::{PhysRect, TerminalGpuResources, TerminalPaintCallback};
+use pipeline::BackgroundPipeline;
+pub use snapshot::TerminalSnapshot;
 
 /// GPU-accelerated terminal renderer using wgpu.
 ///
 /// Renders terminal panes via instanced quad drawing inside egui's render pass,
 /// using `egui_wgpu::CallbackTrait` for custom paint callbacks.
 pub struct GpuRenderer {
+    #[allow(dead_code)]
     render_state: egui_wgpu::RenderState,
+    cell_width: f32,
+    cell_height: f32,
 }
 
 impl GpuRenderer {
     /// Create a new GPU renderer from eframe's render state.
+    ///
+    /// Initializes the background pipeline and registers GPU resources
+    /// in egui's callback resource map.
     pub fn new(render_state: egui_wgpu::RenderState) -> Self {
-        Self { render_state }
+        let target_format = render_state.target_format;
+        let device = &render_state.device;
+
+        let bg_pipeline = BackgroundPipeline::new(device, target_format);
+
+        // Register resources in egui's callback_resources for access during prepare/paint.
+        render_state
+            .renderer
+            .write()
+            .callback_resources
+            .insert(TerminalGpuResources {
+                bg_pipeline,
+                bg_instance_count: 0,
+            });
+
+        Self {
+            render_state,
+            // Placeholder cell dimensions — will be set properly when cosmic-text
+            // font measurement is added in PR 8c. For now, use egui's measurements
+            // passed in via paint_callback().
+            cell_width: 0.0,
+            cell_height: 0.0,
+        }
     }
 
     /// Create an egui `PaintCallback` that will render the terminal pane
     /// into the given rect during egui's render pass.
     ///
-    /// For now this is a placeholder that clears to the default background.
-    pub fn paint_callback(&self, rect: egui::Rect) -> egui::PaintCallback {
+    /// `snapshot` contains pre-extracted terminal state (cells, colors, cursor).
+    /// `cell_width` and `cell_height` are in logical points (will be scaled by pixels_per_point).
+    /// `pixels_per_point` is the current DPI scale factor.
+    pub fn paint_callback(
+        &self,
+        rect: egui::Rect,
+        snapshot: TerminalSnapshot,
+        cell_width: f32,
+        cell_height: f32,
+        pixels_per_point: f32,
+    ) -> egui::PaintCallback {
+        let phys_cell_w = cell_width * pixels_per_point;
+        let phys_cell_h = cell_height * pixels_per_point;
+
         let callback = TerminalPaintCallback {
-            _render_state: self.render_state.clone(),
+            snapshot,
+            phys_rect: PhysRect {
+                x: rect.min.x * pixels_per_point,
+                y: rect.min.y * pixels_per_point,
+                width: rect.width() * pixels_per_point,
+                height: rect.height() * pixels_per_point,
+            },
+            cell_width: phys_cell_w,
+            cell_height: phys_cell_h,
         };
         egui_wgpu::Callback::new_paint_callback(rect, callback)
     }
-}
 
-/// Placeholder paint callback for terminal pane rendering.
-///
-/// Implements `CallbackTrait` to hook into egui's wgpu render pass.
-/// Currently a no-op — will be extended with background and foreground
-/// rendering passes in subsequent PRs.
-struct TerminalPaintCallback {
-    _render_state: egui_wgpu::RenderState,
-}
-
-impl CallbackTrait for TerminalPaintCallback {
-    fn prepare(
-        &self,
-        _device: &wgpu::Device,
-        _queue: &wgpu::Queue,
-        _screen_descriptor: &ScreenDescriptor,
-        _egui_encoder: &mut wgpu::CommandEncoder,
-        _callback_resources: &mut CallbackResources,
-    ) -> Vec<wgpu::CommandBuffer> {
-        Vec::new()
+    /// Get the cell width in logical points.
+    ///
+    /// Returns 0.0 until cosmic-text font measurement is implemented (PR 8c).
+    pub fn cell_width(&self) -> f32 {
+        self.cell_width
     }
 
-    fn paint(
-        &self,
-        _info: egui::PaintCallbackInfo,
-        _render_pass: &mut wgpu::RenderPass<'static>,
-        _callback_resources: &CallbackResources,
-    ) {
-        // No-op placeholder. Background and foreground passes will be added here.
+    /// Get the cell height in logical points.
+    ///
+    /// Returns 0.0 until cosmic-text font measurement is implemented (PR 8c).
+    pub fn cell_height(&self) -> f32 {
+        self.cell_height
     }
 }
-
-// Compile-time check that the callback is Send + Sync as required by egui_wgpu.
-fn _assert_send_sync<T: Send + Sync>() {}
-const _: fn() = _assert_send_sync::<TerminalPaintCallback>;

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -1,1 +1,63 @@
+use egui_wgpu::wgpu;
+use egui_wgpu::{CallbackResources, CallbackTrait, ScreenDescriptor};
 
+/// GPU-accelerated terminal renderer using wgpu.
+///
+/// Renders terminal panes via instanced quad drawing inside egui's render pass,
+/// using `egui_wgpu::CallbackTrait` for custom paint callbacks.
+pub struct GpuRenderer {
+    render_state: egui_wgpu::RenderState,
+}
+
+impl GpuRenderer {
+    /// Create a new GPU renderer from eframe's render state.
+    pub fn new(render_state: egui_wgpu::RenderState) -> Self {
+        Self { render_state }
+    }
+
+    /// Create an egui `PaintCallback` that will render the terminal pane
+    /// into the given rect during egui's render pass.
+    ///
+    /// For now this is a placeholder that clears to the default background.
+    pub fn paint_callback(&self, rect: egui::Rect) -> egui::PaintCallback {
+        let callback = TerminalPaintCallback {
+            _render_state: self.render_state.clone(),
+        };
+        egui_wgpu::Callback::new_paint_callback(rect, callback)
+    }
+}
+
+/// Placeholder paint callback for terminal pane rendering.
+///
+/// Implements `CallbackTrait` to hook into egui's wgpu render pass.
+/// Currently a no-op — will be extended with background and foreground
+/// rendering passes in subsequent PRs.
+struct TerminalPaintCallback {
+    _render_state: egui_wgpu::RenderState,
+}
+
+impl CallbackTrait for TerminalPaintCallback {
+    fn prepare(
+        &self,
+        _device: &wgpu::Device,
+        _queue: &wgpu::Queue,
+        _screen_descriptor: &ScreenDescriptor,
+        _egui_encoder: &mut wgpu::CommandEncoder,
+        _callback_resources: &mut CallbackResources,
+    ) -> Vec<wgpu::CommandBuffer> {
+        Vec::new()
+    }
+
+    fn paint(
+        &self,
+        _info: egui::PaintCallbackInfo,
+        _render_pass: &mut wgpu::RenderPass<'static>,
+        _callback_resources: &CallbackResources,
+    ) {
+        // No-op placeholder. Background and foreground passes will be added here.
+    }
+}
+
+// Compile-time check that the callback is Send + Sync as required by egui_wgpu.
+fn _assert_send_sync<T: Send + Sync>() {}
+const _: fn() = _assert_send_sync::<TerminalPaintCallback>;

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -1,10 +1,18 @@
+mod atlas;
 mod callback;
 mod pipeline;
 pub mod snapshot;
 
+use cosmic_text::fontdb::Family;
+use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, SwashCache};
+
+use atlas::GlyphAtlas;
 use callback::{PhysRect, TerminalGpuResources, TerminalPaintCallback};
-use pipeline::BackgroundPipeline;
+use pipeline::{BackgroundPipeline, ForegroundPipeline};
 pub use snapshot::TerminalSnapshot;
+
+/// Atlas texture size (2048×2048, ~4MB for R8).
+const ATLAS_SIZE: u32 = 2048;
 
 /// GPU-accelerated terminal renderer using wgpu.
 ///
@@ -20,31 +28,46 @@ pub struct GpuRenderer {
 impl GpuRenderer {
     /// Create a new GPU renderer from eframe's render state.
     ///
-    /// Initializes the background pipeline and registers GPU resources
-    /// in egui's callback resource map.
-    pub fn new(render_state: egui_wgpu::RenderState) -> Self {
+    /// Initializes pipelines, glyph atlas, and font system. Registers GPU
+    /// resources in egui's callback resource map.
+    pub fn new(render_state: egui_wgpu::RenderState, font_size: f32) -> Self {
         let target_format = render_state.target_format;
         let device = &render_state.device;
 
         let bg_pipeline = BackgroundPipeline::new(device, target_format);
+        let fg_pipeline = ForegroundPipeline::new(device, target_format);
+        let atlas = GlyphAtlas::new(device, ATLAS_SIZE);
 
-        // Register resources in egui's callback_resources for access during prepare/paint.
+        let mut font_system = FontSystem::new();
+        let swash_cache = SwashCache::new();
+
+        // Measure cell dimensions via cosmic-text (same approach as amux-render-soft).
+        let line_height = (font_size * 1.3).ceil();
+        let metrics = Metrics::new(font_size, line_height);
+        let cell_width = measure_cell_width(&mut font_system, metrics);
+        let cell_height = line_height;
+
+        // Register resources in egui's callback_resources.
         render_state
             .renderer
             .write()
             .callback_resources
             .insert(TerminalGpuResources {
                 bg_pipeline,
+                fg_pipeline,
+                atlas,
+                font_system,
+                swash_cache,
+                metrics,
                 bg_instance_count: 0,
+                fg_instance_count: 0,
+                atlas_bind_group_dirty: true,
             });
 
         Self {
             render_state,
-            // Placeholder cell dimensions — will be set properly when cosmic-text
-            // font measurement is added in PR 8c. For now, use egui's measurements
-            // passed in via paint_callback().
-            cell_width: 0.0,
-            cell_height: 0.0,
+            cell_width,
+            cell_height,
         }
     }
 
@@ -52,18 +75,15 @@ impl GpuRenderer {
     /// into the given rect during egui's render pass.
     ///
     /// `snapshot` contains pre-extracted terminal state (cells, colors, cursor).
-    /// `cell_width` and `cell_height` are in logical points (will be scaled by pixels_per_point).
     /// `pixels_per_point` is the current DPI scale factor.
     pub fn paint_callback(
         &self,
         rect: egui::Rect,
         snapshot: TerminalSnapshot,
-        cell_width: f32,
-        cell_height: f32,
         pixels_per_point: f32,
     ) -> egui::PaintCallback {
-        let phys_cell_w = cell_width * pixels_per_point;
-        let phys_cell_h = cell_height * pixels_per_point;
+        let phys_cell_w = self.cell_width * pixels_per_point;
+        let phys_cell_h = self.cell_height * pixels_per_point;
 
         let callback = TerminalPaintCallback {
             snapshot,
@@ -80,16 +100,36 @@ impl GpuRenderer {
     }
 
     /// Get the cell width in logical points.
-    ///
-    /// Returns 0.0 until cosmic-text font measurement is implemented (PR 8c).
     pub fn cell_width(&self) -> f32 {
         self.cell_width
     }
 
     /// Get the cell height in logical points.
-    ///
-    /// Returns 0.0 until cosmic-text font measurement is implemented (PR 8c).
     pub fn cell_height(&self) -> f32 {
         self.cell_height
     }
+}
+
+/// Measure monospace cell width by laying out "M" and reading the advance.
+fn measure_cell_width(font_system: &mut FontSystem, metrics: Metrics) -> f32 {
+    let mut buffer = Buffer::new_empty(metrics);
+    {
+        let mut borrowed = buffer.borrow_with(font_system);
+        borrowed.set_size(Some(200.0), Some(metrics.line_height));
+        borrowed.set_text(
+            "M",
+            Attrs::new().family(Family::Monospace),
+            Shaping::Advanced,
+        );
+        borrowed.shape_until_scroll(true);
+    }
+
+    for run in buffer.layout_runs() {
+        if let Some(glyph) = run.glyphs.iter().next() {
+            return glyph.w;
+        }
+    }
+
+    // Fallback: estimate from font size
+    metrics.font_size * 0.6
 }

--- a/crates/amux-render-gpu/src/pipeline.rs
+++ b/crates/amux-render-gpu/src/pipeline.rs
@@ -213,6 +213,9 @@ pub struct CellFgInstance {
     pub uv_max: [f32; 2],
     /// Foreground color (linear RGBA).
     pub color: [f32; 4],
+    /// 1.0 for color emoji, 0.0 for monochrome glyphs.
+    pub is_color: f32,
+    pub _pad: [f32; 3],
 }
 
 /// Foreground rendering pipeline: instanced textured quads for glyphs.
@@ -252,11 +255,12 @@ impl ForegroundPipeline {
                 }],
             });
 
-        // Group 1: atlas texture + sampler
+        // Group 1: mono atlas + color atlas + sampler
         let atlas_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 label: Some("fg_atlas_bind_group_layout"),
                 entries: &[
+                    // binding 0: mono atlas (R8Unorm)
                     wgpu::BindGroupLayoutEntry {
                         binding: 0,
                         visibility: wgpu::ShaderStages::FRAGMENT,
@@ -267,8 +271,20 @@ impl ForegroundPipeline {
                         },
                         count: None,
                     },
+                    // binding 1: color atlas (Rgba8UnormSrgb)
                     wgpu::BindGroupLayoutEntry {
                         binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    // binding 2: shared sampler
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                         count: None,
@@ -306,6 +322,7 @@ impl ForegroundPipeline {
                             3 => Float32x2, // uv_min
                             4 => Float32x2, // uv_max
                             5 => Float32x4, // color
+                            6 => Float32x4, // is_color + padding
                         ],
                     },
                 ],
@@ -380,11 +397,12 @@ impl ForegroundPipeline {
         }
     }
 
-    /// Update the atlas bind group when the atlas texture changes.
+    /// Update the atlas bind group when atlas textures change.
     pub fn update_atlas_bind_group(
         &mut self,
         device: &wgpu::Device,
-        texture_view: &wgpu::TextureView,
+        mono_view: &wgpu::TextureView,
+        color_view: &wgpu::TextureView,
         sampler: &wgpu::Sampler,
     ) {
         self.atlas_bind_group = Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -393,10 +411,14 @@ impl ForegroundPipeline {
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: wgpu::BindingResource::TextureView(texture_view),
+                    resource: wgpu::BindingResource::TextureView(mono_view),
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
+                    resource: wgpu::BindingResource::TextureView(color_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
                     resource: wgpu::BindingResource::Sampler(sampler),
                 },
             ],

--- a/crates/amux-render-gpu/src/pipeline.rs
+++ b/crates/amux-render-gpu/src/pipeline.rs
@@ -229,3 +229,275 @@ impl BackgroundPipeline {
         render_pass.draw_indexed(0..6, 0, 0..instance_count);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Foreground pipeline (textured glyph quads)
+// ---------------------------------------------------------------------------
+
+/// Per-glyph foreground instance data.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct CellFgInstance {
+    /// Glyph position in physical pixels (top-left corner).
+    pub pos: [f32; 2],
+    /// Glyph size in physical pixels.
+    pub size: [f32; 2],
+    /// Atlas UV min (top-left).
+    pub uv_min: [f32; 2],
+    /// Atlas UV max (bottom-right).
+    pub uv_max: [f32; 2],
+    /// Foreground color (linear RGBA).
+    pub color: [f32; 4],
+}
+
+/// Foreground rendering pipeline: instanced textured quads for glyphs.
+pub struct ForegroundPipeline {
+    pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    index_buffer: wgpu::Buffer,
+    viewport_buffer: wgpu::Buffer,
+    viewport_bind_group: wgpu::BindGroup,
+    atlas_bind_group_layout: wgpu::BindGroupLayout,
+    atlas_bind_group: Option<wgpu::BindGroup>,
+    instance_buffer: wgpu::Buffer,
+    instance_capacity: usize,
+}
+
+impl ForegroundPipeline {
+    /// Create the foreground pipeline.
+    pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("foreground_shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/foreground.wgsl").into()),
+        });
+
+        // Group 0: viewport uniform
+        let viewport_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("fg_viewport_bind_group_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
+        // Group 1: atlas texture + sampler
+        let atlas_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("fg_atlas_bind_group_layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("fg_pipeline_layout"),
+            bind_group_layouts: &[&viewport_bind_group_layout, &atlas_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("fg_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[
+                    // Vertex buffer: unit quad
+                    wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<QuadVertex>() as u64,
+                        step_mode: wgpu::VertexStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array![0 => Float32x2],
+                    },
+                    // Instance buffer: per-glyph data
+                    wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<CellFgInstance>() as u64,
+                        step_mode: wgpu::VertexStepMode::Instance,
+                        attributes: &wgpu::vertex_attr_array![
+                            1 => Float32x2, // pos
+                            2 => Float32x2, // size
+                            3 => Float32x2, // uv_min
+                            4 => Float32x2, // uv_max
+                            5 => Float32x4, // color
+                        ],
+                    },
+                ],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: target_format,
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        // Shared unit quad (same as background pipeline)
+        let vertices = [
+            QuadVertex { pos: [0.0, 0.0] },
+            QuadVertex { pos: [1.0, 0.0] },
+            QuadVertex { pos: [1.0, 1.0] },
+            QuadVertex { pos: [0.0, 1.0] },
+        ];
+        let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("fg_vertex_buffer"),
+            contents: bytemuck::cast_slice(&vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("fg_index_buffer"),
+            contents: bytemuck::cast_slice(&indices),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+
+        let viewport_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("fg_viewport_uniform"),
+            contents: bytemuck::cast_slice(&[ViewportUniform {
+                size: [1.0, 1.0],
+                _pad: [0.0; 2],
+            }]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let viewport_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("fg_viewport_bind_group"),
+            layout: &viewport_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: viewport_buffer.as_entire_binding(),
+            }],
+        });
+
+        let initial_capacity = 10_000;
+        let instance_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("fg_instance_buffer"),
+            size: (initial_capacity * std::mem::size_of::<CellFgInstance>()) as u64,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        Self {
+            pipeline,
+            vertex_buffer,
+            index_buffer,
+            viewport_buffer,
+            viewport_bind_group,
+            atlas_bind_group_layout,
+            atlas_bind_group: None,
+            instance_buffer,
+            instance_capacity: initial_capacity,
+        }
+    }
+
+    /// Update the atlas bind group when the atlas texture changes.
+    pub fn update_atlas_bind_group(
+        &mut self,
+        device: &wgpu::Device,
+        texture_view: &wgpu::TextureView,
+        sampler: &wgpu::Sampler,
+    ) {
+        self.atlas_bind_group = Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("fg_atlas_bind_group"),
+            layout: &self.atlas_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(texture_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(sampler),
+                },
+            ],
+        }));
+    }
+
+    /// Upload instance data and viewport size. Returns the number of instances.
+    pub fn upload(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        instances: &[CellFgInstance],
+        viewport_width: f32,
+        viewport_height: f32,
+    ) -> u32 {
+        queue.write_buffer(
+            &self.viewport_buffer,
+            0,
+            bytemuck::cast_slice(&[ViewportUniform {
+                size: [viewport_width, viewport_height],
+                _pad: [0.0; 2],
+            }]),
+        );
+
+        if instances.is_empty() {
+            return 0;
+        }
+
+        if instances.len() > self.instance_capacity {
+            self.instance_capacity = instances.len().next_power_of_two();
+            self.instance_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("fg_instance_buffer"),
+                size: (self.instance_capacity * std::mem::size_of::<CellFgInstance>()) as u64,
+                usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+        }
+
+        queue.write_buffer(&self.instance_buffer, 0, bytemuck::cast_slice(instances));
+        instances.len() as u32
+    }
+
+    /// Record draw commands into a render pass.
+    pub fn draw(&self, render_pass: &mut wgpu::RenderPass<'static>, instance_count: u32) {
+        if instance_count == 0 {
+            return;
+        }
+        let Some(atlas_bind_group) = &self.atlas_bind_group else {
+            return;
+        };
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_bind_group(0, &self.viewport_bind_group, &[]);
+        render_pass.set_bind_group(1, atlas_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        render_pass.set_vertex_buffer(1, self.instance_buffer.slice(..));
+        render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+        render_pass.draw_indexed(0..6, 0, 0..instance_count);
+    }
+}

--- a/crates/amux-render-gpu/src/pipeline.rs
+++ b/crates/amux-render-gpu/src/pipeline.rs
@@ -1,0 +1,231 @@
+use bytemuck::{Pod, Zeroable};
+use wgpu::util::DeviceExt;
+
+/// Per-cell background instance data.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct CellBgInstance {
+    /// Cell position in physical pixels (top-left corner).
+    pub pos: [f32; 2],
+    /// Cell size in physical pixels.
+    pub size: [f32; 2],
+    /// Background color (linear RGBA).
+    pub color: [f32; 4],
+}
+
+/// Viewport uniform data.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+struct ViewportUniform {
+    /// Viewport size in physical pixels.
+    size: [f32; 2],
+    _pad: [f32; 2],
+}
+
+/// Unit quad vertex.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+struct QuadVertex {
+    pos: [f32; 2],
+}
+
+/// Background rendering pipeline: instanced colored quads for cell backgrounds.
+pub struct BackgroundPipeline {
+    pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    index_buffer: wgpu::Buffer,
+    viewport_buffer: wgpu::Buffer,
+    viewport_bind_group: wgpu::BindGroup,
+    instance_buffer: wgpu::Buffer,
+    instance_capacity: usize,
+}
+
+impl BackgroundPipeline {
+    /// Create the background pipeline.
+    pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("background_shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/background.wgsl").into()),
+        });
+
+        // Viewport uniform bind group layout
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("bg_viewport_bind_group_layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("bg_pipeline_layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("bg_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[
+                    // Vertex buffer: unit quad
+                    wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<QuadVertex>() as u64,
+                        step_mode: wgpu::VertexStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array![0 => Float32x2],
+                    },
+                    // Instance buffer: per-cell data
+                    wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<CellBgInstance>() as u64,
+                        step_mode: wgpu::VertexStepMode::Instance,
+                        attributes: &wgpu::vertex_attr_array![
+                            1 => Float32x2, // pos
+                            2 => Float32x2, // size
+                            3 => Float32x4, // color
+                        ],
+                    },
+                ],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: target_format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        // Unit quad: two triangles covering (0,0) to (1,1)
+        let vertices = [
+            QuadVertex { pos: [0.0, 0.0] },
+            QuadVertex { pos: [1.0, 0.0] },
+            QuadVertex { pos: [1.0, 1.0] },
+            QuadVertex { pos: [0.0, 1.0] },
+        ];
+        let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("bg_vertex_buffer"),
+            contents: bytemuck::cast_slice(&vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("bg_index_buffer"),
+            contents: bytemuck::cast_slice(&indices),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+
+        let viewport_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("bg_viewport_uniform"),
+            contents: bytemuck::cast_slice(&[ViewportUniform {
+                size: [1.0, 1.0],
+                _pad: [0.0; 2],
+            }]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let viewport_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("bg_viewport_bind_group"),
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: viewport_buffer.as_entire_binding(),
+            }],
+        });
+
+        // Pre-allocate instance buffer for a typical terminal (200 cols × 50 rows)
+        let initial_capacity = 10_000;
+        let instance_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("bg_instance_buffer"),
+            size: (initial_capacity * std::mem::size_of::<CellBgInstance>()) as u64,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        Self {
+            pipeline,
+            vertex_buffer,
+            index_buffer,
+            viewport_buffer,
+            viewport_bind_group,
+            instance_buffer,
+            instance_capacity: initial_capacity,
+        }
+    }
+
+    /// Upload instance data and viewport size. Returns the number of instances.
+    pub fn upload(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        instances: &[CellBgInstance],
+        viewport_width: f32,
+        viewport_height: f32,
+    ) -> u32 {
+        // Update viewport uniform
+        queue.write_buffer(
+            &self.viewport_buffer,
+            0,
+            bytemuck::cast_slice(&[ViewportUniform {
+                size: [viewport_width, viewport_height],
+                _pad: [0.0; 2],
+            }]),
+        );
+
+        if instances.is_empty() {
+            return 0;
+        }
+
+        // Grow instance buffer if needed
+        if instances.len() > self.instance_capacity {
+            self.instance_capacity = instances.len().next_power_of_two();
+            self.instance_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("bg_instance_buffer"),
+                size: (self.instance_capacity * std::mem::size_of::<CellBgInstance>()) as u64,
+                usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+        }
+
+        queue.write_buffer(&self.instance_buffer, 0, bytemuck::cast_slice(instances));
+        instances.len() as u32
+    }
+
+    /// Record draw commands into a render pass.
+    ///
+    /// The `'static` lifetime on the render pass is required by egui_wgpu's
+    /// `CallbackTrait::paint()`. We use `wgpu::RenderPass::set_pipeline` etc.
+    /// which internally hold references via `Arc`, so this is safe.
+    pub fn draw(&self, render_pass: &mut wgpu::RenderPass<'static>, instance_count: u32) {
+        if instance_count == 0 {
+            return;
+        }
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_bind_group(0, &self.viewport_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        render_pass.set_vertex_buffer(1, self.instance_buffer.slice(..));
+        render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+        render_pass.draw_indexed(0..6, 0, 0..instance_count);
+    }
+}

--- a/crates/amux-render-gpu/src/pipeline.rs
+++ b/crates/amux-render-gpu/src/pipeline.rs
@@ -30,14 +30,15 @@ struct QuadVertex {
 }
 
 /// Background rendering pipeline: instanced colored quads for cell backgrounds.
+///
+/// Instance buffers are stored per-pane in `PaneRenderState`, not here.
+/// This struct holds the shared render pipeline, vertex/index buffers, and viewport uniform.
 pub struct BackgroundPipeline {
     pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
     index_buffer: wgpu::Buffer,
     viewport_buffer: wgpu::Buffer,
     viewport_bind_group: wgpu::BindGroup,
-    instance_buffer: wgpu::Buffer,
-    instance_capacity: usize,
 }
 
 impl BackgroundPipeline {
@@ -154,36 +155,17 @@ impl BackgroundPipeline {
             }],
         });
 
-        // Pre-allocate instance buffer for a typical terminal (200 cols × 50 rows)
-        let initial_capacity = 10_000;
-        let instance_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("bg_instance_buffer"),
-            size: (initial_capacity * std::mem::size_of::<CellBgInstance>()) as u64,
-            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
         Self {
             pipeline,
             vertex_buffer,
             index_buffer,
             viewport_buffer,
             viewport_bind_group,
-            instance_buffer,
-            instance_capacity: initial_capacity,
         }
     }
 
-    /// Upload instance data and viewport size. Returns the number of instances.
-    pub fn upload(
-        &mut self,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        instances: &[CellBgInstance],
-        viewport_width: f32,
-        viewport_height: f32,
-    ) -> u32 {
-        // Update viewport uniform
+    /// Update the viewport uniform.
+    pub fn upload_viewport(&self, queue: &wgpu::Queue, viewport_width: f32, viewport_height: f32) {
         queue.write_buffer(
             &self.viewport_buffer,
             0,
@@ -192,39 +174,22 @@ impl BackgroundPipeline {
                 _pad: [0.0; 2],
             }]),
         );
-
-        if instances.is_empty() {
-            return 0;
-        }
-
-        // Grow instance buffer if needed
-        if instances.len() > self.instance_capacity {
-            self.instance_capacity = instances.len().next_power_of_two();
-            self.instance_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-                label: Some("bg_instance_buffer"),
-                size: (self.instance_capacity * std::mem::size_of::<CellBgInstance>()) as u64,
-                usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
-                mapped_at_creation: false,
-            });
-        }
-
-        queue.write_buffer(&self.instance_buffer, 0, bytemuck::cast_slice(instances));
-        instances.len() as u32
     }
 
-    /// Record draw commands into a render pass.
-    ///
-    /// The `'static` lifetime on the render pass is required by egui_wgpu's
-    /// `CallbackTrait::paint()`. We use `wgpu::RenderPass::set_pipeline` etc.
-    /// which internally hold references via `Arc`, so this is safe.
-    pub fn draw(&self, render_pass: &mut wgpu::RenderPass<'static>, instance_count: u32) {
+    /// Record draw commands using a per-pane instance buffer.
+    pub fn draw(
+        &self,
+        render_pass: &mut wgpu::RenderPass<'static>,
+        instance_buffer: &wgpu::Buffer,
+        instance_count: u32,
+    ) {
         if instance_count == 0 {
             return;
         }
         render_pass.set_pipeline(&self.pipeline);
         render_pass.set_bind_group(0, &self.viewport_bind_group, &[]);
         render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
-        render_pass.set_vertex_buffer(1, self.instance_buffer.slice(..));
+        render_pass.set_vertex_buffer(1, instance_buffer.slice(..));
         render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
         render_pass.draw_indexed(0..6, 0, 0..instance_count);
     }
@@ -251,6 +216,8 @@ pub struct CellFgInstance {
 }
 
 /// Foreground rendering pipeline: instanced textured quads for glyphs.
+///
+/// Instance buffers are stored per-pane in `PaneRenderState`, not here.
 pub struct ForegroundPipeline {
     pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
@@ -259,8 +226,6 @@ pub struct ForegroundPipeline {
     viewport_bind_group: wgpu::BindGroup,
     atlas_bind_group_layout: wgpu::BindGroupLayout,
     atlas_bind_group: Option<wgpu::BindGroup>,
-    instance_buffer: wgpu::Buffer,
-    instance_capacity: usize,
 }
 
 impl ForegroundPipeline {
@@ -404,14 +369,6 @@ impl ForegroundPipeline {
             }],
         });
 
-        let initial_capacity = 10_000;
-        let instance_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("fg_instance_buffer"),
-            size: (initial_capacity * std::mem::size_of::<CellFgInstance>()) as u64,
-            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
         Self {
             pipeline,
             vertex_buffer,
@@ -420,8 +377,6 @@ impl ForegroundPipeline {
             viewport_bind_group,
             atlas_bind_group_layout,
             atlas_bind_group: None,
-            instance_buffer,
-            instance_capacity: initial_capacity,
         }
     }
 
@@ -448,15 +403,8 @@ impl ForegroundPipeline {
         }));
     }
 
-    /// Upload instance data and viewport size. Returns the number of instances.
-    pub fn upload(
-        &mut self,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        instances: &[CellFgInstance],
-        viewport_width: f32,
-        viewport_height: f32,
-    ) -> u32 {
+    /// Update the viewport uniform.
+    pub fn upload_viewport(&self, queue: &wgpu::Queue, viewport_width: f32, viewport_height: f32) {
         queue.write_buffer(
             &self.viewport_buffer,
             0,
@@ -465,27 +413,15 @@ impl ForegroundPipeline {
                 _pad: [0.0; 2],
             }]),
         );
-
-        if instances.is_empty() {
-            return 0;
-        }
-
-        if instances.len() > self.instance_capacity {
-            self.instance_capacity = instances.len().next_power_of_two();
-            self.instance_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-                label: Some("fg_instance_buffer"),
-                size: (self.instance_capacity * std::mem::size_of::<CellFgInstance>()) as u64,
-                usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
-                mapped_at_creation: false,
-            });
-        }
-
-        queue.write_buffer(&self.instance_buffer, 0, bytemuck::cast_slice(instances));
-        instances.len() as u32
     }
 
-    /// Record draw commands into a render pass.
-    pub fn draw(&self, render_pass: &mut wgpu::RenderPass<'static>, instance_count: u32) {
+    /// Record draw commands using a per-pane instance buffer.
+    pub fn draw(
+        &self,
+        render_pass: &mut wgpu::RenderPass<'static>,
+        instance_buffer: &wgpu::Buffer,
+        instance_count: u32,
+    ) {
         if instance_count == 0 {
             return;
         }
@@ -496,8 +432,29 @@ impl ForegroundPipeline {
         render_pass.set_bind_group(0, &self.viewport_bind_group, &[]);
         render_pass.set_bind_group(1, atlas_bind_group, &[]);
         render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
-        render_pass.set_vertex_buffer(1, self.instance_buffer.slice(..));
+        render_pass.set_vertex_buffer(1, instance_buffer.slice(..));
         render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
         render_pass.draw_indexed(0..6, 0, 0..instance_count);
     }
+}
+
+/// Create or grow an instance buffer if needed. Returns the buffer and its capacity.
+pub fn ensure_instance_buffer<T: Pod>(
+    device: &wgpu::Device,
+    existing: Option<&wgpu::Buffer>,
+    existing_capacity: usize,
+    required: usize,
+    label: &str,
+) -> Option<(wgpu::Buffer, usize)> {
+    if required <= existing_capacity && existing.is_some() {
+        return None; // existing buffer is fine
+    }
+    let new_capacity = required.max(1024).next_power_of_two();
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        size: (new_capacity * std::mem::size_of::<T>()) as u64,
+        usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    Some((buffer, new_capacity))
 }

--- a/crates/amux-render-gpu/src/shaders/background.wgsl
+++ b/crates/amux-render-gpu/src/shaders/background.wgsl
@@ -1,0 +1,52 @@
+// Background pass: renders one colored quad per terminal cell with a non-default background.
+// Uses instancing: the unit quad vertices are shared, per-instance data provides position/size/color.
+
+struct Viewport {
+    // Viewport size in physical pixels.
+    size: vec2<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> viewport: Viewport;
+
+struct VertexInput {
+    // Unit quad vertex position (0..1).
+    @location(0) vertex_pos: vec2<f32>,
+}
+
+struct InstanceInput {
+    // Cell position in physical pixels (top-left corner).
+    @location(1) cell_pos: vec2<f32>,
+    // Cell size in physical pixels.
+    @location(2) cell_size: vec2<f32>,
+    // Cell background color (linear RGBA).
+    @location(3) color: vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) color: vec4<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput, instance: InstanceInput) -> VertexOutput {
+    // Scale unit quad to cell size and translate to cell position.
+    let pixel_pos = instance.cell_pos + vertex.vertex_pos * instance.cell_size;
+
+    // Convert pixel coordinates to NDC: (0,0) = top-left, (w,h) = bottom-right
+    // NDC range: x [-1, 1], y [-1, 1] (y up in NDC, y down in screen)
+    let ndc = vec2<f32>(
+        pixel_pos.x / viewport.size.x * 2.0 - 1.0,
+        1.0 - pixel_pos.y / viewport.size.y * 2.0,
+    );
+
+    var out: VertexOutput;
+    out.clip_pos = vec4<f32>(ndc, 0.0, 1.0);
+    out.color = instance.color;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return in.color;
+}

--- a/crates/amux-render-gpu/src/shaders/foreground.wgsl
+++ b/crates/amux-render-gpu/src/shaders/foreground.wgsl
@@ -1,7 +1,7 @@
 // Foreground pass: renders one textured quad per visible glyph.
 // Uses instancing: unit quad vertices are shared, per-instance data provides
-// position/size/UV/color. The atlas texture contains alpha masks; the fragment
-// shader multiplies the sampled alpha by the instance foreground color.
+// position/size/UV/color. Supports both monochrome (alpha-only) and color (emoji)
+// atlas textures, selected by the is_color instance flag.
 
 struct Viewport {
     size: vec2<f32>,
@@ -11,8 +11,10 @@ struct Viewport {
 var<uniform> viewport: Viewport;
 
 @group(1) @binding(0)
-var atlas_texture: texture_2d<f32>;
+var mono_atlas: texture_2d<f32>;
 @group(1) @binding(1)
+var color_atlas: texture_2d<f32>;
+@group(1) @binding(2)
 var atlas_sampler: sampler;
 
 struct VertexInput {
@@ -29,12 +31,15 @@ struct InstanceInput {
     @location(4) uv_max: vec2<f32>,
     // Foreground color (linear RGBA).
     @location(5) color: vec4<f32>,
+    // is_color flag (x component): 1.0 = color emoji, 0.0 = monochrome.
+    @location(6) is_color_pad: vec4<f32>,
 }
 
 struct VertexOutput {
     @builtin(position) clip_pos: vec4<f32>,
     @location(0) uv: vec2<f32>,
     @location(1) color: vec4<f32>,
+    @location(2) is_color: f32,
 }
 
 @vertex
@@ -53,11 +58,19 @@ fn vs_main(vertex: VertexInput, instance: InstanceInput) -> VertexOutput {
     out.clip_pos = vec4<f32>(ndc, 0.0, 1.0);
     out.uv = uv;
     out.color = instance.color;
+    out.is_color = instance.is_color_pad.x;
     return out;
 }
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    let alpha = textureSample(atlas_texture, atlas_sampler, in.uv).r;
-    return vec4<f32>(in.color.rgb * alpha, alpha * in.color.a);
+    if in.is_color > 0.5 {
+        // Color emoji: sample RGBA directly from color atlas, premultiply alpha.
+        let texel = textureSample(color_atlas, atlas_sampler, in.uv);
+        return vec4<f32>(texel.rgb * texel.a, texel.a);
+    } else {
+        // Monochrome glyph: sample alpha from mono atlas, multiply by fg color.
+        let alpha = textureSample(mono_atlas, atlas_sampler, in.uv).r;
+        return vec4<f32>(in.color.rgb * alpha, alpha * in.color.a);
+    }
 }

--- a/crates/amux-render-gpu/src/shaders/foreground.wgsl
+++ b/crates/amux-render-gpu/src/shaders/foreground.wgsl
@@ -1,0 +1,63 @@
+// Foreground pass: renders one textured quad per visible glyph.
+// Uses instancing: unit quad vertices are shared, per-instance data provides
+// position/size/UV/color. The atlas texture contains alpha masks; the fragment
+// shader multiplies the sampled alpha by the instance foreground color.
+
+struct Viewport {
+    size: vec2<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> viewport: Viewport;
+
+@group(1) @binding(0)
+var atlas_texture: texture_2d<f32>;
+@group(1) @binding(1)
+var atlas_sampler: sampler;
+
+struct VertexInput {
+    @location(0) vertex_pos: vec2<f32>,
+}
+
+struct InstanceInput {
+    // Glyph position in physical pixels (top-left corner).
+    @location(1) glyph_pos: vec2<f32>,
+    // Glyph size in physical pixels.
+    @location(2) glyph_size: vec2<f32>,
+    // Atlas UV coordinates: [u_min, v_min, u_max, v_max].
+    @location(3) uv_min: vec2<f32>,
+    @location(4) uv_max: vec2<f32>,
+    // Foreground color (linear RGBA).
+    @location(5) color: vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) color: vec4<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput, instance: InstanceInput) -> VertexOutput {
+    let pixel_pos = instance.glyph_pos + vertex.vertex_pos * instance.glyph_size;
+
+    let ndc = vec2<f32>(
+        pixel_pos.x / viewport.size.x * 2.0 - 1.0,
+        1.0 - pixel_pos.y / viewport.size.y * 2.0,
+    );
+
+    // Interpolate UV from min to max across the unit quad.
+    let uv = mix(instance.uv_min, instance.uv_max, vertex.vertex_pos);
+
+    var out: VertexOutput;
+    out.clip_pos = vec4<f32>(ndc, 0.0, 1.0);
+    out.uv = uv;
+    out.color = instance.color;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let alpha = textureSample(atlas_texture, atlas_sampler, in.uv).r;
+    return vec4<f32>(in.color.rgb * alpha, alpha * in.color.a);
+}

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -1,0 +1,105 @@
+use wezterm_term::color::{ColorAttribute, ColorPalette, SrgbaTuple};
+use wezterm_term::CursorPosition;
+
+/// Pre-extracted terminal state for GPU rendering.
+///
+/// Built on the main thread (where the terminal screen borrow is held),
+/// then moved into the paint callback which must be `Send + Sync`.
+pub struct TerminalSnapshot {
+    pub cols: usize,
+    pub rows: usize,
+    pub cells: Vec<CellData>,
+    pub cursor: CursorPosition,
+    pub default_bg: [f32; 4],
+    pub cursor_color: [f32; 4],
+}
+
+/// Data for a single terminal cell.
+pub struct CellData {
+    pub col: usize,
+    pub row: usize,
+    pub text: String,
+    pub fg: [f32; 4],
+    pub bg: [f32; 4],
+    pub bold: bool,
+    pub italic: bool,
+}
+
+impl TerminalSnapshot {
+    /// Extract a snapshot from the terminal screen.
+    ///
+    /// `scroll_offset` is the number of lines scrolled back from the bottom.
+    pub fn from_screen(
+        screen: &wezterm_term::screen::Screen,
+        palette: &ColorPalette,
+        cursor: &CursorPosition,
+        cols: usize,
+        rows: usize,
+        scroll_offset: usize,
+    ) -> Self {
+        let default_bg = srgba_to_f32(palette.background);
+        let cursor_color = srgba_to_f32(palette.cursor_bg);
+
+        let total = screen.scrollback_rows();
+        let end = total.saturating_sub(scroll_offset);
+        let start = end.saturating_sub(rows);
+        let lines = screen.lines_in_phys_range(start..end);
+
+        let mut cells = Vec::with_capacity(cols * rows);
+
+        for (row_idx, line) in lines.iter().enumerate() {
+            for cell_ref in line.visible_cells() {
+                let col_idx = cell_ref.cell_index();
+                if col_idx >= cols {
+                    break;
+                }
+
+                let attrs = cell_ref.attrs();
+                let reverse = attrs.reverse();
+
+                let fg_attr = attrs.foreground();
+                let bg_attr = attrs.background();
+
+                let fg_color = resolve_color(&fg_attr, palette, true, reverse);
+                let bg_color = resolve_color(&bg_attr, palette, false, reverse);
+
+                cells.push(CellData {
+                    col: col_idx,
+                    row: row_idx,
+                    text: cell_ref.str().to_string(),
+                    fg: srgba_to_f32(fg_color),
+                    bg: srgba_to_f32(bg_color),
+                    bold: attrs.intensity() == wezterm_term::Intensity::Bold,
+                    italic: attrs.italic(),
+                });
+            }
+        }
+
+        Self {
+            cols,
+            rows,
+            cells,
+            cursor: *cursor,
+            default_bg,
+            cursor_color,
+        }
+    }
+}
+
+fn resolve_color(
+    color: &ColorAttribute,
+    palette: &ColorPalette,
+    is_fg: bool,
+    reverse: bool,
+) -> SrgbaTuple {
+    let effective_is_fg = if reverse { !is_fg } else { is_fg };
+    if effective_is_fg {
+        palette.resolve_fg(*color)
+    } else {
+        palette.resolve_bg(*color)
+    }
+}
+
+fn srgba_to_f32(c: SrgbaTuple) -> [f32; 4] {
+    [c.0, c.1, c.2, c.3]
+}

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -21,6 +21,7 @@ pub struct TerminalSnapshot {
     /// Text under the cursor (for block cursor rendering).
     pub cursor_text: String,
     pub cursor_text_bold: bool,
+    pub cursor_text_italic: bool,
     /// Selection start/end for dirty tracking (None if no selection).
     pub selection_range: Option<((usize, usize), (usize, usize))>,
 }
@@ -92,6 +93,7 @@ impl TerminalSnapshot {
         let mut cells = Vec::with_capacity(cols * rows);
         let mut cursor_text = String::new();
         let mut cursor_text_bold = false;
+        let mut cursor_text_italic = false;
 
         for (row_idx, line) in lines.iter().enumerate() {
             for cell_ref in line.visible_cells() {
@@ -130,6 +132,7 @@ impl TerminalSnapshot {
                     if !text.is_empty() && text != " " {
                         cursor_text = text.to_string();
                         cursor_text_bold = attrs.intensity() == wezterm_term::Intensity::Bold;
+                        cursor_text_italic = attrs.italic();
                     }
                 }
 
@@ -160,6 +163,7 @@ impl TerminalSnapshot {
             scroll_offset,
             cursor_text,
             cursor_text_bold,
+            cursor_text_italic,
             selection_range,
         }
     }

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -6,6 +6,8 @@ use wezterm_term::CursorPosition;
 /// Built on the main thread (where the terminal screen borrow is held),
 /// then moved into the paint callback which must be `Send + Sync`.
 pub struct TerminalSnapshot {
+    pub pane_id: u64,
+    pub seqno: usize,
     pub cols: usize,
     pub rows: usize,
     pub cells: Vec<CellData>,
@@ -19,6 +21,8 @@ pub struct TerminalSnapshot {
     /// Text under the cursor (for block cursor rendering).
     pub cursor_text: String,
     pub cursor_text_bold: bool,
+    /// Whether a selection is active (used for dirty tracking).
+    pub has_selection: bool,
 }
 
 /// Data for a single terminal cell.
@@ -71,7 +75,10 @@ impl TerminalSnapshot {
         scroll_offset: usize,
         is_focused: bool,
         selection: Option<SelectionRange>,
+        pane_id: u64,
+        seqno: usize,
     ) -> Self {
+        let has_selection = selection.is_some();
         let default_bg = srgba_to_f32(palette.background);
         let default_fg = srgba_to_f32(palette.foreground);
         let cursor_bg = srgba_to_f32(palette.cursor_bg);
@@ -139,6 +146,8 @@ impl TerminalSnapshot {
         }
 
         Self {
+            pane_id,
+            seqno,
             cols,
             rows,
             cells,
@@ -151,6 +160,7 @@ impl TerminalSnapshot {
             scroll_offset,
             cursor_text,
             cursor_text_bold,
+            has_selection,
         }
     }
 }

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -11,7 +11,14 @@ pub struct TerminalSnapshot {
     pub cells: Vec<CellData>,
     pub cursor: CursorPosition,
     pub default_bg: [f32; 4],
-    pub cursor_color: [f32; 4],
+    pub default_fg: [f32; 4],
+    pub cursor_bg: [f32; 4],
+    pub cursor_fg: [f32; 4],
+    pub is_focused: bool,
+    pub scroll_offset: usize,
+    /// Text under the cursor (for block cursor rendering).
+    pub cursor_text: String,
+    pub cursor_text_bold: bool,
 }
 
 /// Data for a single terminal cell.
@@ -25,10 +32,36 @@ pub struct CellData {
     pub italic: bool,
 }
 
+/// Selection range for highlight rendering.
+pub struct SelectionRange {
+    pub start: (usize, usize), // (col, stable_row)
+    pub end: (usize, usize),   // (col, stable_row)
+}
+
+impl SelectionRange {
+    fn contains(&self, col: usize, stable_row: usize) -> bool {
+        if stable_row < self.start.1 || stable_row > self.end.1 {
+            return false;
+        }
+        if stable_row == self.start.1 && stable_row == self.end.1 {
+            return col >= self.start.0 && col <= self.end.0;
+        }
+        if stable_row == self.start.1 {
+            return col >= self.start.0;
+        }
+        if stable_row == self.end.1 {
+            return col <= self.end.0;
+        }
+        true
+    }
+}
+
 impl TerminalSnapshot {
     /// Extract a snapshot from the terminal screen.
     ///
     /// `scroll_offset` is the number of lines scrolled back from the bottom.
+    /// `selection` is an optional normalized selection range for highlight rendering.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_screen(
         screen: &wezterm_term::screen::Screen,
         palette: &ColorPalette,
@@ -36,9 +69,13 @@ impl TerminalSnapshot {
         cols: usize,
         rows: usize,
         scroll_offset: usize,
+        is_focused: bool,
+        selection: Option<SelectionRange>,
     ) -> Self {
         let default_bg = srgba_to_f32(palette.background);
-        let cursor_color = srgba_to_f32(palette.cursor_bg);
+        let default_fg = srgba_to_f32(palette.foreground);
+        let cursor_bg = srgba_to_f32(palette.cursor_bg);
+        let cursor_fg = srgba_to_f32(palette.cursor_fg);
 
         let total = screen.scrollback_rows();
         let end = total.saturating_sub(scroll_offset);
@@ -46,6 +83,8 @@ impl TerminalSnapshot {
         let lines = screen.lines_in_phys_range(start..end);
 
         let mut cells = Vec::with_capacity(cols * rows);
+        let mut cursor_text = String::new();
+        let mut cursor_text_bold = false;
 
         for (row_idx, line) in lines.iter().enumerate() {
             for cell_ref in line.visible_cells() {
@@ -57,18 +96,42 @@ impl TerminalSnapshot {
                 let attrs = cell_ref.attrs();
                 let reverse = attrs.reverse();
 
-                let fg_attr = attrs.foreground();
-                let bg_attr = attrs.background();
+                let mut fg = resolve_color(&attrs.foreground(), palette, true, reverse);
+                let mut bg = resolve_color(&attrs.background(), palette, false, reverse);
 
-                let fg_color = resolve_color(&fg_attr, palette, true, reverse);
-                let bg_color = resolve_color(&bg_attr, palette, false, reverse);
+                // Apply selection highlighting (swap fg/bg)
+                let stable_row = start + row_idx;
+                if let Some(ref sel) = selection {
+                    if sel.contains(col_idx, stable_row) {
+                        std::mem::swap(&mut fg, &mut bg);
+                        // Ensure selected empty cells have visible bg
+                        let fg_f32 = srgba_to_f32(fg);
+                        let bg_f32 = srgba_to_f32(bg);
+                        if bg_f32 == default_bg {
+                            bg = palette.foreground;
+                            fg = palette.background;
+                        } else {
+                            // Use already-swapped values
+                            let _ = (fg_f32, bg_f32);
+                        }
+                    }
+                }
+
+                // Capture text under cursor for block cursor rendering
+                if row_idx == cursor.y as usize && col_idx == cursor.x {
+                    let text = cell_ref.str();
+                    if !text.is_empty() && text != " " {
+                        cursor_text = text.to_string();
+                        cursor_text_bold = attrs.intensity() == wezterm_term::Intensity::Bold;
+                    }
+                }
 
                 cells.push(CellData {
                     col: col_idx,
                     row: row_idx,
                     text: cell_ref.str().to_string(),
-                    fg: srgba_to_f32(fg_color),
-                    bg: srgba_to_f32(bg_color),
+                    fg: srgba_to_f32(fg),
+                    bg: srgba_to_f32(bg),
                     bold: attrs.intensity() == wezterm_term::Intensity::Bold,
                     italic: attrs.italic(),
                 });
@@ -81,7 +144,13 @@ impl TerminalSnapshot {
             cells,
             cursor: *cursor,
             default_bg,
-            cursor_color,
+            default_fg,
+            cursor_bg,
+            cursor_fg,
+            is_focused,
+            scroll_offset,
+            cursor_text,
+            cursor_text_bold,
         }
     }
 }

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -21,8 +21,8 @@ pub struct TerminalSnapshot {
     /// Text under the cursor (for block cursor rendering).
     pub cursor_text: String,
     pub cursor_text_bold: bool,
-    /// Whether a selection is active (used for dirty tracking).
-    pub has_selection: bool,
+    /// Selection start/end for dirty tracking (None if no selection).
+    pub selection_range: Option<((usize, usize), (usize, usize))>,
 }
 
 /// Data for a single terminal cell.
@@ -78,7 +78,7 @@ impl TerminalSnapshot {
         pane_id: u64,
         seqno: usize,
     ) -> Self {
-        let has_selection = selection.is_some();
+        let selection_range = selection.as_ref().map(|s| (s.start, s.end));
         let default_bg = srgba_to_f32(palette.background);
         let default_fg = srgba_to_f32(palette.foreground);
         let cursor_bg = srgba_to_f32(palette.cursor_bg);
@@ -160,7 +160,7 @@ impl TerminalSnapshot {
             scroll_offset,
             cursor_text,
             cursor_text_bold,
-            has_selection,
+            selection_range,
         }
     }
 }
@@ -179,6 +179,24 @@ fn resolve_color(
     }
 }
 
+/// Convert sRGB color from wezterm-term to linear RGB for GPU shaders.
+///
+/// The GPU pipeline outputs to an sRGB surface (e.g., Bgra8UnormSrgb),
+/// which applies gamma encoding on write. Colors must be linear in the
+/// shader to avoid double-gamma.
 fn srgba_to_f32(c: SrgbaTuple) -> [f32; 4] {
-    [c.0, c.1, c.2, c.3]
+    [
+        srgb_to_linear(c.0),
+        srgb_to_linear(c.1),
+        srgb_to_linear(c.2),
+        c.3,
+    ]
+}
+
+fn srgb_to_linear(v: f32) -> f32 {
+    if v <= 0.04045 {
+        v / 12.92
+    } else {
+        ((v + 0.055) / 1.055).powf(2.4)
+    }
 }


### PR DESCRIPTION
## Summary

- Add wgpu-based GPU renderer using instanced quad drawing inside egui's render pass via `CallbackTrait`
- Two-pass rendering: background colored quads + foreground textured glyph quads from a dual-texture glyph atlas (mono R8 + color RGBA for emoji)
- `TerminalSnapshot` pattern extracts terminal state into `Send + Sync` struct on the main thread for the paint callback
- Per-pane instance buffers with seqno-based dirty tracking to skip rebuilds when content is unchanged
- Cursor rendering (block/bar/underline), selection highlighting (fg/bg swap), color emoji support
- Behind `gpu-renderer` feature flag (default on); `--no-default-features` falls back to existing egui painter

## Sub-commits
- **8a**: Scaffolding — feature flag, `CreationContext` capture, empty callback
- **8b**: Background pass — instanced colored quads for cell backgrounds  
- **8c**: Glyph atlas + foreground pass — cosmic-text shaping, swash rasterization, R8 atlas
- **8d**: Cursor, selection, scroll indicator
- **8e**: Per-pane instance buffers (fixes multi-pane rendering) + dirty tracking
- **8f**: Color emoji — dual atlas textures (R8Unorm + Rgba8UnormSrgb), shader branching

## Test plan
- [ ] `cargo build --workspace` succeeds
- [ ] `cargo build -p amux-app --no-default-features` (soft renderer fallback) succeeds
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo test --workspace` passes
- [ ] Visual: `vim`, `htop`, `ls --color` render correctly with GPU path
- [ ] Visual: cursor shapes (block, bar, underline) render correctly
- [ ] Visual: text selection highlights correctly
- [ ] Visual: emoji (`echo "🦀"`) renders via color atlas
- [ ] Visual: split panes render independently (no buffer overwrite)
- [ ] Idle terminal has near-zero GPU instance rebuild (dirty tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional GPU-accelerated terminal rendering for panes, offering faster, smoother display with glyph caching and texture atlasing.
  * Automatic GPU resource cleanup for closed panes to reduce memory usage.
  * Improved cell measurement to better align text and cursor rendering across backends.

* **Chores**
  * Build configuration updated to expose the GPU renderer as a toggleable feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->