### PR TITLE
Phase 8: GPU-accelerated terminal renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "amux-ipc",
  "amux-layout",
  "amux-notify",
+ "amux-render-gpu",
  "amux-session",
  "amux-term",
  "anyhow",
@@ -153,6 +154,16 @@ dependencies = [
 [[package]]
 name = "amux-render-gpu"
 version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "cosmic-text",
+ "egui",
+ "egui-wgpu",
+ "tracing",
+ "wezterm-surface",
+ "wezterm-term",
+ "wgpu",
+]
 
 [[package]]
 name = "amux-render-soft"
@@ -1504,6 +1515,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "windows",
 ]
 
 [[package]]
@@ -2904,6 +2927,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3044,6 +3073,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "rangemap"
@@ -4735,6 +4770,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
+ "bit-set",
  "bitflags 2.11.0",
  "block",
  "bytemuck",
@@ -4743,6 +4779,7 @@ dependencies = [
  "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
+ "gpu-allocator",
  "gpu-descriptor",
  "js-sys",
  "khronos-egl",
@@ -4757,6 +4794,7 @@ dependencies = [
  "ordered-float",
  "parking_lot",
  "profiling",
+ "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
  "rustc-hash 1.1.0",
@@ -4766,6 +4804,7 @@ dependencies = [
  "web-sys",
  "wgpu-types",
  "windows",
+ "windows-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,11 @@ egui = "0.31"
 # Font rendering
 cosmic-text = "0.12"
 
+# GPU rendering
+wgpu = "24.0"
+egui-wgpu = "0.31"
+bytemuck = { version = "1", features = ["derive"] }
+
 # Clipboard
 arboard = "3"
 

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -5,8 +5,13 @@ edition.workspace = true
 license.workspace = true
 description = "amux main binary: GUI + event loop"
 
+[features]
+default = ["gpu-renderer"]
+gpu-renderer = ["dep:amux-render-gpu"]
+
 [dependencies]
 amux-term = { workspace = true }
+amux-render-gpu = { workspace = true, optional = true }
 wezterm-term = { workspace = true }
 wezterm-surface = { workspace = true }
 eframe = { workspace = true }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -18,8 +18,12 @@ use portable_pty::CommandBuilder;
 use wezterm_surface::{CursorShape, CursorVisibility};
 use wezterm_term::color::SrgbaTuple;
 
+#[cfg(feature = "gpu-renderer")]
+use amux_render_gpu::GpuRenderer;
+
 /// Try to get the current working directory of a process by PID.
 /// Falls back across platform-specific mechanisms.
+#[allow(unused_variables)]
 fn get_cwd_from_pid(pid: u32) -> Option<String> {
     // Linux: readlink /proc/{pid}/cwd
     #[cfg(target_os = "linux")]
@@ -98,6 +102,12 @@ fn main() -> anyhow::Result<()> {
         "amux",
         options,
         Box::new(move |_cc| {
+            #[cfg(feature = "gpu-renderer")]
+            let gpu_renderer = _cc.wgpu_render_state.as_ref().map(|rs| {
+                tracing::info!("GPU renderer initialized (wgpu backend)");
+                GpuRenderer::new(rs.clone(), FONT_SIZE)
+            });
+
             Ok(Box::new(AmuxApp {
                 workspaces: state.workspaces,
                 active_workspace_idx: state.active_workspace_idx,
@@ -116,6 +126,8 @@ fn main() -> anyhow::Result<()> {
                 last_click_pos: egui::Pos2::ZERO,
                 click_count: 0,
                 wants_exit: false,
+                #[cfg(feature = "gpu-renderer")]
+                gpu_renderer,
             }))
         }),
     )
@@ -559,9 +571,28 @@ struct AmuxApp {
     last_click_pos: egui::Pos2,
     click_count: u32,
     wants_exit: bool,
+    #[cfg(feature = "gpu-renderer")]
+    gpu_renderer: Option<GpuRenderer>,
 }
 
 impl AmuxApp {
+    /// Get cell dimensions in logical points, using GPU renderer measurements
+    /// when available, falling back to egui font measurements.
+    fn cell_dimensions(&self, ui: &egui::Ui) -> (f32, f32) {
+        #[cfg(feature = "gpu-renderer")]
+        if let Some(gpu) = &self.gpu_renderer {
+            let cw = gpu.cell_width();
+            let ch = gpu.cell_height();
+            if cw > 0.0 && ch > 0.0 {
+                return (cw, ch);
+            }
+        }
+        let font_id = egui::FontId::monospace(FONT_SIZE);
+        let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
+        let cell_height = ui.fonts(|f| f.row_height(&font_id));
+        (cell_width, cell_height)
+    }
+
     fn active_workspace(&self) -> &Workspace {
         &self.workspaces[self.active_workspace_idx]
     }
@@ -896,6 +927,13 @@ impl eframe::App for AmuxApp {
             }
         }
 
+        // Clean up GPU resources for closed panes.
+        #[cfg(feature = "gpu-renderer")]
+        if let Some(ref gpu) = self.gpu_renderer {
+            let live_ids: Vec<u64> = self.panes.keys().copied().collect();
+            gpu.retain_panes(&live_ids);
+        }
+
         // Smart repaint
         if got_data {
             ctx.request_repaint();
@@ -1105,6 +1143,10 @@ impl AmuxApp {
             is_focused,
             surface.scroll_offset,
             selection.as_ref(),
+            #[cfg(feature = "gpu-renderer")]
+            self.gpu_renderer.as_ref(),
+            #[cfg(feature = "gpu-renderer")]
+            pane_id,
         );
 
         // Notification ring + flash animation (matching cmux)
@@ -1315,9 +1357,7 @@ impl AmuxApp {
     // --- Resize ---
 
     fn resize_pane_if_needed(&mut self, id: PaneId, rect: egui::Rect, ui: &egui::Ui) {
-        let font_id = egui::FontId::monospace(FONT_SIZE);
-        let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
-        let cell_height = ui.fonts(|f| f.row_height(&font_id));
+        let (cell_width, cell_height) = self.cell_dimensions(ui);
 
         // Account for tab bar height (always shown)
         let content_height = rect.height() - TAB_BAR_HEIGHT;
@@ -2221,9 +2261,7 @@ impl AmuxApp {
     // --- Selection Mouse ---
 
     fn handle_selection_mouse(&mut self, ui: &egui::Ui, pane_id: PaneId, content_rect: egui::Rect) {
-        let font_id = egui::FontId::monospace(FONT_SIZE);
-        let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
-        let cell_height = ui.fonts(|f| f.row_height(&font_id));
+        let (cell_width, cell_height) = self.cell_dimensions(ui);
 
         let managed = match self.panes.get(&pane_id) {
             Some(m) => m,
@@ -3171,6 +3209,7 @@ fn line_text_string(pane: &TerminalPane, stable_row: usize, cols: usize) -> Stri
 
 // --- Rendering ---
 
+#[allow(clippy::too_many_arguments)]
 fn render_pane(
     ui: &mut egui::Ui,
     pane: &mut TerminalPane,
@@ -3178,7 +3217,42 @@ fn render_pane(
     is_focused: bool,
     scroll_offset: usize,
     selection: Option<&SelectionState>,
+    #[cfg(feature = "gpu-renderer")] gpu_renderer: Option<&GpuRenderer>,
+    #[cfg(feature = "gpu-renderer")] pane_id: u64,
 ) {
+    // GPU renderer path: build snapshot, emit a paint callback, and return early.
+    #[cfg(feature = "gpu-renderer")]
+    if let Some(gpu) = gpu_renderer {
+        let (actual_cols, actual_rows) = pane.dimensions();
+        if actual_cols == 0 || actual_rows == 0 {
+            return;
+        }
+        let palette = pane.palette();
+        let cursor = pane.cursor();
+        let screen = pane.screen();
+        let gpu_selection = selection.map(|sel| {
+            let (start, end) = sel.normalized();
+            amux_render_gpu::snapshot::SelectionRange { start, end }
+        });
+        let seqno = pane.current_seqno();
+        let snapshot = amux_render_gpu::TerminalSnapshot::from_screen(
+            screen,
+            &palette,
+            &cursor,
+            actual_cols,
+            actual_rows,
+            scroll_offset,
+            is_focused,
+            gpu_selection,
+            pane_id,
+            seqno,
+        );
+        let pixels_per_point = ui.ctx().pixels_per_point();
+        let callback = gpu.paint_callback(rect, snapshot, pixels_per_point);
+        ui.painter().add(egui::Shape::Callback(callback));
+        return;
+    }
+
     let font_id = egui::FontId::monospace(FONT_SIZE);
     let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
     let cell_height = ui.fonts(|f| f.row_height(&font_id));

--- a/crates/amux-render-gpu/Cargo.toml
+++ b/crates/amux-render-gpu/Cargo.toml
@@ -6,3 +6,11 @@ license.workspace = true
 description = "amux wgpu + cosmic-text GPU renderer"
 
 [dependencies]
+wgpu = { workspace = true }
+egui-wgpu = { workspace = true }
+egui = { workspace = true }
+wezterm-term = { workspace = true }
+cosmic-text = { workspace = true }
+bytemuck = { workspace = true }
+tracing = { workspace = true }
+wezterm-surface = { workspace = true }

--- a/crates/amux-render-gpu/src/atlas.rs
+++ b/crates/amux-render-gpu/src/atlas.rs
@@ -1,0 +1,282 @@
+use std::collections::HashMap;
+
+use cosmic_text::{CacheKey, FontSystem, SwashCache, SwashContent, SwashImage};
+use egui_wgpu::wgpu;
+
+/// A single glyph's location in the atlas texture.
+#[derive(Clone, Copy)]
+pub struct AtlasEntry {
+    /// UV coordinates in the atlas: [u_min, v_min, u_max, v_max] in 0..1 range.
+    pub uv: [f32; 4],
+    /// Glyph placement offset from cell origin (in pixels).
+    pub placement_left: i32,
+    pub placement_top: i32,
+    /// Glyph pixel dimensions.
+    pub width: u32,
+    pub height: u32,
+    /// Whether this glyph is a color glyph (emoji) vs monochrome.
+    pub is_color: bool,
+}
+
+/// Shelf in the shelf-packing algorithm.
+struct Shelf {
+    y: u32,
+    height: u32,
+    x_cursor: u32,
+}
+
+/// A single atlas page (texture + shelf packer).
+struct AtlasPage {
+    texture: wgpu::Texture,
+    texture_view: wgpu::TextureView,
+    size: u32,
+    shelves: Vec<Shelf>,
+    bytes_per_pixel: u32,
+}
+
+impl AtlasPage {
+    fn new(
+        device: &wgpu::Device,
+        size: u32,
+        format: wgpu::TextureFormat,
+        label: &str,
+        bytes_per_pixel: u32,
+    ) -> Self {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some(label),
+            size: wgpu::Extent3d {
+                width: size,
+                height: size,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        Self {
+            texture,
+            texture_view,
+            size,
+            shelves: Vec::new(),
+            bytes_per_pixel,
+        }
+    }
+
+    fn allocate(&mut self, w: u32, h: u32) -> Option<(u32, u32)> {
+        // Try to fit in an existing shelf.
+        for shelf in &mut self.shelves {
+            if h <= shelf.height && shelf.x_cursor + w <= self.size {
+                let x = shelf.x_cursor;
+                let y = shelf.y;
+                shelf.x_cursor += w + 1;
+                return Some((x, y));
+            }
+        }
+
+        // Create a new shelf.
+        let shelf_y = self.shelves.last().map(|s| s.y + s.height + 1).unwrap_or(0);
+
+        if shelf_y + h > self.size || w > self.size {
+            tracing::warn!("Atlas page full, cannot allocate {}x{}", w, h);
+            return None;
+        }
+
+        self.shelves.push(Shelf {
+            y: shelf_y,
+            height: h,
+            x_cursor: w + 1,
+        });
+        Some((0, shelf_y))
+    }
+
+    fn upload_region(&self, queue: &wgpu::Queue, x: u32, y: u32, w: u32, h: u32, data: &[u8]) {
+        let unpadded_bytes_per_row = w * self.bytes_per_pixel;
+        let alignment = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(alignment) * alignment;
+
+        let copy_info = wgpu::TexelCopyTextureInfo {
+            texture: &self.texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d { x, y, z: 0 },
+            aspect: wgpu::TextureAspect::All,
+        };
+        let extent = wgpu::Extent3d {
+            width: w,
+            height: h,
+            depth_or_array_layers: 1,
+        };
+
+        if padded_bytes_per_row == unpadded_bytes_per_row || h <= 1 {
+            // Data is already aligned or single row — upload directly.
+            queue.write_texture(
+                copy_info,
+                data,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bytes_per_row),
+                    rows_per_image: Some(h),
+                },
+                extent,
+            );
+        } else {
+            // Pad each row to satisfy wgpu alignment requirements.
+            let mut padded = vec![0u8; (padded_bytes_per_row * h) as usize];
+            let row_size = unpadded_bytes_per_row as usize;
+            let padded_row_size = padded_bytes_per_row as usize;
+            for row in 0..h as usize {
+                padded[row * padded_row_size..row * padded_row_size + row_size]
+                    .copy_from_slice(&data[row * row_size..row * row_size + row_size]);
+            }
+            queue.write_texture(
+                copy_info,
+                &padded,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded_bytes_per_row),
+                    rows_per_image: Some(h),
+                },
+                extent,
+            );
+        }
+    }
+}
+
+/// GPU glyph atlas using shelf-packing with dual textures.
+///
+/// Monochrome glyphs use an R8Unorm texture (alpha-only).
+/// Color glyphs (emoji) use an Rgba8UnormSrgb texture.
+pub struct GlyphAtlas {
+    mono: AtlasPage,
+    color: AtlasPage,
+    pub sampler: wgpu::Sampler,
+    cache: HashMap<CacheKey, Option<AtlasEntry>>,
+}
+
+impl GlyphAtlas {
+    /// Create a new glyph atlas with the given texture size.
+    pub fn new(device: &wgpu::Device, size: u32) -> Self {
+        let mono = AtlasPage::new(
+            device,
+            size,
+            wgpu::TextureFormat::R8Unorm,
+            "glyph_atlas_mono",
+            1,
+        );
+        let color = AtlasPage::new(
+            device,
+            size,
+            wgpu::TextureFormat::Rgba8UnormSrgb,
+            "glyph_atlas_color",
+            4,
+        );
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("glyph_atlas_sampler"),
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            ..Default::default()
+        });
+
+        Self {
+            mono,
+            color,
+            sampler,
+            cache: HashMap::new(),
+        }
+    }
+
+    /// Get the monochrome atlas texture view.
+    pub fn mono_texture_view(&self) -> &wgpu::TextureView {
+        &self.mono.texture_view
+    }
+
+    /// Get the color atlas texture view.
+    pub fn color_texture_view(&self) -> &wgpu::TextureView {
+        &self.color.texture_view
+    }
+
+    /// Look up or rasterize a glyph, returning `(entry, newly_inserted)`.
+    ///
+    /// Returns `None` for glyphs that can't be rasterized (e.g., spaces, missing glyphs).
+    /// `newly_inserted` is true only when a new glyph was uploaded to the atlas texture.
+    pub fn get_or_insert(
+        &mut self,
+        queue: &wgpu::Queue,
+        font_system: &mut FontSystem,
+        swash_cache: &mut SwashCache,
+        cache_key: CacheKey,
+    ) -> (Option<AtlasEntry>, bool) {
+        if let Some(entry) = self.cache.get(&cache_key) {
+            return (*entry, false);
+        }
+
+        let image: Option<SwashImage> = swash_cache.get_image_uncached(font_system, cache_key);
+
+        let entry = image.and_then(|img| {
+            if img.placement.width == 0 || img.placement.height == 0 {
+                return None;
+            }
+
+            let w = img.placement.width;
+            let h = img.placement.height;
+
+            let is_color = matches!(img.content, SwashContent::Color);
+
+            if is_color {
+                // Color glyph: store RGBA data in the color atlas.
+                let (x, y) = self.color.allocate(w, h)?;
+                self.color.upload_region(queue, x, y, w, h, &img.data);
+                let s = self.color.size as f32;
+                Some(AtlasEntry {
+                    uv: [
+                        x as f32 / s,
+                        y as f32 / s,
+                        (x + w) as f32 / s,
+                        (y + h) as f32 / s,
+                    ],
+                    placement_left: img.placement.left,
+                    placement_top: img.placement.top,
+                    width: w,
+                    height: h,
+                    is_color: true,
+                })
+            } else {
+                // Monochrome glyph: store alpha data in the mono atlas.
+                let alpha_data = match img.content {
+                    SwashContent::Mask => img.data,
+                    SwashContent::SubpixelMask => img
+                        .data
+                        .chunks(3)
+                        .map(|rgb| ((rgb[0] as u16 + rgb[1] as u16 + rgb[2] as u16) / 3) as u8)
+                        .collect(),
+                    SwashContent::Color => unreachable!(),
+                };
+
+                let (x, y) = self.mono.allocate(w, h)?;
+                self.mono.upload_region(queue, x, y, w, h, &alpha_data);
+                let s = self.mono.size as f32;
+                Some(AtlasEntry {
+                    uv: [
+                        x as f32 / s,
+                        y as f32 / s,
+                        (x + w) as f32 / s,
+                        (y + h) as f32 / s,
+                    ],
+                    placement_left: img.placement.left,
+                    placement_top: img.placement.top,
+                    width: w,
+                    height: h,
+                    is_color: false,
+                })
+            }
+        });
+
+        let newly_inserted = entry.is_some();
+        self.cache.insert(cache_key, entry);
+        (entry, newly_inserted)
+    }
+}

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -1,0 +1,527 @@
+use std::collections::{HashMap, HashSet};
+
+use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, SwashCache};
+use egui_wgpu::wgpu;
+use egui_wgpu::{CallbackResources, CallbackTrait, ScreenDescriptor};
+use wezterm_surface::{CursorShape, CursorVisibility};
+
+use crate::atlas::GlyphAtlas;
+use crate::pipeline::{
+    ensure_instance_buffer, BackgroundPipeline, CellBgInstance, CellFgInstance, ForegroundPipeline,
+};
+use crate::snapshot::TerminalSnapshot;
+
+/// Per-pane GPU state: instance buffers and dirty-tracking fingerprint.
+pub struct PaneRenderState {
+    /// False until first successful prepare; forces initial rebuild.
+    initialized: bool,
+    // Dirty-tracking fields — terminal state
+    seqno: usize,
+    cursor_x: usize,
+    cursor_y: i64,
+    cursor_visibility: CursorVisibility,
+    cursor_shape: CursorShape,
+    scroll_offset: usize,
+    is_focused: bool,
+    selection_range: Option<((usize, usize), (usize, usize))>,
+
+    // Dirty-tracking fields — geometry (pane position/size, cell dimensions)
+    rect_x: f32,
+    rect_y: f32,
+    rect_w: f32,
+    rect_h: f32,
+    cell_width: f32,
+    cell_height: f32,
+
+    // Per-pane GPU instance buffers
+    pub bg_buffer: wgpu::Buffer,
+    pub bg_capacity: usize,
+    pub bg_count: u32,
+    pub fg_buffer: wgpu::Buffer,
+    pub fg_capacity: usize,
+    pub fg_count: u32,
+}
+
+impl PaneRenderState {
+    fn new(device: &wgpu::Device) -> Self {
+        let initial_capacity = 1024;
+        let bg_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pane_bg_instance_buffer"),
+            size: (initial_capacity * std::mem::size_of::<CellBgInstance>()) as u64,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let fg_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pane_fg_instance_buffer"),
+            size: (initial_capacity * std::mem::size_of::<CellFgInstance>()) as u64,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        Self {
+            initialized: false,
+            seqno: 0,
+            cursor_x: 0,
+            cursor_y: 0,
+            cursor_visibility: CursorVisibility::Visible,
+            cursor_shape: CursorShape::Default,
+            scroll_offset: 0,
+            is_focused: false,
+            selection_range: None,
+            rect_x: 0.0,
+            rect_y: 0.0,
+            rect_w: 0.0,
+            rect_h: 0.0,
+            cell_width: 0.0,
+            cell_height: 0.0,
+            bg_buffer,
+            bg_capacity: initial_capacity,
+            bg_count: 0,
+            fg_buffer,
+            fg_capacity: initial_capacity,
+            fg_count: 0,
+        }
+    }
+
+    /// Check if the pane content or geometry has changed since last render.
+    fn is_dirty(&self, snap: &TerminalSnapshot, rect: &PhysRect, cell_w: f32, cell_h: f32) -> bool {
+        !self.initialized
+            || self.seqno != snap.seqno
+            || self.cursor_x != snap.cursor.x
+            || self.cursor_y != snap.cursor.y
+            || self.cursor_visibility != snap.cursor.visibility
+            || self.cursor_shape != snap.cursor.shape
+            || self.scroll_offset != snap.scroll_offset
+            || self.is_focused != snap.is_focused
+            || self.selection_range != snap.selection_range
+            || self.rect_x != rect.x
+            || self.rect_y != rect.y
+            || self.rect_w != rect.width
+            || self.rect_h != rect.height
+            || self.cell_width != cell_w
+            || self.cell_height != cell_h
+    }
+
+    /// Update the fingerprint to match the current state.
+    fn update_fingerprint(
+        &mut self,
+        snap: &TerminalSnapshot,
+        rect: &PhysRect,
+        cell_w: f32,
+        cell_h: f32,
+    ) {
+        self.initialized = true;
+        self.seqno = snap.seqno;
+        self.cursor_x = snap.cursor.x;
+        self.cursor_y = snap.cursor.y;
+        self.cursor_visibility = snap.cursor.visibility;
+        self.cursor_shape = snap.cursor.shape;
+        self.scroll_offset = snap.scroll_offset;
+        self.is_focused = snap.is_focused;
+        self.selection_range = snap.selection_range;
+        self.rect_x = rect.x;
+        self.rect_y = rect.y;
+        self.rect_w = rect.width;
+        self.rect_h = rect.height;
+        self.cell_width = cell_w;
+        self.cell_height = cell_h;
+    }
+}
+
+/// Resources stored in egui's `CallbackResources` for the terminal renderer.
+pub struct TerminalGpuResources {
+    pub bg_pipeline: BackgroundPipeline,
+    pub fg_pipeline: ForegroundPipeline,
+    pub atlas: GlyphAtlas,
+    pub font_system: FontSystem,
+    pub swash_cache: SwashCache,
+    pub metrics: Metrics,
+    pub atlas_bind_group_dirty: bool,
+    /// Whether the render target uses an sRGB format. When true, colors must
+    /// be converted to linear space because the hardware applies linear→sRGB
+    /// on store. When false (e.g., Bgra8Unorm on macOS), sRGB values are
+    /// passed through directly.
+    pub target_is_srgb: bool,
+    /// Per-pane render state (instance buffers + dirty tracking).
+    pub pane_states: HashMap<u64, PaneRenderState>,
+}
+
+impl TerminalGpuResources {
+    /// Remove render state for panes that are no longer alive.
+    pub fn retain_panes(&mut self, live_pane_ids: &[u64]) {
+        let live: HashSet<u64> = live_pane_ids.iter().copied().collect();
+        self.pane_states.retain(|id, _| live.contains(id));
+    }
+}
+
+/// Paint callback for a single terminal pane.
+pub struct TerminalPaintCallback {
+    pub pane_id: u64,
+    pub snapshot: TerminalSnapshot,
+    pub phys_rect: PhysRect,
+    pub cell_width: f32,
+    pub cell_height: f32,
+}
+
+/// Physical pixel rectangle for the pane area.
+pub struct PhysRect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+impl CallbackTrait for TerminalPaintCallback {
+    fn prepare(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        screen_descriptor: &ScreenDescriptor,
+        _egui_encoder: &mut wgpu::CommandEncoder,
+        callback_resources: &mut CallbackResources,
+    ) -> Vec<wgpu::CommandBuffer> {
+        let resources = callback_resources
+            .get_mut::<TerminalGpuResources>()
+            .expect("TerminalGpuResources not initialized");
+
+        let pixels_per_point = screen_descriptor.pixels_per_point;
+        let viewport_width = screen_descriptor.size_in_pixels[0] as f32;
+        let viewport_height = screen_descriptor.size_in_pixels[1] as f32;
+        let target_is_srgb = resources.target_is_srgb;
+        resources.bg_pipeline.upload_viewport(
+            queue,
+            viewport_width,
+            viewport_height,
+            target_is_srgb,
+        );
+        resources.fg_pipeline.upload_viewport(
+            queue,
+            viewport_width,
+            viewport_height,
+            target_is_srgb,
+        );
+
+        // Get or create per-pane state.
+        let pane_state = resources
+            .pane_states
+            .entry(self.pane_id)
+            .or_insert_with(|| PaneRenderState::new(device));
+
+        // Skip expensive instance rebuild if nothing changed.
+        if !pane_state.is_dirty(
+            &self.snapshot,
+            &self.phys_rect,
+            self.cell_width,
+            self.cell_height,
+        ) {
+            return Vec::new();
+        }
+
+        let snap = &self.snapshot;
+        let linearize = resources.target_is_srgb;
+
+        // --- Background instances ---
+        let mut bg_instances = Vec::with_capacity(snap.cells.len() + 1);
+
+        // Full-rect background quad (absolute physical pixel positions)
+        let default_bg = maybe_linearize(snap.default_bg, linearize);
+        bg_instances.push(CellBgInstance {
+            pos: [self.phys_rect.x, self.phys_rect.y],
+            size: [self.phys_rect.width, self.phys_rect.height],
+            color: default_bg,
+        });
+
+        for cell in &snap.cells {
+            if cell.bg == snap.default_bg {
+                continue;
+            }
+            let px = self.phys_rect.x + cell.col as f32 * self.cell_width;
+            let py = self.phys_rect.y + cell.row as f32 * self.cell_height;
+            bg_instances.push(CellBgInstance {
+                pos: [px, py],
+                size: [self.cell_width, self.cell_height],
+                color: maybe_linearize(cell.bg, linearize),
+            });
+        }
+
+        // --- Foreground instances (glyphs) ---
+        let mut fg_instances = Vec::with_capacity(snap.cells.len());
+
+        for cell in &snap.cells {
+            if cell.text.is_empty() || cell.text == " " {
+                continue;
+            }
+
+            shape_and_rasterize(
+                &cell.text,
+                cell.bold,
+                cell.italic,
+                maybe_linearize(cell.fg, linearize),
+                self.phys_rect.x + cell.col as f32 * self.cell_width,
+                self.phys_rect.y + cell.row as f32 * self.cell_height,
+                self.cell_width,
+                self.cell_height,
+                pixels_per_point,
+                resources,
+                queue,
+                &mut fg_instances,
+            );
+        }
+
+        // --- Cursor ---
+        let cursor = &snap.cursor;
+        if snap.is_focused
+            && snap.scroll_offset == 0
+            && cursor.visibility == CursorVisibility::Visible
+            && cursor.y >= 0
+            && (cursor.y as usize) < snap.rows
+            && cursor.x < snap.cols
+        {
+            let cx = self.phys_rect.x + cursor.x as f32 * self.cell_width;
+            let cy = self.phys_rect.y + cursor.y as f32 * self.cell_height;
+            let cursor_bg = maybe_linearize(snap.cursor_bg, linearize);
+
+            match cursor.shape {
+                CursorShape::BlinkingBar | CursorShape::SteadyBar => {
+                    bg_instances.push(CellBgInstance {
+                        pos: [cx, cy],
+                        size: [2.0, self.cell_height],
+                        color: cursor_bg,
+                    });
+                }
+                CursorShape::BlinkingUnderline | CursorShape::SteadyUnderline => {
+                    bg_instances.push(CellBgInstance {
+                        pos: [cx, cy + self.cell_height - 2.0],
+                        size: [self.cell_width, 2.0],
+                        color: cursor_bg,
+                    });
+                }
+                CursorShape::Default | CursorShape::BlinkingBlock | CursorShape::SteadyBlock => {
+                    bg_instances.push(CellBgInstance {
+                        pos: [cx, cy],
+                        size: [self.cell_width, self.cell_height],
+                        color: cursor_bg,
+                    });
+                    if !snap.cursor_text.is_empty() {
+                        shape_and_rasterize(
+                            &snap.cursor_text,
+                            snap.cursor_text_bold,
+                            snap.cursor_text_italic,
+                            maybe_linearize(snap.cursor_fg, linearize),
+                            cx,
+                            cy,
+                            self.cell_width,
+                            self.cell_height,
+                            pixels_per_point,
+                            resources,
+                            queue,
+                            &mut fg_instances,
+                        );
+                    }
+                }
+            }
+        }
+
+        // --- Update atlas bind group if glyphs were added ---
+        if resources.atlas_bind_group_dirty {
+            resources.fg_pipeline.update_atlas_bind_group(
+                device,
+                resources.atlas.mono_texture_view(),
+                resources.atlas.color_texture_view(),
+                &resources.atlas.sampler,
+            );
+            resources.atlas_bind_group_dirty = false;
+        }
+
+        // --- Upload to per-pane buffers ---
+        // Re-borrow pane_state after releasing the mutable borrow on resources.
+        let pane_state = resources.pane_states.get_mut(&self.pane_id).unwrap();
+
+        // Grow bg buffer if needed.
+        if let Some((buf, cap)) = ensure_instance_buffer::<CellBgInstance>(
+            device,
+            Some(&pane_state.bg_buffer),
+            pane_state.bg_capacity,
+            bg_instances.len(),
+            "pane_bg_instance_buffer",
+        ) {
+            pane_state.bg_buffer = buf;
+            pane_state.bg_capacity = cap;
+        }
+        if !bg_instances.is_empty() {
+            queue.write_buffer(
+                &pane_state.bg_buffer,
+                0,
+                bytemuck::cast_slice(&bg_instances),
+            );
+        }
+        pane_state.bg_count = bg_instances.len() as u32;
+
+        // Grow fg buffer if needed.
+        if let Some((buf, cap)) = ensure_instance_buffer::<CellFgInstance>(
+            device,
+            Some(&pane_state.fg_buffer),
+            pane_state.fg_capacity,
+            fg_instances.len(),
+            "pane_fg_instance_buffer",
+        ) {
+            pane_state.fg_buffer = buf;
+            pane_state.fg_capacity = cap;
+        }
+        if !fg_instances.is_empty() {
+            queue.write_buffer(
+                &pane_state.fg_buffer,
+                0,
+                bytemuck::cast_slice(&fg_instances),
+            );
+        }
+        pane_state.fg_count = fg_instances.len() as u32;
+
+        pane_state.update_fingerprint(
+            &self.snapshot,
+            &self.phys_rect,
+            self.cell_width,
+            self.cell_height,
+        );
+
+        Vec::new()
+    }
+
+    fn paint(
+        &self,
+        info: egui::PaintCallbackInfo,
+        render_pass: &mut wgpu::RenderPass<'static>,
+        callback_resources: &CallbackResources,
+    ) {
+        let resources = callback_resources
+            .get::<TerminalGpuResources>()
+            .expect("TerminalGpuResources not initialized");
+
+        let Some(pane_state) = resources.pane_states.get(&self.pane_id) else {
+            return;
+        };
+
+        // Override egui's per-callback viewport (which is set to the callback rect)
+        // with the full window viewport. Our shader computes NDC from absolute physical
+        // pixel positions, so the viewport must cover the full framebuffer. The scissor
+        // rect (set by egui) still clips rendering to the callback area.
+        let [w, h] = info.screen_size_px;
+        render_pass.set_viewport(0.0, 0.0, w as f32, h as f32, 0.0, 1.0);
+
+        resources
+            .bg_pipeline
+            .draw(render_pass, &pane_state.bg_buffer, pane_state.bg_count);
+        resources
+            .fg_pipeline
+            .draw(render_pass, &pane_state.fg_buffer, pane_state.fg_count);
+    }
+}
+
+/// Shape text with cosmic-text and rasterize glyphs into the atlas,
+/// appending foreground instances for each glyph.
+///
+/// `pixels_per_point` scales the font metrics so glyphs are rasterized at
+/// physical pixel size (e.g. 2× on Retina), matching the physical coordinate
+/// system used for instance placement.
+#[allow(clippy::too_many_arguments)]
+fn shape_and_rasterize(
+    text: &str,
+    bold: bool,
+    italic: bool,
+    color: [f32; 4],
+    cell_px: f32,
+    cell_py: f32,
+    cell_width: f32,
+    cell_height: f32,
+    pixels_per_point: f32,
+    resources: &mut TerminalGpuResources,
+    queue: &wgpu::Queue,
+    fg_instances: &mut Vec<CellFgInstance>,
+) {
+    let weight = if bold {
+        cosmic_text::Weight::BOLD
+    } else {
+        cosmic_text::Weight::NORMAL
+    };
+    let style = if italic {
+        cosmic_text::Style::Italic
+    } else {
+        cosmic_text::Style::Normal
+    };
+    let attrs = Attrs::new()
+        .family(cosmic_text::fontdb::Family::Monospace)
+        .weight(weight)
+        .style(style);
+
+    // Scale metrics by pixels_per_point so glyphs are rasterized at physical
+    // pixel size, not logical size. Without this, glyphs on HiDPI displays
+    // would be rasterized at 1× and appear tiny/faint in the 2× coordinate system.
+    let phys_metrics = Metrics::new(
+        resources.metrics.font_size * pixels_per_point,
+        resources.metrics.line_height * pixels_per_point,
+    );
+    let mut buffer = Buffer::new_empty(phys_metrics);
+    {
+        let mut borrowed = buffer.borrow_with(&mut resources.font_system);
+        borrowed.set_size(Some(cell_width * 2.0), Some(cell_height));
+        borrowed.set_text(text, attrs, Shaping::Advanced);
+        borrowed.shape_until_scroll(true);
+    }
+
+    for run in buffer.layout_runs() {
+        for glyph in run.glyphs.iter() {
+            let physical = glyph.physical((0.0, 0.0), 1.0);
+
+            let (entry, newly_inserted) = resources.atlas.get_or_insert(
+                queue,
+                &mut resources.font_system,
+                &mut resources.swash_cache,
+                physical.cache_key,
+            );
+
+            if let Some(entry) = entry {
+                let gx = cell_px + physical.x as f32 + entry.placement_left as f32;
+                // Use line_y (baseline position) not line_top (line top edge).
+                // line_y = line_top + centering_offset + max_ascent, which
+                // accounts for the font's ascent so glyphs sit on the baseline
+                // rather than floating above the cell.
+                let gy = cell_py + run.line_y + physical.y as f32 - entry.placement_top as f32;
+
+                fg_instances.push(CellFgInstance {
+                    pos: [gx, gy],
+                    size: [entry.width as f32, entry.height as f32],
+                    uv_min: [entry.uv[0], entry.uv[1]],
+                    uv_max: [entry.uv[2], entry.uv[3]],
+                    color,
+                    is_color: if entry.is_color { 1.0 } else { 0.0 },
+                    _pad: [0.0; 3],
+                });
+
+                if newly_inserted {
+                    resources.atlas_bind_group_dirty = true;
+                }
+            }
+        }
+    }
+}
+
+/// Convert an sRGB color to linear if the target is sRGB, otherwise pass through.
+fn maybe_linearize(color: [f32; 4], target_is_srgb: bool) -> [f32; 4] {
+    if target_is_srgb {
+        [
+            srgb_to_linear(color[0]),
+            srgb_to_linear(color[1]),
+            srgb_to_linear(color[2]),
+            color[3],
+        ]
+    } else {
+        color
+    }
+}
+
+fn srgb_to_linear(v: f32) -> f32 {
+    if v <= 0.04045 {
+        v / 12.92
+    } else {
+        ((v + 0.055) / 1.055).powf(2.4)
+    }
+}

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -1,1 +1,152 @@
+mod atlas;
+mod callback;
+mod pipeline;
+pub mod snapshot;
 
+use cosmic_text::fontdb::Family;
+use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, SwashCache};
+
+use atlas::GlyphAtlas;
+use callback::{PhysRect, TerminalGpuResources, TerminalPaintCallback};
+use pipeline::{BackgroundPipeline, ForegroundPipeline};
+pub use snapshot::TerminalSnapshot;
+
+/// Atlas texture size (2048×2048, ~4MB for R8).
+const ATLAS_SIZE: u32 = 2048;
+
+/// GPU-accelerated terminal renderer using wgpu.
+///
+/// Renders terminal panes via instanced quad drawing inside egui's render pass,
+/// using `egui_wgpu::CallbackTrait` for custom paint callbacks.
+pub struct GpuRenderer {
+    #[allow(dead_code)]
+    render_state: egui_wgpu::RenderState,
+    cell_width: f32,
+    cell_height: f32,
+}
+
+impl GpuRenderer {
+    /// Create a new GPU renderer from eframe's render state.
+    ///
+    /// Initializes pipelines, glyph atlas, and font system. Registers GPU
+    /// resources in egui's callback resource map.
+    pub fn new(render_state: egui_wgpu::RenderState, font_size: f32) -> Self {
+        let target_format = render_state.target_format;
+        let target_is_srgb = target_format.is_srgb();
+        tracing::info!("GPU renderer target_format: {target_format:?} (sRGB: {target_is_srgb})");
+        let device = &render_state.device;
+
+        let bg_pipeline = BackgroundPipeline::new(device, target_format);
+        let fg_pipeline = ForegroundPipeline::new(device, target_format);
+        let atlas = GlyphAtlas::new(device, ATLAS_SIZE);
+
+        let mut font_system = FontSystem::new();
+        let swash_cache = SwashCache::new();
+
+        // Measure cell dimensions via cosmic-text (same approach as amux-render-soft).
+        let line_height = (font_size * 1.3).ceil();
+        let metrics = Metrics::new(font_size, line_height);
+        let cell_width = measure_cell_width(&mut font_system, metrics);
+        let cell_height = line_height;
+
+        // Register resources in egui's callback_resources.
+        render_state
+            .renderer
+            .write()
+            .callback_resources
+            .insert(TerminalGpuResources {
+                bg_pipeline,
+                fg_pipeline,
+                atlas,
+                font_system,
+                swash_cache,
+                metrics,
+                atlas_bind_group_dirty: true,
+                target_is_srgb,
+                pane_states: std::collections::HashMap::new(),
+            });
+
+        Self {
+            render_state,
+            cell_width,
+            cell_height,
+        }
+    }
+
+    /// Create an egui `PaintCallback` that will render the terminal pane
+    /// into the given rect during egui's render pass.
+    ///
+    /// `snapshot` contains pre-extracted terminal state (cells, colors, cursor).
+    /// `pixels_per_point` is the current DPI scale factor.
+    pub fn paint_callback(
+        &self,
+        rect: egui::Rect,
+        snapshot: TerminalSnapshot,
+        pixels_per_point: f32,
+    ) -> egui::PaintCallback {
+        let phys_cell_w = self.cell_width * pixels_per_point;
+        let phys_cell_h = self.cell_height * pixels_per_point;
+
+        let pane_id = snapshot.pane_id;
+        let callback = TerminalPaintCallback {
+            pane_id,
+            snapshot,
+            phys_rect: PhysRect {
+                x: rect.min.x * pixels_per_point,
+                y: rect.min.y * pixels_per_point,
+                width: rect.width() * pixels_per_point,
+                height: rect.height() * pixels_per_point,
+            },
+            cell_width: phys_cell_w,
+            cell_height: phys_cell_h,
+        };
+        egui_wgpu::Callback::new_paint_callback(rect, callback)
+    }
+
+    /// Get the cell width in logical points.
+    pub fn cell_width(&self) -> f32 {
+        self.cell_width
+    }
+
+    /// Get the cell height in logical points.
+    pub fn cell_height(&self) -> f32 {
+        self.cell_height
+    }
+
+    /// Remove cached render state for panes that no longer exist.
+    pub fn retain_panes(&self, live_pane_ids: &[u64]) {
+        if let Some(r) = self
+            .render_state
+            .renderer
+            .write()
+            .callback_resources
+            .get_mut::<TerminalGpuResources>()
+        {
+            r.retain_panes(live_pane_ids);
+        }
+    }
+}
+
+/// Measure monospace cell width by laying out "M" and reading the advance.
+fn measure_cell_width(font_system: &mut FontSystem, metrics: Metrics) -> f32 {
+    let mut buffer = Buffer::new_empty(metrics);
+    {
+        let mut borrowed = buffer.borrow_with(font_system);
+        borrowed.set_size(Some(200.0), Some(metrics.line_height));
+        borrowed.set_text(
+            "M",
+            Attrs::new().family(Family::Monospace),
+            Shaping::Advanced,
+        );
+        borrowed.shape_until_scroll(true);
+    }
+
+    for run in buffer.layout_runs() {
+        if let Some(glyph) = run.glyphs.iter().next() {
+            return glyph.w;
+        }
+    }
+
+    // Fallback: estimate from font size
+    metrics.font_size * 0.6
+}

--- a/crates/amux-render-gpu/src/pipeline.rs
+++ b/crates/amux-render-gpu/src/pipeline.rs
@@ -1,0 +1,501 @@
+use bytemuck::{Pod, Zeroable};
+use wgpu::util::DeviceExt;
+
+/// Per-cell background instance data.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct CellBgInstance {
+    /// Cell position in physical pixels (top-left corner).
+    pub pos: [f32; 2],
+    /// Cell size in physical pixels.
+    pub size: [f32; 2],
+    /// Background color (sRGB or linear RGBA, depending on render target format).
+    pub color: [f32; 4],
+}
+
+/// Viewport uniform data.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+struct ViewportUniform {
+    /// Viewport size in physical pixels.
+    size: [f32; 2],
+    /// 1.0 if the render target is sRGB (hardware does linear→sRGB on store),
+    /// 0.0 if non-sRGB (values are passed through directly).
+    target_is_srgb: f32,
+    _pad: f32,
+}
+
+/// Unit quad vertex.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+struct QuadVertex {
+    pos: [f32; 2],
+}
+
+/// Background rendering pipeline: instanced colored quads for cell backgrounds.
+///
+/// Instance buffers are stored per-pane in `PaneRenderState`, not here.
+/// This struct holds the shared render pipeline, vertex/index buffers, and viewport uniform.
+pub struct BackgroundPipeline {
+    pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    index_buffer: wgpu::Buffer,
+    viewport_buffer: wgpu::Buffer,
+    viewport_bind_group: wgpu::BindGroup,
+}
+
+impl BackgroundPipeline {
+    /// Create the background pipeline.
+    pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("background_shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/background.wgsl").into()),
+        });
+
+        // Viewport uniform bind group layout
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("bg_viewport_bind_group_layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("bg_pipeline_layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("bg_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[
+                    // Vertex buffer: unit quad
+                    wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<QuadVertex>() as u64,
+                        step_mode: wgpu::VertexStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array![0 => Float32x2],
+                    },
+                    // Instance buffer: per-cell data
+                    wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<CellBgInstance>() as u64,
+                        step_mode: wgpu::VertexStepMode::Instance,
+                        attributes: &wgpu::vertex_attr_array![
+                            1 => Float32x2, // pos
+                            2 => Float32x2, // size
+                            3 => Float32x4, // color
+                        ],
+                    },
+                ],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: target_format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        // Unit quad: two triangles covering (0,0) to (1,1)
+        let vertices = [
+            QuadVertex { pos: [0.0, 0.0] },
+            QuadVertex { pos: [1.0, 0.0] },
+            QuadVertex { pos: [1.0, 1.0] },
+            QuadVertex { pos: [0.0, 1.0] },
+        ];
+        let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("bg_vertex_buffer"),
+            contents: bytemuck::cast_slice(&vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("bg_index_buffer"),
+            contents: bytemuck::cast_slice(&indices),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+
+        let viewport_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("bg_viewport_uniform"),
+            contents: bytemuck::cast_slice(&[ViewportUniform {
+                size: [1.0, 1.0],
+                target_is_srgb: 0.0,
+                _pad: 0.0,
+            }]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let viewport_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("bg_viewport_bind_group"),
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: viewport_buffer.as_entire_binding(),
+            }],
+        });
+
+        Self {
+            pipeline,
+            vertex_buffer,
+            index_buffer,
+            viewport_buffer,
+            viewport_bind_group,
+        }
+    }
+
+    /// Update the viewport uniform.
+    pub fn upload_viewport(
+        &self,
+        queue: &wgpu::Queue,
+        viewport_width: f32,
+        viewport_height: f32,
+        target_is_srgb: bool,
+    ) {
+        queue.write_buffer(
+            &self.viewport_buffer,
+            0,
+            bytemuck::cast_slice(&[ViewportUniform {
+                size: [viewport_width, viewport_height],
+                target_is_srgb: if target_is_srgb { 1.0 } else { 0.0 },
+                _pad: 0.0,
+            }]),
+        );
+    }
+
+    /// Record draw commands using a per-pane instance buffer.
+    pub fn draw(
+        &self,
+        render_pass: &mut wgpu::RenderPass<'static>,
+        instance_buffer: &wgpu::Buffer,
+        instance_count: u32,
+    ) {
+        if instance_count == 0 {
+            return;
+        }
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_bind_group(0, &self.viewport_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        render_pass.set_vertex_buffer(1, instance_buffer.slice(..));
+        render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+        render_pass.draw_indexed(0..6, 0, 0..instance_count);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Foreground pipeline (textured glyph quads)
+// ---------------------------------------------------------------------------
+
+/// Per-glyph foreground instance data.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct CellFgInstance {
+    /// Glyph position in physical pixels (top-left corner).
+    pub pos: [f32; 2],
+    /// Glyph size in physical pixels.
+    pub size: [f32; 2],
+    /// Atlas UV min (top-left).
+    pub uv_min: [f32; 2],
+    /// Atlas UV max (bottom-right).
+    pub uv_max: [f32; 2],
+    /// Foreground color (sRGB or linear RGBA, depending on render target format).
+    pub color: [f32; 4],
+    /// 1.0 for color emoji, 0.0 for monochrome glyphs.
+    pub is_color: f32,
+    pub _pad: [f32; 3],
+}
+
+/// Foreground rendering pipeline: instanced textured quads for glyphs.
+///
+/// Instance buffers are stored per-pane in `PaneRenderState`, not here.
+pub struct ForegroundPipeline {
+    pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    index_buffer: wgpu::Buffer,
+    viewport_buffer: wgpu::Buffer,
+    viewport_bind_group: wgpu::BindGroup,
+    atlas_bind_group_layout: wgpu::BindGroupLayout,
+    atlas_bind_group: Option<wgpu::BindGroup>,
+}
+
+impl ForegroundPipeline {
+    /// Create the foreground pipeline.
+    pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("foreground_shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/foreground.wgsl").into()),
+        });
+
+        // Group 0: viewport uniform
+        let viewport_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("fg_viewport_bind_group_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
+        // Group 1: mono atlas + color atlas + sampler
+        let atlas_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("fg_atlas_bind_group_layout"),
+                entries: &[
+                    // binding 0: mono atlas (R8Unorm)
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    // binding 1: color atlas (Rgba8UnormSrgb)
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    // binding 2: shared sampler
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("fg_pipeline_layout"),
+            bind_group_layouts: &[&viewport_bind_group_layout, &atlas_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("fg_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[
+                    // Vertex buffer: unit quad
+                    wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<QuadVertex>() as u64,
+                        step_mode: wgpu::VertexStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array![0 => Float32x2],
+                    },
+                    // Instance buffer: per-glyph data
+                    wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<CellFgInstance>() as u64,
+                        step_mode: wgpu::VertexStepMode::Instance,
+                        attributes: &wgpu::vertex_attr_array![
+                            1 => Float32x2, // pos
+                            2 => Float32x2, // size
+                            3 => Float32x2, // uv_min
+                            4 => Float32x2, // uv_max
+                            5 => Float32x4, // color
+                            6 => Float32x4, // is_color + padding
+                        ],
+                    },
+                ],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: target_format,
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        // Shared unit quad (same as background pipeline)
+        let vertices = [
+            QuadVertex { pos: [0.0, 0.0] },
+            QuadVertex { pos: [1.0, 0.0] },
+            QuadVertex { pos: [1.0, 1.0] },
+            QuadVertex { pos: [0.0, 1.0] },
+        ];
+        let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("fg_vertex_buffer"),
+            contents: bytemuck::cast_slice(&vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("fg_index_buffer"),
+            contents: bytemuck::cast_slice(&indices),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+
+        let viewport_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("fg_viewport_uniform"),
+            contents: bytemuck::cast_slice(&[ViewportUniform {
+                size: [1.0, 1.0],
+                target_is_srgb: 0.0,
+                _pad: 0.0,
+            }]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let viewport_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("fg_viewport_bind_group"),
+            layout: &viewport_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: viewport_buffer.as_entire_binding(),
+            }],
+        });
+
+        Self {
+            pipeline,
+            vertex_buffer,
+            index_buffer,
+            viewport_buffer,
+            viewport_bind_group,
+            atlas_bind_group_layout,
+            atlas_bind_group: None,
+        }
+    }
+
+    /// Update the atlas bind group when atlas textures change.
+    pub fn update_atlas_bind_group(
+        &mut self,
+        device: &wgpu::Device,
+        mono_view: &wgpu::TextureView,
+        color_view: &wgpu::TextureView,
+        sampler: &wgpu::Sampler,
+    ) {
+        self.atlas_bind_group = Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("fg_atlas_bind_group"),
+            layout: &self.atlas_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(mono_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(color_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(sampler),
+                },
+            ],
+        }));
+    }
+
+    /// Update the viewport uniform.
+    pub fn upload_viewport(
+        &self,
+        queue: &wgpu::Queue,
+        viewport_width: f32,
+        viewport_height: f32,
+        target_is_srgb: bool,
+    ) {
+        queue.write_buffer(
+            &self.viewport_buffer,
+            0,
+            bytemuck::cast_slice(&[ViewportUniform {
+                size: [viewport_width, viewport_height],
+                target_is_srgb: if target_is_srgb { 1.0 } else { 0.0 },
+                _pad: 0.0,
+            }]),
+        );
+    }
+
+    /// Record draw commands using a per-pane instance buffer.
+    pub fn draw(
+        &self,
+        render_pass: &mut wgpu::RenderPass<'static>,
+        instance_buffer: &wgpu::Buffer,
+        instance_count: u32,
+    ) {
+        if instance_count == 0 {
+            return;
+        }
+        let Some(atlas_bind_group) = &self.atlas_bind_group else {
+            return;
+        };
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_bind_group(0, &self.viewport_bind_group, &[]);
+        render_pass.set_bind_group(1, atlas_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        render_pass.set_vertex_buffer(1, instance_buffer.slice(..));
+        render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+        render_pass.draw_indexed(0..6, 0, 0..instance_count);
+    }
+}
+
+/// Create or grow an instance buffer if needed. Returns the buffer and its capacity.
+pub fn ensure_instance_buffer<T: Pod>(
+    device: &wgpu::Device,
+    existing: Option<&wgpu::Buffer>,
+    existing_capacity: usize,
+    required: usize,
+    label: &str,
+) -> Option<(wgpu::Buffer, usize)> {
+    if required <= existing_capacity && existing.is_some() {
+        return None; // existing buffer is fine
+    }
+    let new_capacity = required.max(1024).next_power_of_two();
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        size: (new_capacity * std::mem::size_of::<T>()) as u64,
+        usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    Some((buffer, new_capacity))
+}

--- a/crates/amux-render-gpu/src/shaders/background.wgsl
+++ b/crates/amux-render-gpu/src/shaders/background.wgsl
@@ -1,0 +1,52 @@
+// Background pass: renders one colored quad per terminal cell with a non-default background.
+// Uses instancing: the unit quad vertices are shared, per-instance data provides position/size/color.
+
+struct Viewport {
+    // Viewport size in physical pixels.
+    size: vec2<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> viewport: Viewport;
+
+struct VertexInput {
+    // Unit quad vertex position (0..1).
+    @location(0) vertex_pos: vec2<f32>,
+}
+
+struct InstanceInput {
+    // Cell position in physical pixels (top-left corner).
+    @location(1) cell_pos: vec2<f32>,
+    // Cell size in physical pixels.
+    @location(2) cell_size: vec2<f32>,
+    // Cell background color (sRGB or linear RGBA, depending on target format).
+    @location(3) color: vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) color: vec4<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput, instance: InstanceInput) -> VertexOutput {
+    // Scale unit quad to cell size and translate to cell position.
+    let pixel_pos = instance.cell_pos + vertex.vertex_pos * instance.cell_size;
+
+    // Convert pixel coordinates to NDC: (0,0) = top-left, (w,h) = bottom-right
+    // NDC range: x [-1, 1], y [-1, 1] (y up in NDC, y down in screen)
+    let ndc = vec2<f32>(
+        pixel_pos.x / viewport.size.x * 2.0 - 1.0,
+        1.0 - pixel_pos.y / viewport.size.y * 2.0,
+    );
+
+    var out: VertexOutput;
+    out.clip_pos = vec4<f32>(ndc, 0.0, 1.0);
+    out.color = instance.color;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return in.color;
+}

--- a/crates/amux-render-gpu/src/shaders/foreground.wgsl
+++ b/crates/amux-render-gpu/src/shaders/foreground.wgsl
@@ -1,0 +1,98 @@
+// Foreground pass: renders one textured quad per visible glyph.
+// Uses instancing: unit quad vertices are shared, per-instance data provides
+// position/size/UV/color. Supports both monochrome (alpha-only) and color (emoji)
+// atlas textures, selected by the is_color instance flag.
+
+struct Viewport {
+    size: vec2<f32>,
+    // 1.0 if target is sRGB (hardware converts linear→sRGB on store),
+    // 0.0 if non-sRGB (values pass through directly).
+    target_is_srgb: f32,
+}
+
+@group(0) @binding(0)
+var<uniform> viewport: Viewport;
+
+@group(1) @binding(0)
+var mono_atlas: texture_2d<f32>;
+@group(1) @binding(1)
+var color_atlas: texture_2d<f32>;
+@group(1) @binding(2)
+var atlas_sampler: sampler;
+
+struct VertexInput {
+    @location(0) vertex_pos: vec2<f32>,
+}
+
+struct InstanceInput {
+    // Glyph position in physical pixels (top-left corner).
+    @location(1) glyph_pos: vec2<f32>,
+    // Glyph size in physical pixels.
+    @location(2) glyph_size: vec2<f32>,
+    // Atlas UV coordinates: [u_min, v_min, u_max, v_max].
+    @location(3) uv_min: vec2<f32>,
+    @location(4) uv_max: vec2<f32>,
+    // Foreground color (sRGB or linear RGBA, depending on target format).
+    @location(5) color: vec4<f32>,
+    // is_color flag (x component): 1.0 = color emoji, 0.0 = monochrome.
+    @location(6) is_color_pad: vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) color: vec4<f32>,
+    @location(2) is_color: f32,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput, instance: InstanceInput) -> VertexOutput {
+    let pixel_pos = instance.glyph_pos + vertex.vertex_pos * instance.glyph_size;
+
+    let ndc = vec2<f32>(
+        pixel_pos.x / viewport.size.x * 2.0 - 1.0,
+        1.0 - pixel_pos.y / viewport.size.y * 2.0,
+    );
+
+    // Interpolate UV from min to max across the unit quad.
+    let uv = mix(instance.uv_min, instance.uv_max, vertex.vertex_pos);
+
+    var out: VertexOutput;
+    out.clip_pos = vec4<f32>(ndc, 0.0, 1.0);
+    out.uv = uv;
+    out.color = instance.color;
+    out.is_color = instance.is_color_pad.x;
+    return out;
+}
+
+// Convert a single linear channel to sRGB.
+fn linear_to_srgb(v: f32) -> f32 {
+    if v <= 0.0031308 {
+        return v * 12.92;
+    }
+    return 1.055 * pow(v, 1.0 / 2.4) - 0.055;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    if in.is_color > 0.5 {
+        // Color emoji: sample from Rgba8UnormSrgb atlas (returns linear values).
+        var texel = textureSample(color_atlas, atlas_sampler, in.uv);
+        // On non-sRGB targets, convert linear→sRGB since hardware won't do it.
+        if viewport.target_is_srgb < 0.5 {
+            texel = vec4<f32>(
+                linear_to_srgb(texel.r),
+                linear_to_srgb(texel.g),
+                linear_to_srgb(texel.b),
+                texel.a,
+            );
+        }
+        return vec4<f32>(texel.rgb * texel.a, texel.a);
+    } else {
+        // Monochrome glyph: sample alpha from mono atlas, multiply by fg color.
+        // Use alpha * color.a for correct premultiplication when color.a < 1.0.
+        let alpha = textureSample(mono_atlas, atlas_sampler, in.uv).r;
+        let final_alpha = alpha * in.color.a;
+        return vec4<f32>(in.color.rgb * final_alpha, final_alpha);
+    }
+}

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -1,0 +1,186 @@
+use wezterm_term::color::{ColorAttribute, ColorPalette, SrgbaTuple};
+use wezterm_term::CursorPosition;
+
+/// Pre-extracted terminal state for GPU rendering.
+///
+/// Built on the main thread (where the terminal screen borrow is held),
+/// then moved into the paint callback which must be `Send + Sync`.
+pub struct TerminalSnapshot {
+    pub pane_id: u64,
+    pub seqno: usize,
+    pub cols: usize,
+    pub rows: usize,
+    pub cells: Vec<CellData>,
+    pub cursor: CursorPosition,
+    pub default_bg: [f32; 4],
+    pub cursor_bg: [f32; 4],
+    pub cursor_fg: [f32; 4],
+    pub is_focused: bool,
+    pub scroll_offset: usize,
+    /// Text under the cursor (for block cursor rendering).
+    pub cursor_text: String,
+    pub cursor_text_bold: bool,
+    pub cursor_text_italic: bool,
+    /// Selection start/end for dirty tracking (None if no selection).
+    pub selection_range: Option<((usize, usize), (usize, usize))>,
+}
+
+/// Data for a single terminal cell.
+pub struct CellData {
+    pub col: usize,
+    pub row: usize,
+    pub text: String,
+    pub fg: [f32; 4],
+    pub bg: [f32; 4],
+    pub bold: bool,
+    pub italic: bool,
+}
+
+/// Selection range for highlight rendering.
+pub struct SelectionRange {
+    pub start: (usize, usize), // (col, stable_row)
+    pub end: (usize, usize),   // (col, stable_row)
+}
+
+impl SelectionRange {
+    fn contains(&self, col: usize, stable_row: usize) -> bool {
+        if stable_row < self.start.1 || stable_row > self.end.1 {
+            return false;
+        }
+        if stable_row == self.start.1 && stable_row == self.end.1 {
+            return col >= self.start.0 && col <= self.end.0;
+        }
+        if stable_row == self.start.1 {
+            return col >= self.start.0;
+        }
+        if stable_row == self.end.1 {
+            return col <= self.end.0;
+        }
+        true
+    }
+}
+
+impl TerminalSnapshot {
+    /// Extract a snapshot from the terminal screen.
+    ///
+    /// `scroll_offset` is the number of lines scrolled back from the bottom.
+    /// `selection` is an optional normalized selection range for highlight rendering.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_screen(
+        screen: &wezterm_term::screen::Screen,
+        palette: &ColorPalette,
+        cursor: &CursorPosition,
+        cols: usize,
+        rows: usize,
+        scroll_offset: usize,
+        is_focused: bool,
+        selection: Option<SelectionRange>,
+        pane_id: u64,
+        seqno: usize,
+    ) -> Self {
+        let selection_range = selection.as_ref().map(|s| (s.start, s.end));
+        let default_bg = srgba_to_f32(palette.background);
+        let cursor_bg = srgba_to_f32(palette.cursor_bg);
+        let cursor_fg = srgba_to_f32(palette.cursor_fg);
+
+        let total = screen.scrollback_rows();
+        let end = total.saturating_sub(scroll_offset);
+        let start = end.saturating_sub(rows);
+        let lines = screen.lines_in_phys_range(start..end);
+
+        let mut cells = Vec::with_capacity(cols * rows);
+        let mut cursor_text = String::new();
+        let mut cursor_text_bold = false;
+        let mut cursor_text_italic = false;
+
+        for (row_idx, line) in lines.iter().enumerate() {
+            for cell_ref in line.visible_cells() {
+                let col_idx = cell_ref.cell_index();
+                if col_idx >= cols {
+                    break;
+                }
+
+                let attrs = cell_ref.attrs();
+                let reverse = attrs.reverse();
+
+                let mut fg = resolve_color(&attrs.foreground(), palette, true, reverse);
+                let mut bg = resolve_color(&attrs.background(), palette, false, reverse);
+
+                // Apply selection highlighting (swap fg/bg)
+                let stable_row = start + row_idx;
+                if let Some(ref sel) = selection {
+                    if sel.contains(col_idx, stable_row) {
+                        std::mem::swap(&mut fg, &mut bg);
+                        // Ensure selected empty cells have visible bg
+                        if srgba_to_f32(bg) == default_bg {
+                            bg = palette.foreground;
+                            fg = palette.background;
+                        }
+                    }
+                }
+
+                // Capture text under cursor for block cursor rendering
+                if row_idx == cursor.y as usize && col_idx == cursor.x {
+                    let text = cell_ref.str();
+                    if !text.is_empty() && text != " " {
+                        cursor_text = text.to_string();
+                        cursor_text_bold = attrs.intensity() == wezterm_term::Intensity::Bold;
+                        cursor_text_italic = attrs.italic();
+                    }
+                }
+
+                cells.push(CellData {
+                    col: col_idx,
+                    row: row_idx,
+                    text: cell_ref.str().to_string(),
+                    fg: srgba_to_f32(fg),
+                    bg: srgba_to_f32(bg),
+                    bold: attrs.intensity() == wezterm_term::Intensity::Bold,
+                    italic: attrs.italic(),
+                });
+            }
+        }
+
+        Self {
+            pane_id,
+            seqno,
+            cols,
+            rows,
+            cells,
+            cursor: *cursor,
+            default_bg,
+            cursor_bg,
+            cursor_fg,
+            is_focused,
+            scroll_offset,
+            cursor_text,
+            cursor_text_bold,
+            cursor_text_italic,
+            selection_range,
+        }
+    }
+}
+
+fn resolve_color(
+    color: &ColorAttribute,
+    palette: &ColorPalette,
+    is_fg: bool,
+    reverse: bool,
+) -> SrgbaTuple {
+    let effective_is_fg = if reverse { !is_fg } else { is_fg };
+    if effective_is_fg {
+        palette.resolve_fg(*color)
+    } else {
+        palette.resolve_bg(*color)
+    }
+}
+
+/// Convert wezterm-term color tuple to [f32; 4].
+///
+/// Colors are kept in sRGB space here. The GPU callback converts to linear
+/// only when the render target uses an sRGB format (which applies hardware
+/// linear→sRGB on store). For non-sRGB targets (e.g., Bgra8Unorm on macOS),
+/// sRGB values are passed through directly.
+fn srgba_to_f32(c: SrgbaTuple) -> [f32; 4] {
+    [c.0, c.1, c.2, c.3]
+}


### PR DESCRIPTION
## Summary
- Add wgpu-based GPU renderer (`amux-render-gpu`) using instanced quad drawing inside egui's render pass via `CallbackTrait`
- Glyph atlas with shelf-packing (dual textures: R8Unorm for monochrome, Rgba8UnormSrgb for color emoji)
- cosmic-text for font shaping/rasterization with bold/italic/HiDPI support
- Per-pane dirty tracking (seqno, cursor, scroll, selection, geometry) to skip instance buffer rebuilds
- Conditional sRGB→linear color conversion based on render target format (macOS Metal uses Bgra8Unorm)
- Full cursor rendering (block with inverted text, bar, underline) and selection highlighting

## Test plan
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo test --workspace` passes
- [ ] `cargo build --no-default-features` (soft renderer fallback compiles)
- [ ] Visual: `vim`, `htop`, `ls --color`, emoji, scrollback, selection, cursor shapes render correctly
- [ ] Visual: HiDPI/Retina display renders crisp glyphs at correct size
- [ ] Visual: Multiple panes render at correct positions with correct backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU-accelerated terminal rendering added and enabled by default, improving performance and visual smoothness for panes.
  * Faster glyph/text rendering with on-GPU glyph caching and reduced redraw work.
  * Cursor, selection, and pane resizing are handled when GPU rendering is active, with automatic fallback to CPU rendering when GPU is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->