### PR TITLE
Fix fg pipeline viewport visibility for fragment shader access

### DIFF
--- a/crates/amux-render-gpu/src/pipeline.rs
+++ b/crates/amux-render-gpu/src/pipeline.rs
@@ -256,7 +256,7 @@ impl ForegroundPipeline {
                 label: Some("fg_viewport_bind_group_layout"),
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,


### PR DESCRIPTION
## Summary
- The foreground shader now reads `viewport.target_is_srgb` in the fragment stage (added in #11 for color emoji sRGB conversion), but the viewport bind group layout only had `VERTEX` visibility
- This caused a wgpu validation panic on launch: `Visibility flags don't include the shader stage`
- Fix: change visibility from `ShaderStages::VERTEX` to `ShaderStages::VERTEX_FRAGMENT`

## Test plan
- [x] App launches without panic on macOS (Bgra8Unorm target)
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)