### PR TITLE
Phase 9a: Font size controls (Cmd+/-, Cmd+0)

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -59,7 +59,9 @@ fn get_cwd_from_pid(pid: u32) -> Option<String> {
     None
 }
 
-const FONT_SIZE: f32 = 14.0;
+const DEFAULT_FONT_SIZE: f32 = 14.0;
+const MIN_FONT_SIZE: f32 = 8.0;
+const MAX_FONT_SIZE: f32 = 36.0;
 const DEFAULT_SIDEBAR_WIDTH: f32 = 200.0;
 const TAB_BAR_HEIGHT: f32 = 24.0;
 
@@ -105,7 +107,7 @@ fn main() -> anyhow::Result<()> {
             #[cfg(feature = "gpu-renderer")]
             let gpu_renderer = _cc.wgpu_render_state.as_ref().map(|rs| {
                 tracing::info!("GPU renderer initialized (wgpu backend)");
-                GpuRenderer::new(rs.clone(), FONT_SIZE)
+                GpuRenderer::new(rs.clone(), DEFAULT_FONT_SIZE)
             });
 
             Ok(Box::new(AmuxApp {
@@ -126,6 +128,7 @@ fn main() -> anyhow::Result<()> {
                 last_click_pos: egui::Pos2::ZERO,
                 click_count: 0,
                 wants_exit: false,
+                font_size: DEFAULT_FONT_SIZE,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
             }))
@@ -571,6 +574,7 @@ struct AmuxApp {
     last_click_pos: egui::Pos2,
     click_count: u32,
     wants_exit: bool,
+    font_size: f32,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
 }
@@ -587,10 +591,22 @@ impl AmuxApp {
                 return (cw, ch);
             }
         }
-        let font_id = egui::FontId::monospace(FONT_SIZE);
+        let font_id = egui::FontId::monospace(self.font_size);
         let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
         let cell_height = ui.fonts(|f| f.row_height(&font_id));
         (cell_width, cell_height)
+    }
+
+    fn change_font_size(&mut self, delta: f32) {
+        self.font_size = (self.font_size + delta).clamp(MIN_FONT_SIZE, MAX_FONT_SIZE);
+        self.apply_font_size_change();
+    }
+
+    fn apply_font_size_change(&mut self) {
+        #[cfg(feature = "gpu-renderer")]
+        if let Some(gpu) = &mut self.gpu_renderer {
+            gpu.set_font_size(self.font_size);
+        }
     }
 
     fn active_workspace(&self) -> &Workspace {
@@ -1143,6 +1159,7 @@ impl AmuxApp {
             is_focused,
             surface.scroll_offset,
             selection.as_ref(),
+            self.font_size,
             #[cfg(feature = "gpu-renderer")]
             self.gpu_renderer.as_ref(),
             #[cfg(feature = "gpu-renderer")]
@@ -1784,6 +1801,26 @@ impl AmuxApp {
                 if modifiers.shift && *key == egui::Key::PageDown {
                     return self.do_scroll(1);
                 }
+
+                // Font size: Cmd+Plus / Cmd+Minus / Cmd+0
+                if is_cmd && !modifiers.shift && *key == egui::Key::Plus {
+                    self.change_font_size(1.0);
+                    return true;
+                }
+                if is_cmd && !modifiers.shift && *key == egui::Key::Equals {
+                    // Equals key often sends Plus on some keyboards
+                    self.change_font_size(1.0);
+                    return true;
+                }
+                if is_cmd && !modifiers.shift && *key == egui::Key::Minus {
+                    self.change_font_size(-1.0);
+                    return true;
+                }
+                if is_cmd && !modifiers.shift && *key == egui::Key::Num0 {
+                    self.font_size = DEFAULT_FONT_SIZE;
+                    self.apply_font_size_change();
+                    return true;
+                }
             }
         }
 
@@ -1810,7 +1847,7 @@ impl AmuxApp {
             if let Some(pane_id) = target_pane {
                 if let Some(managed) = self.panes.get_mut(&pane_id) {
                     let surface = managed.active_surface_mut();
-                    let font_id = egui::FontId::monospace(FONT_SIZE);
+                    let font_id = egui::FontId::monospace(self.font_size);
                     let cell_height = ctx.fonts(|f| f.row_height(&font_id));
 
                     surface.scroll_accum += -scroll_delta / cell_height;
@@ -3217,6 +3254,7 @@ fn render_pane(
     is_focused: bool,
     scroll_offset: usize,
     selection: Option<&SelectionState>,
+    font_size: f32,
     #[cfg(feature = "gpu-renderer")] gpu_renderer: Option<&GpuRenderer>,
     #[cfg(feature = "gpu-renderer")] pane_id: u64,
 ) {
@@ -3253,7 +3291,7 @@ fn render_pane(
         return;
     }
 
-    let font_id = egui::FontId::monospace(FONT_SIZE);
+    let font_id = egui::FontId::monospace(font_size);
     let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
     let cell_height = ui.fonts(|f| f.row_height(&font_id));
 
@@ -3397,7 +3435,7 @@ fn render_pane(
     // Scroll indicator
     if scroll_offset > 0 {
         let indicator = format!("[+{}]", scroll_offset);
-        let indicator_font = egui::FontId::monospace(FONT_SIZE * 0.8);
+        let indicator_font = egui::FontId::monospace(font_size * 0.8);
         let text_color = egui::Color32::from_rgba_unmultiplied(255, 200, 50, 200);
         let bg_color = egui::Color32::from_rgba_unmultiplied(40, 40, 40, 180);
 

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -113,6 +113,29 @@ impl GpuRenderer {
         self.cell_height
     }
 
+    /// Update font size, re-measure cell dimensions, and invalidate caches.
+    pub fn set_font_size(&mut self, font_size: f32) {
+        let line_height = (font_size * 1.3).ceil();
+        let metrics = Metrics::new(font_size, line_height);
+
+        if let Some(r) = self
+            .render_state
+            .renderer
+            .write()
+            .callback_resources
+            .get_mut::<TerminalGpuResources>()
+        {
+            let cell_width = measure_cell_width(&mut r.font_system, metrics);
+            r.metrics = metrics;
+            // Clear all pane render states to force full rebuild with new metrics.
+            r.pane_states.clear();
+            // Mark atlas bind group dirty since glyph sizes will change.
+            r.atlas_bind_group_dirty = true;
+            self.cell_width = cell_width;
+            self.cell_height = line_height;
+        }
+    }
+
     /// Remove cached render state for panes that no longer exist.
     pub fn retain_panes(&self, live_pane_ids: &[u64]) {
         if let Some(r) = self


### PR DESCRIPTION
## Summary
- Add runtime font size adjustment: Cmd+Plus (increase), Cmd+Minus (decrease), Cmd+0 (reset to 14pt)
- Font size clamped between 8pt and 36pt with 1pt increments
- GPU renderer re-measures cell dimensions via cosmic-text and clears pane render caches on change
- Soft renderer fallback works via the existing egui font measurement path
- Pane resize happens automatically since `resize_pane_if_needed()` reads `cell_dimensions()` each frame

## Test plan
- [ ] Cmd+Plus increases font size, text scales up
- [ ] Cmd+Minus decreases font size, text scales down
- [ ] Cmd+0 resets to default 14pt
- [ ] Font size does not go below 8pt or above 36pt
- [ ] Pane grid re-tiles correctly after font size change
- [ ] `cargo build --no-default-features` (soft renderer fallback) still compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic font sizing now available with keyboard shortcuts: Cmd+Plus (increase), Cmd+Minus (decrease), Cmd+0 (reset).
  * Font size changes apply throughout the app and terminal rendering with configurable minimum and maximum bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->