### PR TITLE
Phase 9: Terminal feature completeness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "dirs",
  "eframe",
  "egui",
+ "open",
  "portable-pty",
  "serde",
  "serde_json",
@@ -1794,6 +1795,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,6 +2667,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +2745,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ dependencies = [
  "cosmic-text",
  "egui",
  "egui-wgpu",
+ "image",
  "tracing",
  "wezterm-surface",
  "wezterm-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ clap = { version = "4", features = ["derive"] }
 # Utilities
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
+open = "5"
 
 # Error handling
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ egui = "0.31"
 # Font rendering
 cosmic-text = "0.12"
 
+# Image decoding
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
+
 # GPU rendering
 wgpu = "24.0"
 egui-wgpu = "0.31"

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -28,3 +28,4 @@ amux-session = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 dirs = { workspace = true }
+open = { workspace = true }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -620,7 +620,18 @@ impl AmuxApp {
     fn set_focus(&mut self, pane_id: PaneId) {
         let ws = self.active_workspace_mut();
         if ws.focused_pane != pane_id {
+            let old_id = ws.focused_pane;
             ws.focused_pane = pane_id;
+
+            // Send DECSET 1004 focus-out to old pane
+            if let Some(managed) = self.panes.get_mut(&old_id) {
+                managed.active_surface_mut().pane.focus_changed(false);
+            }
+            // Send DECSET 1004 focus-in to new pane
+            if let Some(managed) = self.panes.get_mut(&pane_id) {
+                managed.active_surface_mut().pane.focus_changed(true);
+            }
+
             // Clear notifications on the newly focused pane
             self.notifications.mark_pane_read(pane_id);
             // Navigation flash — but suppress if other panes have unread
@@ -1794,6 +1805,12 @@ impl AmuxApp {
                     return true;
                 }
 
+                // Clear scrollback: Cmd+K (macOS) / Ctrl+Shift+K (other)
+                if is_cmd && !modifiers.shift && *key == egui::Key::K {
+                    self.do_clear_scrollback();
+                    return true;
+                }
+
                 // Scroll
                 if modifiers.shift && *key == egui::Key::PageUp {
                     return self.do_scroll(-1);
@@ -1856,6 +1873,31 @@ impl AmuxApp {
                         surface.scroll_accum -= whole_lines as f32;
                         self.do_scroll_lines_for(pane_id, whole_lines);
                     }
+                }
+            }
+        }
+
+        // Focus-follows-mouse: set focus to the pane under the cursor on click
+        if ctx.input(|i| i.pointer.primary_clicked()) {
+            let hover_pos = ctx.input(|i| i.pointer.hover_pos());
+            let target_pane = hover_pos.and_then(|pos| {
+                let panel_rect = self.last_panel_rect?;
+                let ws = self.active_workspace();
+                if let Some(zoomed_id) = ws.zoomed {
+                    if panel_rect.contains(pos) {
+                        return Some(zoomed_id);
+                    }
+                    return None;
+                }
+                let layout = ws.tree.layout(panel_rect);
+                layout
+                    .iter()
+                    .find(|(_, rect)| rect.contains(pos))
+                    .map(|(id, _)| *id)
+            });
+            if let Some(pane_id) = target_pane {
+                if pane_id != self.focused_pane_id() {
+                    self.set_focus(pane_id);
                 }
             }
         }
@@ -1974,6 +2016,15 @@ impl AmuxApp {
             let max_offset = total.saturating_sub(rows);
             let new_offset = surface.scroll_offset as isize - lines;
             surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
+        }
+    }
+
+    fn do_clear_scrollback(&mut self) {
+        let focused_id = self.focused_pane_id();
+        if let Some(managed) = self.panes.get_mut(&focused_id) {
+            let surface = managed.active_surface_mut();
+            surface.pane.erase_scrollback();
+            surface.scroll_offset = 0;
         }
     }
 
@@ -3310,6 +3361,12 @@ fn render_pane(
 
     // Fill the full allocated rect first to avoid artifacts when terminal is smaller
     painter.rect_filled(rect, 0.0, bg_default);
+
+    // Dim unfocused panes with a semi-transparent overlay
+    if !is_focused {
+        let dim_overlay = egui::Color32::from_rgba_unmultiplied(0, 0, 0, 100);
+        painter.rect_filled(rect, 0.0, dim_overlay);
+    }
 
     let total = screen.scrollback_rows();
     let end = total.saturating_sub(scroll_offset);

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -130,6 +130,7 @@ fn main() -> anyhow::Result<()> {
                 wants_exit: false,
                 font_size: DEFAULT_FONT_SIZE,
                 find_state: None,
+                copy_mode: None,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
             }))
@@ -489,6 +490,17 @@ struct FindState {
     pane_id: PaneId,
 }
 
+/// State for vi-style copy mode (scrollback navigation + visual selection).
+struct CopyModeState {
+    pane_id: PaneId,
+    /// Cursor position in (col, phys_row).
+    cursor: (usize, usize),
+    /// Visual selection anchor (col, phys_row), set when 'v' is pressed.
+    visual_anchor: Option<(usize, usize)>,
+    /// Line-visual mode (V).
+    line_visual: bool,
+}
+
 /// Word boundary delimiters for double-click selection.
 const WORD_DELIMITERS: &str = " \t\n()[]{}'\"|<>&;:,.`~!@#$%^*-+=?/\\";
 
@@ -587,6 +599,7 @@ struct AmuxApp {
     wants_exit: bool,
     font_size: f32,
     find_state: Option<FindState>,
+    copy_mode: Option<CopyModeState>,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
 }
@@ -869,8 +882,9 @@ impl eframe::App for AmuxApp {
         let shortcut_consumed = self.handle_shortcuts(ctx);
 
         // Handle keyboard/paste input -> focused pane's active surface only
+        // (blocked during copy mode — all keys go through handle_copy_mode_key)
         let mut sent_input = false;
-        if !shortcut_consumed {
+        if !shortcut_consumed && self.copy_mode.is_none() {
             sent_input = self.handle_input(ctx);
         }
 
@@ -1183,12 +1197,41 @@ impl AmuxApp {
             .map(|f| (f.matches.clone(), Some(f.current_match)))
             .unwrap_or_default();
 
+        // Build selection: use copy mode visual selection if active, else normal selection
+        let copy_mode_sel = self
+            .copy_mode
+            .as_ref()
+            .filter(|cm| cm.pane_id == pane_id && cm.visual_anchor.is_some())
+            .map(|cm| {
+                let anchor = cm.visual_anchor.unwrap();
+                let cursor = cm.cursor;
+                let (start, end) =
+                    if anchor.1 < cursor.1 || (anchor.1 == cursor.1 && anchor.0 <= cursor.0) {
+                        (anchor, cursor)
+                    } else {
+                        (cursor, anchor)
+                    };
+                SelectionState {
+                    anchor: start,
+                    end,
+                    mode: if cm.line_visual {
+                        SelectionMode::Line
+                    } else {
+                        SelectionMode::Cell
+                    },
+                    active: false,
+                }
+            });
+
         // Render terminal content for the active surface
         let managed = match self.panes.get_mut(&pane_id) {
             Some(m) => m,
             None => return,
         };
-        let selection = managed.selection.as_ref().cloned();
+        let selection = copy_mode_sel
+            .as_ref()
+            .or(managed.selection.as_ref())
+            .cloned();
         let surface = managed.active_surface_mut();
         render_pane(
             ui,
@@ -1205,6 +1248,31 @@ impl AmuxApp {
             #[cfg(feature = "gpu-renderer")]
             pane_id,
         );
+
+        // Render copy mode cursor overlay
+        if let Some(cm) = self.copy_mode.as_ref().filter(|cm| cm.pane_id == pane_id) {
+            let (cell_w, cell_h) = self.cell_dimensions(ui);
+            if let Some(managed) = self.panes.get(&pane_id) {
+                let surface = managed.active_surface();
+                let (_, rows) = surface.pane.dimensions();
+                let total = surface.pane.screen().scrollback_rows();
+                let end = total.saturating_sub(surface.scroll_offset);
+                let start = end.saturating_sub(rows);
+                if cm.cursor.1 >= start && cm.cursor.1 < end {
+                    let row_in_view = cm.cursor.1 - start;
+                    let x = content_rect.min.x + cm.cursor.0 as f32 * cell_w;
+                    let y = content_rect.min.y + TAB_BAR_HEIGHT + row_in_view as f32 * cell_h;
+                    let cursor_rect =
+                        egui::Rect::from_min_size(egui::pos2(x, y), egui::vec2(cell_w, cell_h));
+                    ui.painter().rect_stroke(
+                        cursor_rect,
+                        0.0,
+                        egui::Stroke::new(2.0, egui::Color32::from_rgb(0, 255, 0)),
+                        egui::StrokeKind::Inside,
+                    );
+                }
+            }
+        }
 
         // Notification ring + flash animation (matching cmux)
         let pane_u64 = pane_id;
@@ -1611,7 +1679,12 @@ impl AmuxApp {
                     return true;
                 }
 
-                // Escape: close find bar or clear selection
+                // Copy mode: intercept all keys when active
+                if self.copy_mode.is_some() {
+                    return self.handle_copy_mode_key(key, modifiers);
+                }
+
+                // Escape: close find bar, exit copy mode, or clear selection
                 if *key == egui::Key::Escape
                     && !modifiers.shift
                     && !modifiers.ctrl
@@ -1651,6 +1724,12 @@ impl AmuxApp {
                 #[cfg(not(target_os = "macos"))]
                 if modifiers.ctrl && modifiers.shift && *key == egui::Key::A {
                     self.select_all_visible();
+                    return true;
+                }
+
+                // Enter copy mode: Cmd+Shift+X (macOS) / Ctrl+Shift+X (other)
+                if is_cmd && modifiers.shift && *key == egui::Key::X {
+                    self.enter_copy_mode();
                     return true;
                 }
 
@@ -2107,6 +2186,196 @@ impl AmuxApp {
             }
             self.set_focus(pane_id);
         }
+    }
+
+    fn enter_copy_mode(&mut self) {
+        let pane_id = self.focused_pane_id();
+        if let Some(managed) = self.panes.get(&pane_id) {
+            let surface = managed.active_surface();
+            let cursor = surface.pane.cursor();
+            let screen = surface.pane.screen();
+            let (_, rows) = surface.pane.dimensions();
+            let total = screen.scrollback_rows();
+            let end = total.saturating_sub(surface.scroll_offset);
+            let start = end.saturating_sub(rows);
+            // Place copy mode cursor at terminal cursor position in phys coords
+            let phys_row = start + cursor.y as usize;
+            self.copy_mode = Some(CopyModeState {
+                pane_id,
+                cursor: (cursor.x, phys_row),
+                visual_anchor: None,
+                line_visual: false,
+            });
+        }
+    }
+
+    fn handle_copy_mode_key(&mut self, key: &egui::Key, modifiers: &egui::Modifiers) -> bool {
+        let cm = match self.copy_mode.as_mut() {
+            Some(cm) => cm,
+            None => return false,
+        };
+        let pane_id = cm.pane_id;
+
+        // Get dimensions for bounds checking
+        let (cols, rows, total_rows) = match self.panes.get(&pane_id) {
+            Some(m) => {
+                let s = m.active_surface();
+                let (c, r) = s.pane.dimensions();
+                let t = s.pane.screen().scrollback_rows();
+                (c, r, t)
+            }
+            None => {
+                self.copy_mode = None;
+                return true;
+            }
+        };
+        let cm = self.copy_mode.as_mut().unwrap();
+
+        match key {
+            // Exit copy mode
+            egui::Key::Escape | egui::Key::Q => {
+                self.copy_mode = None;
+                return true;
+            }
+            // Movement
+            egui::Key::H | egui::Key::ArrowLeft => {
+                cm.cursor.0 = cm.cursor.0.saturating_sub(1);
+            }
+            egui::Key::L | egui::Key::ArrowRight => {
+                cm.cursor.0 = (cm.cursor.0 + 1).min(cols.saturating_sub(1));
+            }
+            egui::Key::K | egui::Key::ArrowUp => {
+                cm.cursor.1 = cm.cursor.1.saturating_sub(1);
+            }
+            egui::Key::J | egui::Key::ArrowDown => {
+                cm.cursor.1 = (cm.cursor.1 + 1).min(total_rows.saturating_sub(1));
+            }
+            // Half-page up/down
+            egui::Key::U if modifiers.ctrl => {
+                let half = rows / 2;
+                cm.cursor.1 = cm.cursor.1.saturating_sub(half);
+            }
+            egui::Key::D if modifiers.ctrl => {
+                let half = rows / 2;
+                cm.cursor.1 = (cm.cursor.1 + half).min(total_rows.saturating_sub(1));
+            }
+            // Start of scrollback
+            egui::Key::G if modifiers.shift => {
+                cm.cursor.1 = total_rows.saturating_sub(1);
+                cm.cursor.0 = 0;
+            }
+            egui::Key::G => {
+                cm.cursor.1 = 0;
+                cm.cursor.0 = 0;
+            }
+            // Line start/end
+            egui::Key::Num0 => {
+                cm.cursor.0 = 0;
+            }
+            // Visual mode toggle
+            egui::Key::V if modifiers.shift => {
+                // Line visual
+                if cm.line_visual {
+                    cm.visual_anchor = None;
+                    cm.line_visual = false;
+                } else {
+                    cm.visual_anchor = Some(cm.cursor);
+                    cm.line_visual = true;
+                }
+            }
+            egui::Key::V => {
+                // Character visual
+                if cm.visual_anchor.is_some() && !cm.line_visual {
+                    cm.visual_anchor = None;
+                } else {
+                    cm.visual_anchor = Some(cm.cursor);
+                    cm.line_visual = false;
+                }
+            }
+            // Yank selection
+            egui::Key::Y => {
+                let anchor = cm.visual_anchor;
+                let line_visual = cm.line_visual;
+                if let Some(anchor) = anchor {
+                    let text = self.extract_copy_mode_text(pane_id, anchor, cols, line_visual);
+                    if let Some(text) = text {
+                        if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                            let _ = clipboard.set_text(&text);
+                        }
+                    }
+                    self.copy_mode = None;
+                    return true;
+                }
+            }
+            _ => {}
+        }
+
+        // Scroll viewport to keep cursor visible
+        if let Some(managed) = self.panes.get_mut(&pane_id) {
+            let cm = self.copy_mode.as_ref().unwrap();
+            let surface = managed.active_surface_mut();
+            let end = total_rows.saturating_sub(surface.scroll_offset);
+            let start = end.saturating_sub(rows);
+            if cm.cursor.1 < start {
+                surface.scroll_offset = total_rows.saturating_sub(cm.cursor.1 + rows);
+            } else if cm.cursor.1 >= end {
+                surface.scroll_offset = total_rows.saturating_sub(cm.cursor.1 + 1);
+            }
+        }
+
+        true
+    }
+
+    fn extract_copy_mode_text(
+        &self,
+        pane_id: PaneId,
+        anchor: (usize, usize),
+        cols: usize,
+        line_visual: bool,
+    ) -> Option<String> {
+        let cm = self.copy_mode.as_ref()?;
+        let managed = self.panes.get(&pane_id)?;
+        let surface = managed.active_surface();
+        let screen = surface.pane.screen();
+
+        let (start, end) =
+            if anchor.1 < cm.cursor.1 || (anchor.1 == cm.cursor.1 && anchor.0 <= cm.cursor.0) {
+                (anchor, cm.cursor)
+            } else {
+                (cm.cursor, anchor)
+            };
+
+        let lines = screen.lines_in_phys_range(start.1..end.1 + 1);
+        let mut result = String::new();
+
+        for (i, line) in lines.iter().enumerate() {
+            if i > 0 {
+                result.push('\n');
+            }
+            let phys_row = start.1 + i;
+            for cell in line.visible_cells() {
+                let col = cell.cell_index();
+                if col >= cols {
+                    break;
+                }
+                if line_visual {
+                    result.push_str(cell.str());
+                } else {
+                    // Character visual: clip to selection bounds
+                    if phys_row == start.1 && col < start.0 {
+                        continue;
+                    }
+                    if phys_row == end.1 && col > end.0 {
+                        break;
+                    }
+                    result.push_str(cell.str());
+                }
+            }
+        }
+
+        // Trim trailing whitespace per line
+        let trimmed: Vec<&str> = result.lines().map(|l| l.trim_end()).collect();
+        Some(trimmed.join("\n"))
     }
 
     fn render_find_bar(&mut self, ctx: &egui::Context) {

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1010,8 +1010,8 @@ impl eframe::App for AmuxApp {
         self.update_ime_position(ctx);
 
         // Render IME preedit overlay
-        if let Some(ref preedit) = self.ime_preedit.clone() {
-            self.render_ime_preedit(ctx, preedit);
+        if let Some(preedit) = self.ime_preedit.clone() {
+            self.render_ime_preedit(ctx, &preedit);
         }
 
         // Clean up GPU resources for closed panes.
@@ -1289,7 +1289,7 @@ impl AmuxApp {
                 if cm.cursor.1 >= start && cm.cursor.1 < end {
                     let row_in_view = cm.cursor.1 - start;
                     let x = content_rect.min.x + cm.cursor.0 as f32 * cell_w;
-                    let y = content_rect.min.y + TAB_BAR_HEIGHT + row_in_view as f32 * cell_h;
+                    let y = content_rect.min.y + row_in_view as f32 * cell_h;
                     let cursor_rect =
                         egui::Rect::from_min_size(egui::pos2(x, y), egui::vec2(cell_w, cell_h));
                     ui.painter().rect_stroke(
@@ -2153,6 +2153,7 @@ impl AmuxApp {
             let surface = managed.active_surface_mut();
             surface.pane.erase_scrollback();
             surface.scroll_offset = 0;
+            surface.scroll_accum = 0.0;
         }
     }
 
@@ -2374,6 +2375,9 @@ impl AmuxApp {
             }
         };
         let content_top = pane_rect.min.y + TAB_BAR_HEIGHT;
+        if hover_pos.y < content_top || hover_pos.x < pane_rect.min.x {
+            return;
+        }
         let col = ((hover_pos.x - pane_rect.min.x) / cell_w) as usize;
         let row = ((hover_pos.y - content_top) / cell_h) as usize;
 
@@ -2439,7 +2443,7 @@ impl AmuxApp {
             let end = total.saturating_sub(surface.scroll_offset);
             let start = end.saturating_sub(rows);
             // Place copy mode cursor at terminal cursor position in phys coords
-            let phys_row = start + cursor.y as usize;
+            let phys_row = start + (cursor.y.max(0) as usize).min(rows.saturating_sub(1));
             self.copy_mode = Some(CopyModeState {
                 pane_id,
                 cursor: (cursor.x, phys_row),
@@ -2499,11 +2503,12 @@ impl AmuxApp {
                 let half = rows / 2;
                 cm.cursor.1 = (cm.cursor.1 + half).min(total_rows.saturating_sub(1));
             }
-            // Start of scrollback
+            // End of scrollback (Shift+G = vim 'G')
             egui::Key::G if modifiers.shift => {
                 cm.cursor.1 = total_rows.saturating_sub(1);
                 cm.cursor.0 = 0;
             }
+            // Start of scrollback (g = vim 'gg', second g handled by repeat)
             egui::Key::G => {
                 cm.cursor.1 = 0;
                 cm.cursor.0 = 0;

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -129,6 +129,7 @@ fn main() -> anyhow::Result<()> {
                 click_count: 0,
                 wants_exit: false,
                 font_size: DEFAULT_FONT_SIZE,
+                find_state: None,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
             }))
@@ -478,6 +479,16 @@ impl SelectionState {
     }
 }
 
+/// State for the in-pane find/search bar.
+struct FindState {
+    query: String,
+    /// Matches as (phys_row, start_col, end_col_exclusive).
+    matches: Vec<(usize, usize, usize)>,
+    current_match: usize,
+    /// The pane this search applies to.
+    pane_id: PaneId,
+}
+
 /// Word boundary delimiters for double-click selection.
 const WORD_DELIMITERS: &str = " \t\n()[]{}'\"|<>&;:,.`~!@#$%^*-+=?/\\";
 
@@ -575,6 +586,7 @@ struct AmuxApp {
     click_count: u32,
     wants_exit: bool,
     font_size: f32,
+    find_state: Option<FindState>,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
 }
@@ -857,8 +869,9 @@ impl eframe::App for AmuxApp {
         let shortcut_consumed = self.handle_shortcuts(ctx);
 
         // Handle keyboard/paste input -> focused pane's active surface only
+        let mut sent_input = false;
         if !shortcut_consumed {
-            self.handle_input(ctx);
+            sent_input = self.handle_input(ctx);
         }
 
         // Render sidebar
@@ -945,6 +958,11 @@ impl eframe::App for AmuxApp {
             self.render_notification_panel(ctx);
         }
 
+        // Find bar overlay
+        if self.find_state.is_some() {
+            self.render_find_bar(ctx);
+        }
+
         // Update window title from focused pane's active surface
         let focused_id = self.focused_pane_id();
         if let Some(managed) = self.panes.get(&focused_id) {
@@ -961,8 +979,9 @@ impl eframe::App for AmuxApp {
             gpu.retain_panes(&live_ids);
         }
 
-        // Smart repaint
-        if got_data {
+        // Smart repaint: immediate when data arrived or input was sent (to
+        // catch the PTY echo on the very next frame), otherwise poll at 50ms.
+        if got_data || sent_input || shortcut_consumed {
             ctx.request_repaint();
         } else {
             ctx.request_repaint_after(Duration::from_millis(50));
@@ -1156,6 +1175,14 @@ impl AmuxApp {
             }
         }
 
+        // Collect find highlights for this pane
+        let (find_highlights, current_highlight) = self
+            .find_state
+            .as_ref()
+            .filter(|f| f.pane_id == pane_id)
+            .map(|f| (f.matches.clone(), Some(f.current_match)))
+            .unwrap_or_default();
+
         // Render terminal content for the active surface
         let managed = match self.panes.get_mut(&pane_id) {
             Some(m) => m,
@@ -1171,6 +1198,8 @@ impl AmuxApp {
             surface.scroll_offset,
             selection.as_ref(),
             self.font_size,
+            &find_highlights,
+            current_highlight,
             #[cfg(feature = "gpu-renderer")]
             self.gpu_renderer.as_ref(),
             #[cfg(feature = "gpu-renderer")]
@@ -1582,12 +1611,16 @@ impl AmuxApp {
                     return true;
                 }
 
-                // Escape: clear selection if active
+                // Escape: close find bar or clear selection
                 if *key == egui::Key::Escape
                     && !modifiers.shift
                     && !modifiers.ctrl
                     && !modifiers.alt
                 {
+                    if self.find_state.is_some() {
+                        self.find_state = None;
+                        return true;
+                    }
                     let focused = self.focused_pane_id();
                     if let Some(m) = self.panes.get_mut(&focused) {
                         if m.selection.is_some() {
@@ -1595,6 +1628,18 @@ impl AmuxApp {
                             return true;
                         }
                     }
+                }
+
+                // Find: Cmd+F (macOS) / Ctrl+Shift+F (other)
+                if is_cmd && !modifiers.shift && *key == egui::Key::F {
+                    let pane_id = self.focused_pane_id();
+                    self.find_state = Some(FindState {
+                        query: String::new(),
+                        matches: Vec::new(),
+                        current_match: 0,
+                        pane_id,
+                    });
+                    return true;
                 }
 
                 // Select all: Cmd+A
@@ -1877,31 +1922,6 @@ impl AmuxApp {
             }
         }
 
-        // Focus-follows-mouse: set focus to the pane under the cursor on click
-        if ctx.input(|i| i.pointer.primary_clicked()) {
-            let hover_pos = ctx.input(|i| i.pointer.hover_pos());
-            let target_pane = hover_pos.and_then(|pos| {
-                let panel_rect = self.last_panel_rect?;
-                let ws = self.active_workspace();
-                if let Some(zoomed_id) = ws.zoomed {
-                    if panel_rect.contains(pos) {
-                        return Some(zoomed_id);
-                    }
-                    return None;
-                }
-                let layout = ws.tree.layout(panel_rect);
-                layout
-                    .iter()
-                    .find(|(_, rect)| rect.contains(pos))
-                    .map(|(id, _)| *id)
-            });
-            if let Some(pane_id) = target_pane {
-                if pane_id != self.focused_pane_id() {
-                    self.set_focus(pane_id);
-                }
-            }
-        }
-
         false
     }
 
@@ -2086,6 +2106,109 @@ impl AmuxApp {
                 self.active_workspace_idx = idx;
             }
             self.set_focus(pane_id);
+        }
+    }
+
+    fn render_find_bar(&mut self, ctx: &egui::Context) {
+        let mut close = false;
+        let mut navigate: Option<isize> = None; // +1 = next, -1 = prev
+
+        egui::Window::new("Find")
+            .collapsible(false)
+            .resizable(false)
+            .anchor(egui::Align2::RIGHT_TOP, [-8.0, 8.0])
+            .fixed_size([300.0, 0.0])
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    let response =
+                        ui.text_edit_singleline(&mut self.find_state.as_mut().unwrap().query);
+
+                    // Auto-focus the text field
+                    if response.gained_focus() || !response.has_focus() {
+                        response.request_focus();
+                    }
+
+                    // Enter = next, Shift+Enter = prev
+                    if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                        if ui.input(|i| i.modifiers.shift) {
+                            navigate = Some(-1);
+                        } else {
+                            navigate = Some(1);
+                        }
+                        response.request_focus();
+                    }
+
+                    // Trigger search on text change
+                    if response.changed() {
+                        let find = self.find_state.as_ref().unwrap();
+                        let query = find.query.clone();
+                        let pane_id = find.pane_id;
+                        if let Some(managed) = self.panes.get(&pane_id) {
+                            let matches = managed.active_surface().pane.search_scrollback(&query);
+                            let find = self.find_state.as_mut().unwrap();
+                            find.matches = matches;
+                            find.current_match = 0;
+                        }
+                    }
+
+                    if ui.button("X").clicked() {
+                        close = true;
+                    }
+                });
+
+                // Show match count
+                if let Some(find) = &self.find_state {
+                    let total = find.matches.len();
+                    if total > 0 {
+                        ui.horizontal(|ui| {
+                            ui.label(format!("{}/{}", find.current_match + 1, total));
+                            if ui.button("<").clicked() {
+                                navigate = Some(-1);
+                            }
+                            if ui.button(">").clicked() {
+                                navigate = Some(1);
+                            }
+                        });
+                    } else if !find.query.is_empty() {
+                        ui.label("No matches");
+                    }
+                }
+            });
+
+        if close {
+            self.find_state = None;
+            return;
+        }
+
+        // Navigate matches
+        if let Some(dir) = navigate {
+            if let Some(find) = self.find_state.as_mut() {
+                if !find.matches.is_empty() {
+                    let total = find.matches.len();
+                    if dir > 0 {
+                        find.current_match = (find.current_match + 1) % total;
+                    } else {
+                        find.current_match = if find.current_match == 0 {
+                            total - 1
+                        } else {
+                            find.current_match - 1
+                        };
+                    }
+
+                    // Scroll to the current match
+                    let (phys_row, _, _) = find.matches[find.current_match];
+                    let pane_id = find.pane_id;
+                    if let Some(managed) = self.panes.get_mut(&pane_id) {
+                        let surface = managed.active_surface_mut();
+                        let (_, rows) = surface.pane.dimensions();
+                        let total_rows = surface.pane.screen().scrollback_rows();
+                        // Calculate scroll offset to center the match
+                        let target_end = phys_row + rows / 2;
+                        let actual_end = target_end.min(total_rows);
+                        surface.scroll_offset = total_rows.saturating_sub(actual_end);
+                    }
+                }
+            }
         }
     }
 
@@ -2512,7 +2635,7 @@ impl AmuxApp {
 
     // --- Input ---
 
-    fn handle_input(&mut self, ctx: &egui::Context) {
+    fn handle_input(&mut self, ctx: &egui::Context) -> bool {
         let events = ctx.input(|i| i.events.clone());
         let focused_id = self.focused_pane_id();
 
@@ -2531,7 +2654,7 @@ impl AmuxApp {
 
         let managed = match self.panes.get_mut(&focused_id) {
             Some(m) => m,
-            None => return,
+            None => return has_input,
         };
         let surface = managed.active_surface_mut();
 
@@ -2568,6 +2691,7 @@ impl AmuxApp {
                 _ => {}
             }
         }
+        has_input
     }
 
     // --- IPC ---
@@ -3306,6 +3430,8 @@ fn render_pane(
     scroll_offset: usize,
     selection: Option<&SelectionState>,
     font_size: f32,
+    find_highlights: &[(usize, usize, usize)],
+    current_highlight: Option<usize>,
     #[cfg(feature = "gpu-renderer")] gpu_renderer: Option<&GpuRenderer>,
     #[cfg(feature = "gpu-renderer")] pane_id: u64,
 ) {
@@ -3335,6 +3461,8 @@ fn render_pane(
             gpu_selection,
             pane_id,
             seqno,
+            find_highlights.to_vec(),
+            current_highlight,
         );
         let pixels_per_point = ui.ctx().pixels_per_point();
         let callback = gpu.paint_callback(rect, snapshot, pixels_per_point);
@@ -3406,6 +3534,20 @@ fn render_pane(
                         bg = srgba_to_egui(palette.foreground);
                         fg = bg_default;
                     }
+                }
+            }
+
+            // Find/search highlighting
+            for (i, &(h_row, h_start, h_end)) in find_highlights.iter().enumerate() {
+                if h_row == stable_row && col_idx >= h_start && col_idx < h_end {
+                    if current_highlight == Some(i) {
+                        bg = egui::Color32::from_rgb(255, 153, 0); // orange
+                    } else {
+                        bg = egui::Color32::from_rgba_unmultiplied(255, 255, 0, 180);
+                        // yellow
+                    }
+                    fg = egui::Color32::BLACK;
+                    break;
                 }
             }
 

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -3170,7 +3170,14 @@ impl AmuxApp {
                         let surface = self.resolve_surface(&params.surface_id);
                         match surface {
                             Some(sf) => {
-                                let text = sf.pane.read_screen_text();
+                                let text = if let Some(ref line_spec) = params.lines {
+                                    sf.pane.read_screen_lines(line_spec, params.ansi)
+                                } else if params.ansi {
+                                    let (_, rows) = sf.pane.dimensions();
+                                    sf.pane.read_scrollback_text(rows)
+                                } else {
+                                    sf.pane.read_screen_text()
+                                };
                                 Response::ok(req.id.clone(), serde_json::json!({"text": text}))
                             }
                             None => Response::err(req.id.clone(), "not_found", "surface not found"),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -131,6 +131,7 @@ fn main() -> anyhow::Result<()> {
                 font_size: DEFAULT_FONT_SIZE,
                 find_state: None,
                 copy_mode: None,
+                hovered_hyperlink: None,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
             }))
@@ -600,6 +601,7 @@ struct AmuxApp {
     font_size: f32,
     find_state: Option<FindState>,
     copy_mode: Option<CopyModeState>,
+    hovered_hyperlink: Option<String>,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
 }
@@ -976,6 +978,9 @@ impl eframe::App for AmuxApp {
         if self.find_state.is_some() {
             self.render_find_bar(ctx);
         }
+
+        // Hyperlink hover detection + Cmd+click handling
+        self.handle_hyperlinks(ctx);
 
         // Update window title from focused pane's active surface
         let focused_id = self.focused_pane_id();
@@ -2185,6 +2190,125 @@ impl AmuxApp {
                 self.active_workspace_idx = idx;
             }
             self.set_focus(pane_id);
+        }
+    }
+
+    fn handle_hyperlinks(&mut self, ctx: &egui::Context) {
+        self.hovered_hyperlink = None;
+
+        let hover_pos = match ctx.input(|i| i.pointer.hover_pos()) {
+            Some(pos) => pos,
+            None => return,
+        };
+
+        let panel_rect = match self.last_panel_rect {
+            Some(r) => r,
+            None => return,
+        };
+
+        // Find which pane the mouse is over
+        let ws = self.active_workspace();
+        let pane_id = if let Some(zoomed_id) = ws.zoomed {
+            if panel_rect.contains(hover_pos) {
+                zoomed_id
+            } else {
+                return;
+            }
+        } else {
+            let layout = ws.tree.layout(panel_rect);
+            match layout
+                .iter()
+                .find(|(_, rect)| rect.contains(hover_pos))
+                .map(|(id, _)| *id)
+            {
+                Some(id) => id,
+                None => return,
+            }
+        };
+
+        // Resolve cell coordinates from pixel position
+        let (cell_w, cell_h) = ctx.fonts(|f| {
+            let fid = egui::FontId::monospace(self.font_size);
+            (f.glyph_width(&fid, 'M'), f.row_height(&fid))
+        });
+
+        #[cfg(feature = "gpu-renderer")]
+        let (cell_w, cell_h) = if let Some(gpu) = &self.gpu_renderer {
+            let cw = gpu.cell_width();
+            let ch = gpu.cell_height();
+            if cw > 0.0 && ch > 0.0 {
+                (cw, ch)
+            } else {
+                (cell_w, cell_h)
+            }
+        } else {
+            (cell_w, cell_h)
+        };
+
+        if cell_w <= 0.0 || cell_h <= 0.0 {
+            return;
+        }
+
+        // Get the content rect (below tab bar) for this pane
+        let pane_rect = if let Some(zoomed_id) = self.active_workspace().zoomed {
+            if zoomed_id == pane_id {
+                panel_rect
+            } else {
+                return;
+            }
+        } else {
+            let layout = self.active_workspace().tree.layout(panel_rect);
+            match layout.iter().find(|(id, _)| *id == pane_id) {
+                Some((_, r)) => *r,
+                None => return,
+            }
+        };
+        let content_top = pane_rect.min.y + TAB_BAR_HEIGHT;
+        let col = ((hover_pos.x - pane_rect.min.x) / cell_w) as usize;
+        let row = ((hover_pos.y - content_top) / cell_h) as usize;
+
+        // Check if cell has a hyperlink
+        if let Some(managed) = self.panes.get(&pane_id) {
+            let surface = managed.active_surface();
+            let (cols, rows) = surface.pane.dimensions();
+            if col >= cols || row >= rows {
+                return;
+            }
+            let screen = surface.pane.screen();
+            let total = screen.scrollback_rows();
+            let end = total.saturating_sub(surface.scroll_offset);
+            let start = end.saturating_sub(rows);
+            let phys_row = start + row;
+            let lines = screen.lines_in_phys_range(phys_row..phys_row + 1);
+            if let Some(line) = lines.first() {
+                for cell in line.visible_cells() {
+                    if cell.cell_index() == col {
+                        if let Some(link) = cell.attrs().hyperlink() {
+                            let url = link.uri().to_string();
+                            self.hovered_hyperlink = Some(url.clone());
+
+                            // Set pointer cursor
+                            ctx.set_cursor_icon(egui::CursorIcon::PointingHand);
+
+                            // Cmd+click opens URL
+                            let cmd_held = ctx.input(|i| {
+                                #[cfg(target_os = "macos")]
+                                {
+                                    i.modifiers.mac_cmd || i.modifiers.command
+                                }
+                                #[cfg(not(target_os = "macos"))]
+                                {
+                                    i.modifiers.ctrl
+                                }
+                            });
+                            if cmd_held && ctx.input(|i| i.pointer.primary_clicked()) {
+                                let _ = open::that(&url);
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -490,6 +490,8 @@ struct FindState {
     current_match: usize,
     /// The pane this search applies to.
     pane_id: PaneId,
+    /// True on the first frame after opening, for initial focus.
+    just_opened: bool,
 }
 
 /// State for vi-style copy mode (scrollback navigation + visual selection).
@@ -1726,6 +1728,7 @@ impl AmuxApp {
                         matches: Vec::new(),
                         current_match: 0,
                         pane_id,
+                        just_opened: true,
                     });
                     return true;
                 }
@@ -2228,9 +2231,11 @@ impl AmuxApp {
         if let Some(managed) = self.panes.get(&focused_id) {
             let surface = managed.active_surface();
             let cursor = surface.pane.cursor();
-            let font_id = egui::FontId::monospace(self.font_size);
-            let (cell_w, cell_h) =
-                ctx.fonts(|f| (f.glyph_width(&font_id, 'M'), f.row_height(&font_id)));
+            let (dim_cols, dim_rows) = surface.pane.dimensions();
+            let cols = dim_cols.max(1) as f32;
+            let rows = dim_rows.max(1) as f32;
+            let cell_w = pane_rect.width() / cols;
+            let cell_h = (pane_rect.height() - TAB_BAR_HEIGHT) / rows;
             let x = pane_rect.min.x + cursor.x as f32 * cell_w;
             let y = pane_rect.min.y + TAB_BAR_HEIGHT + cursor.y as f32 * cell_h;
             ctx.send_viewport_cmd(egui::ViewportCommand::IMERect(egui::Rect::from_min_size(
@@ -2264,9 +2269,11 @@ impl AmuxApp {
         if let Some(managed) = self.panes.get(&focused_id) {
             let surface = managed.active_surface();
             let cursor = surface.pane.cursor();
-            let font_id = egui::FontId::monospace(self.font_size);
-            let (cell_w, cell_h) =
-                ctx.fonts(|f| (f.glyph_width(&font_id, 'M'), f.row_height(&font_id)));
+            let (dim_cols, dim_rows) = surface.pane.dimensions();
+            let cols = dim_cols.max(1) as f32;
+            let rows = dim_rows.max(1) as f32;
+            let cell_w = pane_rect.width() / cols;
+            let cell_h = (pane_rect.height() - TAB_BAR_HEIGHT) / rows;
             let x = pane_rect.min.x + cursor.x as f32 * cell_w;
             let y = pane_rect.min.y + TAB_BAR_HEIGHT + cursor.y as f32 * cell_h;
 
@@ -2394,7 +2401,13 @@ impl AmuxApp {
                                 }
                             });
                             if cmd_held && ctx.input(|i| i.pointer.primary_clicked()) {
-                                let _ = open::that(&url);
+                                // Only open safe URL schemes.
+                                if url.starts_with("http://")
+                                    || url.starts_with("https://")
+                                    || url.starts_with("mailto:")
+                                {
+                                    let _ = open::that(&url);
+                                }
                             }
                         }
                         break;
@@ -2608,9 +2621,12 @@ impl AmuxApp {
                     let response =
                         ui.text_edit_singleline(&mut self.find_state.as_mut().unwrap().query);
 
-                    // Auto-focus the text field
-                    if response.gained_focus() || !response.has_focus() {
-                        response.request_focus();
+                    // Auto-focus the text field on first show
+                    if let Some(fs) = self.find_state.as_mut() {
+                        if fs.just_opened {
+                            response.request_focus();
+                            fs.just_opened = false;
+                        }
                     }
 
                     // Enter = next, Shift+Enter = prev
@@ -3177,6 +3193,7 @@ impl AmuxApp {
                     egui::ImeEvent::Commit(text) => {
                         surface.scroll_offset = 0;
                         surface.scroll_accum = 0.0;
+                        self.ime_preedit = None;
                         let _ = surface.pane.write_bytes(text.as_bytes());
                     }
                     egui::ImeEvent::Preedit(text) => {

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -132,6 +132,7 @@ fn main() -> anyhow::Result<()> {
                 find_state: None,
                 copy_mode: None,
                 hovered_hyperlink: None,
+                ime_preedit: None,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
             }))
@@ -602,6 +603,7 @@ struct AmuxApp {
     find_state: Option<FindState>,
     copy_mode: Option<CopyModeState>,
     hovered_hyperlink: Option<String>,
+    ime_preedit: Option<String>,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
 }
@@ -989,6 +991,14 @@ impl eframe::App for AmuxApp {
             if !title.is_empty() {
                 ctx.send_viewport_cmd(egui::ViewportCommand::Title(format!("amux — {}", title)));
             }
+        }
+
+        // Position IME candidate window at the terminal cursor
+        self.update_ime_position(ctx);
+
+        // Render IME preedit overlay
+        if let Some(ref preedit) = self.ime_preedit.clone() {
+            self.render_ime_preedit(ctx, preedit);
         }
 
         // Clean up GPU resources for closed panes.
@@ -2193,6 +2203,88 @@ impl AmuxApp {
         }
     }
 
+    fn update_ime_position(&self, ctx: &egui::Context) {
+        let focused_id = self.focused_pane_id();
+        let panel_rect = match self.last_panel_rect {
+            Some(r) => r,
+            None => return,
+        };
+
+        // Find the focused pane's rect
+        let pane_rect = if let Some(zoomed_id) = self.active_workspace().zoomed {
+            if zoomed_id == focused_id {
+                panel_rect
+            } else {
+                return;
+            }
+        } else {
+            let layout = self.active_workspace().tree.layout(panel_rect);
+            match layout.iter().find(|(id, _)| *id == focused_id) {
+                Some((_, r)) => *r,
+                None => return,
+            }
+        };
+
+        if let Some(managed) = self.panes.get(&focused_id) {
+            let surface = managed.active_surface();
+            let cursor = surface.pane.cursor();
+            let font_id = egui::FontId::monospace(self.font_size);
+            let (cell_w, cell_h) =
+                ctx.fonts(|f| (f.glyph_width(&font_id, 'M'), f.row_height(&font_id)));
+            let x = pane_rect.min.x + cursor.x as f32 * cell_w;
+            let y = pane_rect.min.y + TAB_BAR_HEIGHT + cursor.y as f32 * cell_h;
+            ctx.send_viewport_cmd(egui::ViewportCommand::IMERect(egui::Rect::from_min_size(
+                egui::pos2(x, y),
+                egui::vec2(cell_w, cell_h),
+            )));
+        }
+    }
+
+    fn render_ime_preedit(&self, ctx: &egui::Context, preedit: &str) {
+        let focused_id = self.focused_pane_id();
+        let panel_rect = match self.last_panel_rect {
+            Some(r) => r,
+            None => return,
+        };
+
+        let pane_rect = if let Some(zoomed_id) = self.active_workspace().zoomed {
+            if zoomed_id == focused_id {
+                panel_rect
+            } else {
+                return;
+            }
+        } else {
+            let layout = self.active_workspace().tree.layout(panel_rect);
+            match layout.iter().find(|(id, _)| *id == focused_id) {
+                Some((_, r)) => *r,
+                None => return,
+            }
+        };
+
+        if let Some(managed) = self.panes.get(&focused_id) {
+            let surface = managed.active_surface();
+            let cursor = surface.pane.cursor();
+            let font_id = egui::FontId::monospace(self.font_size);
+            let (cell_w, cell_h) =
+                ctx.fonts(|f| (f.glyph_width(&font_id, 'M'), f.row_height(&font_id)));
+            let x = pane_rect.min.x + cursor.x as f32 * cell_w;
+            let y = pane_rect.min.y + TAB_BAR_HEIGHT + cursor.y as f32 * cell_h;
+
+            egui::Area::new(egui::Id::new("ime_preedit"))
+                .fixed_pos(egui::pos2(x, y))
+                .show(ctx, |ui| {
+                    egui::Frame::popup(ui.style()).show(ui, |ui| {
+                        ui.label(
+                            egui::RichText::new(preedit)
+                                .monospace()
+                                .size(self.font_size)
+                                .underline(),
+                        );
+                    });
+                });
+        }
+    }
+
     fn handle_hyperlinks(&mut self, ctx: &egui::Context) {
         self.hovered_hyperlink = None;
 
@@ -3081,6 +3173,21 @@ impl AmuxApp {
                         let _ = surface.pane.write_bytes(text.as_bytes());
                     }
                 }
+                egui::Event::Ime(ime_event) => match ime_event {
+                    egui::ImeEvent::Commit(text) => {
+                        surface.scroll_offset = 0;
+                        surface.scroll_accum = 0.0;
+                        let _ = surface.pane.write_bytes(text.as_bytes());
+                    }
+                    egui::ImeEvent::Preedit(text) => {
+                        self.ime_preedit = if text.is_empty() {
+                            None
+                        } else {
+                            Some(text.clone())
+                        };
+                    }
+                    _ => {}
+                },
                 _ => {}
             }
         }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -133,6 +133,7 @@ fn main() -> anyhow::Result<()> {
                 copy_mode: None,
                 hovered_hyperlink: None,
                 ime_preedit: None,
+                selection_changed: false,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
             }))
@@ -606,6 +607,8 @@ struct AmuxApp {
     copy_mode: Option<CopyModeState>,
     hovered_hyperlink: Option<String>,
     ime_preedit: Option<String>,
+    /// Set during update() when selection changes; used for smart repaint.
+    selection_changed: bool,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
 }
@@ -867,6 +870,8 @@ impl eframe::App for AmuxApp {
             return;
         }
 
+        self.selection_changed = false;
+
         // Drain PTY output from all surfaces in all panes
         let mut got_data = false;
         for managed in self.panes.values_mut() {
@@ -916,7 +921,10 @@ impl eframe::App for AmuxApp {
                         egui::pos2(panel_rect.min.x, panel_rect.min.y + TAB_BAR_HEIGHT),
                         panel_rect.max,
                     );
-                    self.handle_selection_mouse(ui, zoomed_id, content_rect);
+                    let sel_changed = self.handle_selection_mouse(ui, zoomed_id, content_rect);
+                    if sel_changed {
+                        self.selection_changed = true;
+                    }
                     self.render_single_pane(ui, zoomed_id, panel_rect, true);
                     self.resize_pane_if_needed(zoomed_id, panel_rect, ui);
                 } else {
@@ -949,7 +957,10 @@ impl eframe::App for AmuxApp {
                                 egui::pos2(rect.min.x, rect.min.y + TAB_BAR_HEIGHT),
                                 rect.max,
                             );
-                            self.handle_selection_mouse(ui, id, content_rect);
+                            let sel_changed = self.handle_selection_mouse(ui, id, content_rect);
+                            if sel_changed {
+                                self.selection_changed = true;
+                            }
                             break;
                         }
                     }
@@ -1012,7 +1023,7 @@ impl eframe::App for AmuxApp {
 
         // Smart repaint: immediate when data arrived or input was sent (to
         // catch the PTY echo on the very next frame), otherwise poll at 50ms.
-        if got_data || sent_input || shortcut_consumed {
+        if got_data || sent_input || shortcut_consumed || self.selection_changed {
             ctx.request_repaint();
         } else {
             ctx.request_repaint_after(Duration::from_millis(50));
@@ -2972,12 +2983,17 @@ impl AmuxApp {
 
     // --- Selection Mouse ---
 
-    fn handle_selection_mouse(&mut self, ui: &egui::Ui, pane_id: PaneId, content_rect: egui::Rect) {
+    fn handle_selection_mouse(
+        &mut self,
+        ui: &egui::Ui,
+        pane_id: PaneId,
+        content_rect: egui::Rect,
+    ) -> bool {
         let (cell_width, cell_height) = self.cell_dimensions(ui);
 
         let managed = match self.panes.get(&pane_id) {
             Some(m) => m,
-            None => return,
+            None => return false,
         };
         let surface = managed.active_surface();
         let (cols, visible_rows) = surface.pane.dimensions();
@@ -2991,7 +3007,7 @@ impl AmuxApp {
 
         // Check if we're dragging a divider — skip selection if so
         if self.active_workspace().dragging_divider.is_some() {
-            return;
+            return false;
         }
 
         if primary_pressed {
@@ -3001,8 +3017,7 @@ impl AmuxApp {
                     if let Some(m) = self.panes.get_mut(&pane_id) {
                         m.selection = None;
                     }
-                    ui.ctx().request_repaint();
-                    return;
+                    return true;
                 }
 
                 let (col, stable_row) = pointer_to_cell(
@@ -3062,7 +3077,7 @@ impl AmuxApp {
                         active: true,
                     });
                 }
-                ui.ctx().request_repaint();
+                return true;
             }
         } else if primary_down {
             // Drag — update selection end
@@ -3118,7 +3133,7 @@ impl AmuxApp {
                             }
                         }
                     }
-                    ui.ctx().request_repaint();
+                    return true;
                 }
             }
         } else if primary_released {
@@ -3132,6 +3147,7 @@ impl AmuxApp {
                 }
             }
         }
+        false
     }
 
     // --- Input ---

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -35,6 +35,12 @@ enum Command {
         /// Target surface ID
         #[arg(long)]
         surface: Option<String>,
+        /// Include ANSI escape sequences (colors/formatting)
+        #[arg(long)]
+        ansi: bool,
+        /// Line range (e.g. "1-50", "-20" for last 20 lines)
+        #[arg(long)]
+        lines: Option<String>,
     },
     /// List server capabilities
     Capabilities,
@@ -216,7 +222,11 @@ async fn main() -> anyhow::Result<()> {
                 .await?;
             print_response(&resp, cli.json);
         }
-        Command::ReadScreen { surface } => {
+        Command::ReadScreen {
+            surface,
+            ansi,
+            lines,
+        } => {
             let surface_id = surface
                 .or_else(|| std::env::var("AMUX_SURFACE_ID").ok())
                 .unwrap_or_else(|| "default".to_string());
@@ -225,6 +235,8 @@ async fn main() -> anyhow::Result<()> {
                     "surface.read_text",
                     serde_json::json!({
                         "surface_id": surface_id,
+                        "ansi": ansi,
+                        "lines": lines,
                     }),
                 )
                 .await?;

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -37,6 +37,12 @@ pub struct SendTextParams {
 #[derive(Debug, Deserialize)]
 pub struct ReadTextParams {
     pub surface_id: String,
+    /// If true, include ANSI escape sequences in the output.
+    #[serde(default)]
+    pub ansi: bool,
+    /// Line range string: "1-50", "-20" (last 20), or None for visible screen.
+    #[serde(default)]
+    pub lines: Option<String>,
 }
 
 // --- Results ---

--- a/crates/amux-render-gpu/Cargo.toml
+++ b/crates/amux-render-gpu/Cargo.toml
@@ -13,4 +13,5 @@ wezterm-term = { workspace = true }
 cosmic-text = { workspace = true }
 bytemuck = { workspace = true }
 tracing = { workspace = true }
+image = { workspace = true }
 wezterm-surface = { workspace = true }

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -383,25 +383,61 @@ impl CallbackTrait for TerminalPaintCallback {
                         usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
                         view_formats: &[],
                     });
-                    queue.write_texture(
-                        wgpu::TexelCopyTextureInfo {
-                            texture: &texture,
-                            mip_level: 0,
-                            origin: wgpu::Origin3d::ZERO,
-                            aspect: wgpu::TextureAspect::All,
-                        },
-                        &decoded.data,
-                        wgpu::TexelCopyBufferLayout {
-                            offset: 0,
-                            bytes_per_row: Some(4 * decoded.width),
-                            rows_per_image: Some(decoded.height),
-                        },
-                        wgpu::Extent3d {
-                            width: decoded.width,
-                            height: decoded.height,
-                            depth_or_array_layers: 1,
-                        },
-                    );
+                    // Pad rows to wgpu's required alignment if needed.
+                    let unpadded_bpr = 4 * decoded.width;
+                    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+                    let padded_bpr = unpadded_bpr.div_ceil(align) * align;
+
+                    if unpadded_bpr == padded_bpr {
+                        queue.write_texture(
+                            wgpu::TexelCopyTextureInfo {
+                                texture: &texture,
+                                mip_level: 0,
+                                origin: wgpu::Origin3d::ZERO,
+                                aspect: wgpu::TextureAspect::All,
+                            },
+                            &decoded.data,
+                            wgpu::TexelCopyBufferLayout {
+                                offset: 0,
+                                bytes_per_row: Some(unpadded_bpr),
+                                rows_per_image: Some(decoded.height),
+                            },
+                            wgpu::Extent3d {
+                                width: decoded.width,
+                                height: decoded.height,
+                                depth_or_array_layers: 1,
+                            },
+                        );
+                    } else {
+                        let mut padded = vec![0u8; (padded_bpr * decoded.height) as usize];
+                        let src_stride = unpadded_bpr as usize;
+                        let dst_stride = padded_bpr as usize;
+                        for row in 0..decoded.height as usize {
+                            padded[row * dst_stride..row * dst_stride + src_stride]
+                                .copy_from_slice(
+                                    &decoded.data[row * src_stride..row * src_stride + src_stride],
+                                );
+                        }
+                        queue.write_texture(
+                            wgpu::TexelCopyTextureInfo {
+                                texture: &texture,
+                                mip_level: 0,
+                                origin: wgpu::Origin3d::ZERO,
+                                aspect: wgpu::TextureAspect::All,
+                            },
+                            &padded,
+                            wgpu::TexelCopyBufferLayout {
+                                offset: 0,
+                                bytes_per_row: Some(padded_bpr),
+                                rows_per_image: Some(decoded.height),
+                            },
+                            wgpu::Extent3d {
+                                width: decoded.width,
+                                height: decoded.height,
+                                depth_or_array_layers: 1,
+                            },
+                        );
+                    }
                     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
                     let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
                         label: Some("image_bind_group"),

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -24,6 +24,8 @@ pub struct PaneRenderState {
     scroll_offset: usize,
     is_focused: bool,
     selection_range: Option<((usize, usize), (usize, usize))>,
+    highlight_count: usize,
+    current_highlight: Option<usize>,
 
     // Dirty-tracking fields — geometry (pane position/size, cell dimensions)
     rect_x: f32,
@@ -67,6 +69,8 @@ impl PaneRenderState {
             scroll_offset: 0,
             is_focused: false,
             selection_range: None,
+            highlight_count: 0,
+            current_highlight: None,
             rect_x: 0.0,
             rect_y: 0.0,
             rect_w: 0.0,
@@ -93,6 +97,8 @@ impl PaneRenderState {
             || self.scroll_offset != snap.scroll_offset
             || self.is_focused != snap.is_focused
             || self.selection_range != snap.selection_range
+            || self.highlight_count != snap.highlight_ranges.len()
+            || self.current_highlight != snap.current_highlight
             || self.rect_x != rect.x
             || self.rect_y != rect.y
             || self.rect_w != rect.width
@@ -118,6 +124,8 @@ impl PaneRenderState {
         self.scroll_offset = snap.scroll_offset;
         self.is_focused = snap.is_focused;
         self.selection_range = snap.selection_range;
+        self.highlight_count = snap.highlight_ranges.len();
+        self.current_highlight = snap.current_highlight;
         self.rect_x = rect.x;
         self.rect_y = rect.y;
         self.rect_w = rect.width;

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -12,6 +12,20 @@ use crate::pipeline::{
 };
 use crate::snapshot::TerminalSnapshot;
 
+/// Cached glyph position/UV from a previous full reshape.
+/// Stored per visible glyph so we can rebuild fg instances with new colors
+/// without re-running cosmic-text shaping.
+#[derive(Clone)]
+struct CachedGlyph {
+    col: usize,
+    row: usize,
+    pos: [f32; 2],
+    size: [f32; 2],
+    uv_min: [f32; 2],
+    uv_max: [f32; 2],
+    is_color: f32,
+}
+
 /// Per-pane GPU state: instance buffers and dirty-tracking fingerprint.
 pub struct PaneRenderState {
     /// False until first successful prepare; forces initial rebuild.
@@ -46,6 +60,10 @@ pub struct PaneRenderState {
 
     /// Image draw calls for this frame: (image_hash, instance_buffer, instance_count).
     pub image_draws: Vec<([u8; 32], wgpu::Buffer, u32)>,
+
+    /// Cached glyph layouts from last full reshape. Reused when only colors change
+    /// (e.g., selection or highlight updates) to avoid expensive cosmic-text shaping.
+    cached_glyph_layouts: Vec<CachedGlyph>,
 }
 
 impl PaneRenderState {
@@ -88,11 +106,18 @@ impl PaneRenderState {
             fg_capacity: initial_capacity,
             fg_count: 0,
             image_draws: Vec::new(),
+            cached_glyph_layouts: Vec::new(),
         }
     }
 
-    /// Check if the pane content or geometry has changed since last render.
-    fn is_dirty(&self, snap: &TerminalSnapshot, rect: &PhysRect, cell_w: f32, cell_h: f32) -> bool {
+    /// Check if terminal content or geometry changed (requires full reshape).
+    fn is_content_dirty(
+        &self,
+        snap: &TerminalSnapshot,
+        rect: &PhysRect,
+        cell_w: f32,
+        cell_h: f32,
+    ) -> bool {
         !self.initialized
             || self.seqno != snap.seqno
             || self.cursor_x != snap.cursor.x
@@ -101,15 +126,19 @@ impl PaneRenderState {
             || self.cursor_shape != snap.cursor.shape
             || self.scroll_offset != snap.scroll_offset
             || self.is_focused != snap.is_focused
-            || self.selection_range != snap.selection_range
-            || self.highlight_count != snap.highlight_ranges.len()
-            || self.current_highlight != snap.current_highlight
             || self.rect_x != rect.x
             || self.rect_y != rect.y
             || self.rect_w != rect.width
             || self.rect_h != rect.height
             || self.cell_width != cell_w
             || self.cell_height != cell_h
+    }
+
+    /// Check if only appearance changed (selection/highlights — can reuse cached glyphs).
+    fn is_appearance_dirty(&self, snap: &TerminalSnapshot) -> bool {
+        self.selection_range != snap.selection_range
+            || self.highlight_count != snap.highlight_ranges.len()
+            || self.current_highlight != snap.current_highlight
     }
 
     /// Update the fingerprint to match the current state.
@@ -147,6 +176,23 @@ pub struct ImageTextureEntry {
     pub bind_group: wgpu::BindGroup,
 }
 
+/// Cached result of shaping a single cell's text through cosmic-text.
+/// Avoids re-running the full shaping pipeline on every frame for unchanged glyphs.
+#[derive(Clone)]
+pub(crate) struct ShapedGlyphEntry {
+    /// Physical glyph x offset within the cell.
+    physical_x: i32,
+    /// Physical glyph y offset within the cell.
+    physical_y: i32,
+    /// cosmic-text cache key for atlas lookup.
+    cache_key: cosmic_text::CacheKey,
+    /// Baseline y from layout run.
+    line_y: f32,
+}
+
+/// Key for the shape cache: (text content, bold, italic).
+pub(crate) type ShapeCacheKey = (String, bool, bool);
+
 /// Resources stored in egui's `CallbackResources` for the terminal renderer.
 pub struct TerminalGpuResources {
     pub bg_pipeline: BackgroundPipeline,
@@ -166,6 +212,9 @@ pub struct TerminalGpuResources {
     pub pane_states: HashMap<u64, PaneRenderState>,
     /// Cached GPU textures for inline images, keyed by image hash.
     pub image_cache: HashMap<[u8; 32], ImageTextureEntry>,
+    /// Shape cache: maps (text, bold, italic) → shaped glyph data.
+    /// Avoids re-running cosmic-text shaping for previously seen glyphs.
+    pub shape_cache: HashMap<ShapeCacheKey, Vec<ShapedGlyphEntry>>,
     /// Shared sampler for image textures.
     pub image_sampler: wgpu::Sampler,
 }
@@ -248,20 +297,23 @@ impl CallbackTrait for TerminalPaintCallback {
             .entry(self.pane_id)
             .or_insert_with(|| PaneRenderState::new(device));
 
-        // Skip expensive instance rebuild if nothing changed.
-        if !pane_state.is_dirty(
+        let content_dirty = pane_state.is_content_dirty(
             &self.snapshot,
             &self.phys_rect,
             self.cell_width,
             self.cell_height,
-        ) {
+        );
+        let appearance_dirty = pane_state.is_appearance_dirty(&self.snapshot);
+
+        // Skip if nothing changed at all.
+        if !content_dirty && !appearance_dirty {
             return Vec::new();
         }
 
         let snap = &self.snapshot;
         let linearize = resources.target_is_srgb;
 
-        // --- Background instances ---
+        // --- Background instances (always rebuilt — cheap) ---
         let mut bg_instances = Vec::with_capacity(snap.cells.len() + 1);
 
         // Full-rect background quad (absolute physical pixel positions)
@@ -286,28 +338,89 @@ impl CallbackTrait for TerminalPaintCallback {
         }
 
         // --- Foreground instances (glyphs) ---
-        let mut fg_instances = Vec::with_capacity(snap.cells.len());
+        // When only appearance changed (selection/highlights), reuse cached glyph
+        // layouts and just update colors. This skips expensive cosmic-text shaping.
+        let mut fg_instances = if content_dirty {
+            // Full reshape needed.
+            let mut fg = Vec::with_capacity(snap.cells.len());
+            let mut cached = Vec::new();
 
-        for cell in &snap.cells {
-            if cell.text.is_empty() || cell.text == " " {
-                continue;
+            for cell in &snap.cells {
+                if cell.text.is_empty() || cell.text == " " {
+                    continue;
+                }
+
+                let color = maybe_linearize(cell.fg, linearize);
+                let prev_len = fg.len();
+
+                shape_and_rasterize(
+                    &cell.text,
+                    cell.bold,
+                    cell.italic,
+                    color,
+                    self.phys_rect.x + cell.col as f32 * self.cell_width,
+                    self.phys_rect.y + cell.row as f32 * self.cell_height,
+                    self.cell_width,
+                    self.cell_height,
+                    pixels_per_point,
+                    resources,
+                    queue,
+                    &mut fg,
+                );
+
+                // Cache the glyph layout (position/UV) for color-only rebuilds.
+                for inst in &fg[prev_len..] {
+                    cached.push(CachedGlyph {
+                        col: cell.col,
+                        row: cell.row,
+                        pos: inst.pos,
+                        size: inst.size,
+                        uv_min: inst.uv_min,
+                        uv_max: inst.uv_max,
+                        is_color: inst.is_color,
+                    });
+                }
             }
 
-            shape_and_rasterize(
-                &cell.text,
-                cell.bold,
-                cell.italic,
-                maybe_linearize(cell.fg, linearize),
-                self.phys_rect.x + cell.col as f32 * self.cell_width,
-                self.phys_rect.y + cell.row as f32 * self.cell_height,
-                self.cell_width,
-                self.cell_height,
-                pixels_per_point,
-                resources,
-                queue,
-                &mut fg_instances,
-            );
-        }
+            // Store cache for future appearance-only rebuilds.
+            // Re-borrow pane_state to update the cache.
+            resources
+                .pane_states
+                .get_mut(&self.pane_id)
+                .unwrap()
+                .cached_glyph_layouts = cached;
+
+            fg
+        } else {
+            // Appearance-only change: reuse cached glyph layouts, apply new colors.
+            // Build a color lookup from snapshot cells.
+            let mut color_map: HashMap<(usize, usize), [f32; 4]> = HashMap::new();
+            for cell in &snap.cells {
+                if cell.text.is_empty() || cell.text == " " {
+                    continue;
+                }
+                color_map.insert((cell.col, cell.row), maybe_linearize(cell.fg, linearize));
+            }
+
+            let cached = &pane_state.cached_glyph_layouts;
+            let mut fg = Vec::with_capacity(cached.len());
+            for glyph in cached {
+                let color = color_map
+                    .get(&(glyph.col, glyph.row))
+                    .copied()
+                    .unwrap_or([1.0, 1.0, 1.0, 1.0]);
+                fg.push(CellFgInstance {
+                    pos: glyph.pos,
+                    size: glyph.size,
+                    uv_min: glyph.uv_min,
+                    uv_max: glyph.uv_max,
+                    color,
+                    is_color: glyph.is_color,
+                    _pad: [0.0; 3],
+                });
+            }
+            fg
+        };
 
         // --- Cursor ---
         let cursor = &snap.cursor;
@@ -605,9 +718,10 @@ impl CallbackTrait for TerminalPaintCallback {
 /// Shape text with cosmic-text and rasterize glyphs into the atlas,
 /// appending foreground instances for each glyph.
 ///
-/// `pixels_per_point` scales the font metrics so glyphs are rasterized at
-/// physical pixel size (e.g. 2× on Retina), matching the physical coordinate
-/// system used for instance placement.
+/// Uses a shape cache to avoid re-running cosmic-text shaping for
+/// previously seen (text, bold, italic) combinations. The atlas already
+/// caches rasterized bitmaps, but getting the CacheKey requires shaping
+/// which is the expensive part (Buffer alloc + font lookup + shaping).
 #[allow(clippy::too_many_arguments)]
 fn shape_and_rasterize(
     text: &str,
@@ -623,6 +737,39 @@ fn shape_and_rasterize(
     queue: &wgpu::Queue,
     fg_instances: &mut Vec<CellFgInstance>,
 ) {
+    let cache_key = (text.to_string(), bold, italic);
+
+    // Check shape cache first to avoid cosmic-text shaping.
+    if let Some(shaped) = resources.shape_cache.get(&cache_key) {
+        let shaped = shaped.clone(); // Clone to release borrow on resources
+        for sg in &shaped {
+            let (entry, newly_inserted) = resources.atlas.get_or_insert(
+                queue,
+                &mut resources.font_system,
+                &mut resources.swash_cache,
+                sg.cache_key,
+            );
+            if let Some(entry) = entry {
+                let gx = cell_px + sg.physical_x as f32 + entry.placement_left as f32;
+                let gy = cell_py + sg.line_y + sg.physical_y as f32 - entry.placement_top as f32;
+                fg_instances.push(CellFgInstance {
+                    pos: [gx, gy],
+                    size: [entry.width as f32, entry.height as f32],
+                    uv_min: [entry.uv[0], entry.uv[1]],
+                    uv_max: [entry.uv[2], entry.uv[3]],
+                    color,
+                    is_color: if entry.is_color { 1.0 } else { 0.0 },
+                    _pad: [0.0; 3],
+                });
+                if newly_inserted {
+                    resources.atlas_bind_group_dirty = true;
+                }
+            }
+        }
+        return;
+    }
+
+    // Cache miss: run full cosmic-text shaping.
     let weight = if bold {
         cosmic_text::Weight::BOLD
     } else {
@@ -638,9 +785,6 @@ fn shape_and_rasterize(
         .weight(weight)
         .style(style);
 
-    // Scale metrics by pixels_per_point so glyphs are rasterized at physical
-    // pixel size, not logical size. Without this, glyphs on HiDPI displays
-    // would be rasterized at 1× and appear tiny/faint in the 2× coordinate system.
     let phys_metrics = Metrics::new(
         resources.metrics.font_size * pixels_per_point,
         resources.metrics.line_height * pixels_per_point,
@@ -653,9 +797,18 @@ fn shape_and_rasterize(
         borrowed.shape_until_scroll(true);
     }
 
+    let mut shaped_entries = Vec::new();
+
     for run in buffer.layout_runs() {
         for glyph in run.glyphs.iter() {
             let physical = glyph.physical((0.0, 0.0), 1.0);
+
+            shaped_entries.push(ShapedGlyphEntry {
+                physical_x: physical.x,
+                physical_y: physical.y,
+                cache_key: physical.cache_key,
+                line_y: run.line_y,
+            });
 
             let (entry, newly_inserted) = resources.atlas.get_or_insert(
                 queue,
@@ -666,10 +819,6 @@ fn shape_and_rasterize(
 
             if let Some(entry) = entry {
                 let gx = cell_px + physical.x as f32 + entry.placement_left as f32;
-                // Use line_y (baseline position) not line_top (line top edge).
-                // line_y = line_top + centering_offset + max_ascent, which
-                // accounts for the font's ascent so glyphs sit on the baseline
-                // rather than floating above the cell.
                 let gy = cell_py + run.line_y + physical.y as f32 - entry.placement_top as f32;
 
                 fg_instances.push(CellFgInstance {
@@ -688,6 +837,8 @@ fn shape_and_rasterize(
             }
         }
     }
+
+    resources.shape_cache.insert(cache_key, shaped_entries);
 }
 
 /// Convert an sRGB color to linear if the target is sRGB, otherwise pass through.

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -12,6 +12,14 @@ use crate::pipeline::{
 };
 use crate::snapshot::TerminalSnapshot;
 
+/// Compute a simple hash of highlight ranges for dirty tracking.
+fn hash_highlight_ranges(ranges: &[(usize, usize, usize)]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    ranges.hash(&mut hasher);
+    hasher.finish()
+}
+
 /// Cached glyph position/UV from a previous full reshape.
 /// Stored per visible glyph so we can rebuild fg instances with new colors
 /// without re-running cosmic-text shaping.
@@ -39,7 +47,7 @@ pub struct PaneRenderState {
     scroll_offset: usize,
     is_focused: bool,
     selection_range: Option<((usize, usize), (usize, usize))>,
-    highlight_count: usize,
+    highlight_hash: u64,
     current_highlight: Option<usize>,
 
     // Dirty-tracking fields — geometry (pane position/size, cell dimensions)
@@ -91,7 +99,7 @@ impl PaneRenderState {
             scroll_offset: 0,
             is_focused: false,
             selection_range: None,
-            highlight_count: 0,
+            highlight_hash: 0,
             current_highlight: None,
             rect_x: 0.0,
             rect_y: 0.0,
@@ -137,7 +145,7 @@ impl PaneRenderState {
     /// Check if only appearance changed (selection/highlights — can reuse cached glyphs).
     fn is_appearance_dirty(&self, snap: &TerminalSnapshot) -> bool {
         self.selection_range != snap.selection_range
-            || self.highlight_count != snap.highlight_ranges.len()
+            || self.highlight_hash != hash_highlight_ranges(&snap.highlight_ranges)
             || self.current_highlight != snap.current_highlight
     }
 
@@ -158,7 +166,7 @@ impl PaneRenderState {
         self.scroll_offset = snap.scroll_offset;
         self.is_focused = snap.is_focused;
         self.selection_range = snap.selection_range;
-        self.highlight_count = snap.highlight_ranges.len();
+        self.highlight_hash = hash_highlight_ranges(&snap.highlight_ranges);
         self.current_highlight = snap.current_highlight;
         self.rect_x = rect.x;
         self.rect_y = rect.y;

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -8,6 +8,7 @@ use wezterm_surface::{CursorShape, CursorVisibility};
 use crate::atlas::GlyphAtlas;
 use crate::pipeline::{
     ensure_instance_buffer, BackgroundPipeline, CellBgInstance, CellFgInstance, ForegroundPipeline,
+    ImagePipeline, ImageQuadInstance,
 };
 use crate::snapshot::TerminalSnapshot;
 
@@ -42,6 +43,9 @@ pub struct PaneRenderState {
     pub fg_buffer: wgpu::Buffer,
     pub fg_capacity: usize,
     pub fg_count: u32,
+
+    /// Image draw calls for this frame: (image_hash, instance_buffer, instance_count).
+    pub image_draws: Vec<([u8; 32], wgpu::Buffer, u32)>,
 }
 
 impl PaneRenderState {
@@ -83,6 +87,7 @@ impl PaneRenderState {
             fg_buffer,
             fg_capacity: initial_capacity,
             fg_count: 0,
+            image_draws: Vec::new(),
         }
     }
 
@@ -135,10 +140,18 @@ impl PaneRenderState {
     }
 }
 
+/// Cached GPU texture for an inline terminal image.
+pub struct ImageTextureEntry {
+    #[allow(dead_code)]
+    pub texture: wgpu::Texture,
+    pub bind_group: wgpu::BindGroup,
+}
+
 /// Resources stored in egui's `CallbackResources` for the terminal renderer.
 pub struct TerminalGpuResources {
     pub bg_pipeline: BackgroundPipeline,
     pub fg_pipeline: ForegroundPipeline,
+    pub img_pipeline: ImagePipeline,
     pub atlas: GlyphAtlas,
     pub font_system: FontSystem,
     pub swash_cache: SwashCache,
@@ -151,6 +164,10 @@ pub struct TerminalGpuResources {
     pub target_is_srgb: bool,
     /// Per-pane render state (instance buffers + dirty tracking).
     pub pane_states: HashMap<u64, PaneRenderState>,
+    /// Cached GPU textures for inline images, keyed by image hash.
+    pub image_cache: HashMap<[u8; 32], ImageTextureEntry>,
+    /// Shared sampler for image textures.
+    pub image_sampler: wgpu::Sampler,
 }
 
 impl TerminalGpuResources {
@@ -158,6 +175,17 @@ impl TerminalGpuResources {
     pub fn retain_panes(&mut self, live_pane_ids: &[u64]) {
         let live: HashSet<u64> = live_pane_ids.iter().copied().collect();
         self.pane_states.retain(|id, _| live.contains(id));
+    }
+
+    /// Remove image textures not referenced by any current pane's image draws.
+    pub fn evict_unused_images(&mut self) {
+        let mut referenced: HashSet<[u8; 32]> = HashSet::new();
+        for state in self.pane_states.values() {
+            for (hash, _, _) in &state.image_draws {
+                referenced.insert(*hash);
+            }
+        }
+        self.image_cache.retain(|hash, _| referenced.contains(hash));
     }
 }
 
@@ -202,6 +230,12 @@ impl CallbackTrait for TerminalPaintCallback {
             target_is_srgb,
         );
         resources.fg_pipeline.upload_viewport(
+            queue,
+            viewport_width,
+            viewport_height,
+            target_is_srgb,
+        );
+        resources.img_pipeline.upload_viewport(
             queue,
             viewport_width,
             viewport_height,
@@ -329,6 +363,100 @@ impl CallbackTrait for TerminalPaintCallback {
             }
         }
 
+        // --- Image textures and instances ---
+        let mut image_draws: Vec<([u8; 32], wgpu::Buffer, u32)> = Vec::new();
+        if !snap.images.is_empty() {
+            // Upload any new image textures.
+            for decoded in &snap.decoded_images {
+                if !resources.image_cache.contains_key(&decoded.hash) {
+                    let texture = device.create_texture(&wgpu::TextureDescriptor {
+                        label: Some("image_texture"),
+                        size: wgpu::Extent3d {
+                            width: decoded.width,
+                            height: decoded.height,
+                            depth_or_array_layers: 1,
+                        },
+                        mip_level_count: 1,
+                        sample_count: 1,
+                        dimension: wgpu::TextureDimension::D2,
+                        format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                        view_formats: &[],
+                    });
+                    queue.write_texture(
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &texture,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d::ZERO,
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        &decoded.data,
+                        wgpu::TexelCopyBufferLayout {
+                            offset: 0,
+                            bytes_per_row: Some(4 * decoded.width),
+                            rows_per_image: Some(decoded.height),
+                        },
+                        wgpu::Extent3d {
+                            width: decoded.width,
+                            height: decoded.height,
+                            depth_or_array_layers: 1,
+                        },
+                    );
+                    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+                    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                        label: Some("image_bind_group"),
+                        layout: &resources.img_pipeline.image_bind_group_layout,
+                        entries: &[
+                            wgpu::BindGroupEntry {
+                                binding: 0,
+                                resource: wgpu::BindingResource::TextureView(&view),
+                            },
+                            wgpu::BindGroupEntry {
+                                binding: 1,
+                                resource: wgpu::BindingResource::Sampler(&resources.image_sampler),
+                            },
+                        ],
+                    });
+                    resources.image_cache.insert(
+                        decoded.hash,
+                        ImageTextureEntry {
+                            texture,
+                            bind_group,
+                        },
+                    );
+                }
+            }
+
+            // Group image placements by hash and build instance buffers.
+            let mut grouped: HashMap<[u8; 32], Vec<ImageQuadInstance>> = HashMap::new();
+            for placement in &snap.images {
+                let px = self.phys_rect.x + placement.col as f32 * self.cell_width;
+                let py = self.phys_rect.y + placement.row as f32 * self.cell_height;
+                grouped
+                    .entry(placement.image_hash)
+                    .or_default()
+                    .push(ImageQuadInstance {
+                        pos: [px, py],
+                        size: [self.cell_width, self.cell_height],
+                        uv_min: placement.uv_min,
+                        uv_max: placement.uv_max,
+                    });
+            }
+
+            for (hash, instances) in grouped {
+                if resources.image_cache.contains_key(&hash) {
+                    let buf = device.create_buffer(&wgpu::BufferDescriptor {
+                        label: Some("image_instance_buffer"),
+                        size: (instances.len() * std::mem::size_of::<ImageQuadInstance>()) as u64,
+                        usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                        mapped_at_creation: false,
+                    });
+                    queue.write_buffer(&buf, 0, bytemuck::cast_slice(&instances));
+                    image_draws.push((hash, buf, instances.len() as u32));
+                }
+            }
+        }
+
         // --- Update atlas bind group if glyphs were added ---
         if resources.atlas_bind_group_dirty {
             resources.fg_pipeline.update_atlas_bind_group(
@@ -384,6 +512,8 @@ impl CallbackTrait for TerminalPaintCallback {
         }
         pane_state.fg_count = fg_instances.len() as u32;
 
+        pane_state.image_draws = image_draws;
+
         pane_state.update_fingerprint(
             &self.snapshot,
             &self.phys_rect,
@@ -421,6 +551,18 @@ impl CallbackTrait for TerminalPaintCallback {
         resources
             .fg_pipeline
             .draw(render_pass, &pane_state.fg_buffer, pane_state.fg_count);
+
+        // Render inline images on top of text.
+        for (hash, instance_buffer, count) in &pane_state.image_draws {
+            if let Some(entry) = resources.image_cache.get(hash) {
+                resources.img_pipeline.draw(
+                    render_pass,
+                    &entry.bind_group,
+                    instance_buffer,
+                    *count,
+                );
+            }
+        }
     }
 }
 

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -8,7 +8,7 @@ use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, SwashCache};
 
 use atlas::GlyphAtlas;
 use callback::{PhysRect, TerminalGpuResources, TerminalPaintCallback};
-use pipeline::{BackgroundPipeline, ForegroundPipeline};
+use pipeline::{BackgroundPipeline, ForegroundPipeline, ImagePipeline};
 pub use snapshot::TerminalSnapshot;
 
 /// Atlas texture size (2048×2048, ~4MB for R8).
@@ -38,7 +38,17 @@ impl GpuRenderer {
 
         let bg_pipeline = BackgroundPipeline::new(device, target_format);
         let fg_pipeline = ForegroundPipeline::new(device, target_format);
+        let img_pipeline = ImagePipeline::new(device, target_format);
         let atlas = GlyphAtlas::new(device, ATLAS_SIZE);
+
+        let image_sampler = device.create_sampler(&egui_wgpu::wgpu::SamplerDescriptor {
+            label: Some("image_sampler"),
+            address_mode_u: egui_wgpu::wgpu::AddressMode::ClampToEdge,
+            address_mode_v: egui_wgpu::wgpu::AddressMode::ClampToEdge,
+            mag_filter: egui_wgpu::wgpu::FilterMode::Linear,
+            min_filter: egui_wgpu::wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
 
         let mut font_system = FontSystem::new();
         let swash_cache = SwashCache::new();
@@ -57,6 +67,7 @@ impl GpuRenderer {
             .insert(TerminalGpuResources {
                 bg_pipeline,
                 fg_pipeline,
+                img_pipeline,
                 atlas,
                 font_system,
                 swash_cache,
@@ -64,6 +75,8 @@ impl GpuRenderer {
                 atlas_bind_group_dirty: true,
                 target_is_srgb,
                 pane_states: std::collections::HashMap::new(),
+                image_cache: std::collections::HashMap::new(),
+                image_sampler,
             });
 
         Self {
@@ -136,7 +149,8 @@ impl GpuRenderer {
         }
     }
 
-    /// Remove cached render state for panes that no longer exist.
+    /// Remove cached render state for panes that no longer exist
+    /// and evict unreferenced image textures.
     pub fn retain_panes(&self, live_pane_ids: &[u64]) {
         if let Some(r) = self
             .render_state
@@ -146,6 +160,7 @@ impl GpuRenderer {
             .get_mut::<TerminalGpuResources>()
         {
             r.retain_panes(live_pane_ids);
+            r.evict_unused_images();
         }
     }
 }

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -76,6 +76,7 @@ impl GpuRenderer {
                 target_is_srgb,
                 pane_states: std::collections::HashMap::new(),
                 image_cache: std::collections::HashMap::new(),
+                shape_cache: std::collections::HashMap::new(),
                 image_sampler,
             });
 
@@ -142,6 +143,8 @@ impl GpuRenderer {
             r.metrics = metrics;
             // Clear all pane render states to force full rebuild with new metrics.
             r.pane_states.clear();
+            // Clear shape cache since glyph sizes change with font size.
+            r.shape_cache.clear();
             // Mark atlas bind group dirty since glyph sizes will change.
             r.atlas_bind_group_dirty = true;
             self.cell_width = cell_width;

--- a/crates/amux-render-gpu/src/pipeline.rs
+++ b/crates/amux-render-gpu/src/pipeline.rs
@@ -479,6 +479,225 @@ impl ForegroundPipeline {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Image pipeline (inline terminal images via Kitty protocol)
+// ---------------------------------------------------------------------------
+
+/// Per-quad image instance data.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct ImageQuadInstance {
+    /// Quad position in physical pixels (top-left corner).
+    pub pos: [f32; 2],
+    /// Quad size in physical pixels.
+    pub size: [f32; 2],
+    /// Texture UV min (top-left).
+    pub uv_min: [f32; 2],
+    /// Texture UV max (bottom-right).
+    pub uv_max: [f32; 2],
+}
+
+/// Image rendering pipeline: instanced textured quads for inline images.
+///
+/// Each draw call binds a single image texture. Instance buffers provide
+/// per-cell position/UV data for cells referencing that image.
+pub struct ImagePipeline {
+    pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    index_buffer: wgpu::Buffer,
+    viewport_buffer: wgpu::Buffer,
+    viewport_bind_group: wgpu::BindGroup,
+    pub image_bind_group_layout: wgpu::BindGroupLayout,
+}
+
+impl ImagePipeline {
+    /// Create the image pipeline.
+    pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("image_shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/image.wgsl").into()),
+        });
+
+        // Group 0: viewport uniform
+        let viewport_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("img_viewport_bind_group_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
+        // Group 1: image texture + sampler
+        let image_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("img_texture_bind_group_layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("img_pipeline_layout"),
+            bind_group_layouts: &[&viewport_bind_group_layout, &image_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("img_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[
+                    wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<QuadVertex>() as u64,
+                        step_mode: wgpu::VertexStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array![0 => Float32x2],
+                    },
+                    wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<ImageQuadInstance>() as u64,
+                        step_mode: wgpu::VertexStepMode::Instance,
+                        attributes: &wgpu::vertex_attr_array![
+                            1 => Float32x2, // pos
+                            2 => Float32x2, // size
+                            3 => Float32x2, // uv_min
+                            4 => Float32x2, // uv_max
+                        ],
+                    },
+                ],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: target_format,
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let vertices = [
+            QuadVertex { pos: [0.0, 0.0] },
+            QuadVertex { pos: [1.0, 0.0] },
+            QuadVertex { pos: [1.0, 1.0] },
+            QuadVertex { pos: [0.0, 1.0] },
+        ];
+        let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("img_vertex_buffer"),
+            contents: bytemuck::cast_slice(&vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("img_index_buffer"),
+            contents: bytemuck::cast_slice(&indices),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+
+        let viewport_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("img_viewport_uniform"),
+            contents: bytemuck::cast_slice(&[ViewportUniform {
+                size: [1.0, 1.0],
+                target_is_srgb: 0.0,
+                _pad: 0.0,
+            }]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let viewport_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("img_viewport_bind_group"),
+            layout: &viewport_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: viewport_buffer.as_entire_binding(),
+            }],
+        });
+
+        Self {
+            pipeline,
+            vertex_buffer,
+            index_buffer,
+            viewport_buffer,
+            viewport_bind_group,
+            image_bind_group_layout,
+        }
+    }
+
+    /// Update the viewport uniform.
+    pub fn upload_viewport(
+        &self,
+        queue: &wgpu::Queue,
+        viewport_width: f32,
+        viewport_height: f32,
+        target_is_srgb: bool,
+    ) {
+        queue.write_buffer(
+            &self.viewport_buffer,
+            0,
+            bytemuck::cast_slice(&[ViewportUniform {
+                size: [viewport_width, viewport_height],
+                target_is_srgb: if target_is_srgb { 1.0 } else { 0.0 },
+                _pad: 0.0,
+            }]),
+        );
+    }
+
+    /// Record draw commands for a single image (one bind group + instance buffer).
+    pub fn draw(
+        &self,
+        render_pass: &mut wgpu::RenderPass<'static>,
+        image_bind_group: &wgpu::BindGroup,
+        instance_buffer: &wgpu::Buffer,
+        instance_count: u32,
+    ) {
+        if instance_count == 0 {
+            return;
+        }
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_bind_group(0, &self.viewport_bind_group, &[]);
+        render_pass.set_bind_group(1, image_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        render_pass.set_vertex_buffer(1, instance_buffer.slice(..));
+        render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+        render_pass.draw_indexed(0..6, 0, 0..instance_count);
+    }
+}
+
 /// Create or grow an instance buffer if needed. Returns the buffer and its capacity.
 pub fn ensure_instance_buffer<T: Pod>(
     device: &wgpu::Device,

--- a/crates/amux-render-gpu/src/shaders/image.wgsl
+++ b/crates/amux-render-gpu/src/shaders/image.wgsl
@@ -1,0 +1,73 @@
+// Image pass: renders textured quads for inline terminal images (Kitty protocol).
+// Uses instancing: unit quad vertices are shared, per-instance data provides
+// position/size/UV coordinates. Each draw call binds a single image texture.
+
+struct Viewport {
+    size: vec2<f32>,
+    target_is_srgb: f32,
+}
+
+@group(0) @binding(0)
+var<uniform> viewport: Viewport;
+
+@group(1) @binding(0)
+var image_texture: texture_2d<f32>;
+@group(1) @binding(1)
+var image_sampler: sampler;
+
+struct VertexInput {
+    @location(0) vertex_pos: vec2<f32>,
+}
+
+struct InstanceInput {
+    @location(1) quad_pos: vec2<f32>,
+    @location(2) quad_size: vec2<f32>,
+    @location(3) uv_min: vec2<f32>,
+    @location(4) uv_max: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput, instance: InstanceInput) -> VertexOutput {
+    let pixel_pos = instance.quad_pos + vertex.vertex_pos * instance.quad_size;
+
+    let ndc = vec2<f32>(
+        pixel_pos.x / viewport.size.x * 2.0 - 1.0,
+        1.0 - pixel_pos.y / viewport.size.y * 2.0,
+    );
+
+    let uv = mix(instance.uv_min, instance.uv_max, vertex.vertex_pos);
+
+    var out: VertexOutput;
+    out.clip_pos = vec4<f32>(ndc, 0.0, 1.0);
+    out.uv = uv;
+    return out;
+}
+
+// Convert a single linear channel to sRGB.
+fn linear_to_srgb(v: f32) -> f32 {
+    if v <= 0.0031308 {
+        return v * 12.92;
+    }
+    return 1.055 * pow(v, 1.0 / 2.4) - 0.055;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    // Image textures are Rgba8UnormSrgb (returns linear values).
+    var texel = textureSample(image_texture, image_sampler, in.uv);
+    // On non-sRGB targets, convert linear→sRGB since hardware won't do it.
+    if viewport.target_is_srgb < 0.5 {
+        texel = vec4<f32>(
+            linear_to_srgb(texel.r),
+            linear_to_srgb(texel.g),
+            linear_to_srgb(texel.b),
+            texel.a,
+        );
+    }
+    return vec4<f32>(texel.rgb * texel.a, texel.a);
+}

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -141,6 +141,15 @@ impl TerminalSnapshot {
             }
         }
 
+        // Dim background colors for unfocused panes.
+        let dim_factor = if is_focused { 1.0 } else { 0.6 };
+        let dimmed_bg = dim_color(default_bg, dim_factor);
+        if !is_focused {
+            for cell in &mut cells {
+                cell.bg = dim_color(cell.bg, dim_factor);
+            }
+        }
+
         Self {
             pane_id,
             seqno,
@@ -148,7 +157,7 @@ impl TerminalSnapshot {
             rows,
             cells,
             cursor: *cursor,
-            default_bg,
+            default_bg: dimmed_bg,
             cursor_bg,
             cursor_fg,
             is_focused,
@@ -183,4 +192,9 @@ fn resolve_color(
 /// sRGB values are passed through directly.
 fn srgba_to_f32(c: SrgbaTuple) -> [f32; 4] {
     [c.0, c.1, c.2, c.3]
+}
+
+/// Dim a color by multiplying RGB channels toward black.
+fn dim_color(c: [f32; 4], factor: f32) -> [f32; 4] {
+    [c[0] * factor, c[1] * factor, c[2] * factor, c[3]]
 }

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -38,6 +38,7 @@ pub struct CellData {
     pub bg: [f32; 4],
     pub bold: bool,
     pub italic: bool,
+    pub hyperlink_url: Option<String>,
 }
 
 /// Selection range for highlight rendering.
@@ -151,6 +152,8 @@ impl TerminalSnapshot {
                     }
                 }
 
+                let hyperlink_url = attrs.hyperlink().map(|h| h.uri().to_string());
+
                 cells.push(CellData {
                     col: col_idx,
                     row: row_idx,
@@ -159,6 +162,7 @@ impl TerminalSnapshot {
                     bg: srgba_to_f32(bg),
                     bold: attrs.intensity() == wezterm_term::Intensity::Bold,
                     italic: attrs.italic(),
+                    hyperlink_url,
                 });
             }
         }

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -23,6 +23,10 @@ pub struct TerminalSnapshot {
     pub cursor_text_italic: bool,
     /// Selection start/end for dirty tracking (None if no selection).
     pub selection_range: Option<((usize, usize), (usize, usize))>,
+    /// Find/search highlight ranges as (phys_row, start_col, end_col_exclusive).
+    /// The current match (if any) uses a distinct color.
+    pub highlight_ranges: Vec<(usize, usize, usize)>,
+    pub current_highlight: Option<usize>,
 }
 
 /// Data for a single terminal cell.
@@ -77,6 +81,8 @@ impl TerminalSnapshot {
         selection: Option<SelectionRange>,
         pane_id: u64,
         seqno: usize,
+        highlight_ranges: Vec<(usize, usize, usize)>,
+        current_highlight: Option<usize>,
     ) -> Self {
         let selection_range = selection.as_ref().map(|s| (s.start, s.end));
         let default_bg = srgba_to_f32(palette.background);
@@ -116,6 +122,22 @@ impl TerminalSnapshot {
                             bg = palette.foreground;
                             fg = palette.background;
                         }
+                    }
+                }
+
+                // Apply find/search highlighting
+                for (i, &(h_row, h_start, h_end)) in highlight_ranges.iter().enumerate() {
+                    if h_row == stable_row && col_idx >= h_start && col_idx < h_end {
+                        if current_highlight == Some(i) {
+                            // Current match: bright orange bg
+                            bg = SrgbaTuple(1.0, 0.6, 0.0, 1.0);
+                            fg = SrgbaTuple(0.0, 0.0, 0.0, 1.0);
+                        } else {
+                            // Other matches: yellow bg
+                            bg = SrgbaTuple(1.0, 1.0, 0.0, 0.7);
+                            fg = SrgbaTuple(0.0, 0.0, 0.0, 1.0);
+                        }
+                        break;
                     }
                 }
 
@@ -166,6 +188,8 @@ impl TerminalSnapshot {
             cursor_text_bold,
             cursor_text_italic,
             selection_range,
+            highlight_ranges,
+            current_highlight,
         }
     }
 }

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -1,4 +1,8 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use wezterm_term::color::{ColorAttribute, ColorPalette, SrgbaTuple};
+use wezterm_term::image::{ImageData, ImageDataType};
 use wezterm_term::CursorPosition;
 
 /// Pre-extracted terminal state for GPU rendering.
@@ -27,6 +31,10 @@ pub struct TerminalSnapshot {
     /// The current match (if any) uses a distinct color.
     pub highlight_ranges: Vec<(usize, usize, usize)>,
     pub current_highlight: Option<usize>,
+    /// Inline image placements (Kitty image protocol).
+    pub images: Vec<ImagePlacement>,
+    /// Decoded image data, deduplicated by hash.
+    pub decoded_images: Vec<DecodedImage>,
 }
 
 /// Data for a single terminal cell.
@@ -39,6 +47,28 @@ pub struct CellData {
     pub bold: bool,
     pub italic: bool,
     pub hyperlink_url: Option<String>,
+}
+
+/// A single cell's image placement within the terminal grid.
+pub struct ImagePlacement {
+    pub col: usize,
+    pub row: usize,
+    /// Texture UV top-left for this cell's portion of the image.
+    pub uv_min: [f32; 2],
+    /// Texture UV bottom-right for this cell's portion of the image.
+    pub uv_max: [f32; 2],
+    /// Hash of the source image (indexes into `decoded_images`).
+    pub image_hash: [u8; 32],
+    /// Z-index: negative = behind text, >= 0 = above text.
+    pub z_index: i32,
+}
+
+/// Decoded RGBA image data, deduplicated by hash.
+pub struct DecodedImage {
+    pub hash: [u8; 32],
+    pub data: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
 }
 
 /// Selection range for highlight rendering.
@@ -99,6 +129,8 @@ impl TerminalSnapshot {
         let mut cursor_text = String::new();
         let mut cursor_text_bold = false;
         let mut cursor_text_italic = false;
+        let mut images = Vec::new();
+        let mut seen_images: HashMap<[u8; 32], Arc<ImageData>> = HashMap::new();
 
         for (row_idx, line) in lines.iter().enumerate() {
             for cell_ref in line.visible_cells() {
@@ -154,6 +186,28 @@ impl TerminalSnapshot {
 
                 let hyperlink_url = attrs.hyperlink().map(|h| h.uri().to_string());
 
+                // Extract inline images (Kitty protocol)
+                if let Some(image_cells) = attrs.images() {
+                    for image_cell in &image_cells {
+                        let image_data = image_cell.image_data();
+                        let hash = image_data.hash();
+                        seen_images
+                            .entry(hash)
+                            .or_insert_with(|| Arc::clone(image_data));
+
+                        let tl = image_cell.top_left();
+                        let br = image_cell.bottom_right();
+                        images.push(ImagePlacement {
+                            col: col_idx,
+                            row: row_idx,
+                            uv_min: [tl.x.into_inner(), tl.y.into_inner()],
+                            uv_max: [br.x.into_inner(), br.y.into_inner()],
+                            image_hash: hash,
+                            z_index: image_cell.z_index(),
+                        });
+                    }
+                }
+
                 cells.push(CellData {
                     col: col_idx,
                     row: row_idx,
@@ -166,6 +220,9 @@ impl TerminalSnapshot {
                 });
             }
         }
+
+        // Decode collected images to RGBA.
+        let decoded_images = decode_images(seen_images);
 
         // Dim background colors for unfocused panes.
         let dim_factor = if is_focused { 1.0 } else { 0.6 };
@@ -194,8 +251,63 @@ impl TerminalSnapshot {
             selection_range,
             highlight_ranges,
             current_highlight,
+            images,
+            decoded_images,
         }
     }
+}
+
+/// Decode image data from wezterm-term into raw RGBA.
+fn decode_images(seen: HashMap<[u8; 32], Arc<ImageData>>) -> Vec<DecodedImage> {
+    let mut result = Vec::with_capacity(seen.len());
+    for (hash, image_data) in seen {
+        let locked: std::sync::MutexGuard<'_, ImageDataType> = image_data.data();
+        match &*locked {
+            ImageDataType::Rgba8 {
+                data,
+                width,
+                height,
+                ..
+            } => {
+                result.push(DecodedImage {
+                    hash,
+                    data: data.clone(),
+                    width: *width,
+                    height: *height,
+                });
+            }
+            ImageDataType::AnimRgba8 {
+                frames,
+                width,
+                height,
+                ..
+            } => {
+                // Use first frame for static rendering.
+                if let Some(frame) = frames.first() {
+                    result.push(DecodedImage {
+                        hash,
+                        data: frame.clone(),
+                        width: *width,
+                        height: *height,
+                    });
+                }
+            }
+            ImageDataType::EncodedFile(bytes) => {
+                // Decode encoded image (PNG, JPEG, GIF, etc.) to RGBA.
+                if let Ok(img) = image::load_from_memory(bytes) {
+                    let rgba = img.to_rgba8();
+                    result.push(DecodedImage {
+                        hash,
+                        data: rgba.as_raw().clone(),
+                        width: rgba.width(),
+                        height: rgba.height(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    result
 }
 
 fn resolve_color(

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -282,6 +282,58 @@ impl TerminalPane {
     }
 
     /// Read the visible screen content as a string (lines joined by newlines).
+    /// Read lines from the terminal with optional ANSI formatting.
+    ///
+    /// `line_spec` formats:
+    /// - `"1-50"` — lines 1 through 50 (1-based, from top of scrollback)
+    /// - `"-20"` — last 20 lines
+    /// - `"5"` — just line 5
+    pub fn read_screen_lines(&self, line_spec: &str, ansi: bool) -> String {
+        let screen = self.terminal.screen();
+        let total = screen.scrollback_rows();
+        let (cols, _) = self.dimensions();
+
+        // Parse line spec into (start_phys, end_phys) range (0-based)
+        let (start, end) = if let Some(rest) = line_spec.strip_prefix('-') {
+            // "-N" means last N lines
+            let n: usize = rest.parse().unwrap_or(total);
+            (total.saturating_sub(n), total)
+        } else if let Some((a, b)) = line_spec.split_once('-') {
+            // "A-B" means lines A through B (1-based)
+            let a: usize = a.parse().unwrap_or(1);
+            let b: usize = b.parse().unwrap_or(total);
+            ((a.saturating_sub(1)).min(total), b.min(total))
+        } else {
+            // Single line number
+            let n: usize = line_spec.parse().unwrap_or(1);
+            let idx = (n.saturating_sub(1)).min(total.saturating_sub(1));
+            (idx, idx + 1)
+        };
+
+        if ansi {
+            // Use the existing ANSI-formatted reader, but for the specific range
+            self.read_scrollback_text_range(start, end)
+        } else {
+            let lines = screen.lines_in_phys_range(start..end);
+            let mut result = String::new();
+            for (i, line) in lines.iter().enumerate() {
+                if i > 0 {
+                    result.push('\n');
+                }
+                let mut line_text = String::new();
+                for cell in line.visible_cells() {
+                    if cell.cell_index() >= cols {
+                        break;
+                    }
+                    line_text.push_str(cell.str());
+                }
+                result.push_str(line_text.trim_end());
+            }
+            result
+        }
+    }
+
+    /// Read the visible screen content as a string (lines joined by newlines).
     pub fn read_screen_text(&self) -> String {
         let (cols, rows) = self.dimensions();
         let screen = self.terminal.screen();
@@ -306,17 +358,28 @@ impl TerminalPane {
         result
     }
 
+    /// Read a range of lines as text with ANSI escape sequences.
+    /// `start` and `end` are physical row indices (0-based, end exclusive).
+    pub fn read_scrollback_text_range(&self, start: usize, end: usize) -> String {
+        self.read_scrollback_text_impl(start, end)
+    }
+
     /// Read scrollback + visible screen as text with ANSI escape sequences,
     /// up to `max_lines` lines. Preserves colors and formatting for session
     /// persistence. Trailing empty lines are trimmed.
     pub fn read_scrollback_text(&self, max_lines: usize) -> String {
+        let screen = self.terminal.screen();
+        let total = screen.scrollback_rows();
+        let start = total.saturating_sub(max_lines);
+        self.read_scrollback_text_impl(start, total)
+    }
+
+    fn read_scrollback_text_impl(&self, start: usize, end: usize) -> String {
         use wezterm_term::{CellAttributes, Intensity, Underline};
 
         let (cols, _) = self.dimensions();
         let screen = self.terminal.screen();
-        let total = screen.scrollback_rows();
-        let start = total.saturating_sub(max_lines);
-        let lines = screen.lines_in_phys_range(start..total);
+        let lines = screen.lines_in_phys_range(start..end);
 
         // Build lines with ANSI formatting, collecting into a Vec
         // so we can trim trailing empty lines.

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -266,6 +266,16 @@ impl TerminalPane {
         self.terminal.current_seqno()
     }
 
+    /// Erase the scrollback buffer, keeping only the visible screen.
+    pub fn erase_scrollback(&mut self) {
+        self.terminal.erase_scrollback();
+    }
+
+    /// Notify the terminal that focus has changed (for DECSET 1004 focus reporting).
+    pub fn focus_changed(&mut self, focused: bool) {
+        self.terminal.focus_changed(focused);
+    }
+
     /// Get the last-rendered sequence number.
     pub fn rendered_seqno(&self) -> SequenceNo {
         self.seqno

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -416,6 +416,58 @@ impl TerminalPane {
 
         output_lines.join("\n")
     }
+
+    /// Search the full scrollback for case-insensitive occurrences of `query`.
+    ///
+    /// Returns matches as `(phys_row, start_col, end_col)` tuples where
+    /// `end_col` is exclusive.
+    pub fn search_scrollback(&self, query: &str) -> Vec<(usize, usize, usize)> {
+        if query.is_empty() {
+            return Vec::new();
+        }
+        let query_lower = query.to_lowercase();
+        let (cols, _) = self.dimensions();
+        let screen = self.terminal.screen();
+        let total = screen.scrollback_rows();
+        let lines = screen.lines_in_phys_range(0..total);
+
+        let mut matches = Vec::new();
+        for (phys_row, line) in lines.iter().enumerate() {
+            let mut line_text = String::new();
+            let mut col_offsets: Vec<usize> = Vec::new(); // byte offset → col index
+
+            for cell in line.visible_cells() {
+                let col_idx = cell.cell_index();
+                if col_idx >= cols {
+                    break;
+                }
+                let s = cell.str();
+                for _ in s.bytes() {
+                    col_offsets.push(col_idx);
+                }
+                line_text.push_str(s);
+            }
+
+            let line_lower = line_text.to_lowercase();
+            let mut search_start = 0;
+            while let Some(byte_pos) = line_lower[search_start..].find(&query_lower) {
+                let abs_pos = search_start + byte_pos;
+                let end_pos = abs_pos + query_lower.len();
+                if abs_pos < col_offsets.len() && end_pos <= col_offsets.len() {
+                    let start_col = col_offsets[abs_pos];
+                    // end_col is exclusive: one past the last matched column
+                    let end_col = if end_pos < col_offsets.len() {
+                        col_offsets[end_pos]
+                    } else {
+                        col_offsets[end_pos - 1] + 1
+                    };
+                    matches.push((phys_row, start_col, end_col));
+                }
+                search_start = abs_pos + 1;
+            }
+        }
+        matches
+    }
 }
 
 /// Append an SGR color parameter to an in-progress SGR sequence.

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -281,8 +281,7 @@ impl TerminalPane {
         self.seqno
     }
 
-    /// Read the visible screen content as a string (lines joined by newlines).
-    /// Read lines from the terminal with optional ANSI formatting.
+    /// Read lines from the scrollback or visible screen, with optional ANSI formatting.
     ///
     /// `line_spec` formats:
     /// - `"1-50"` — lines 1 through 50 (1-based, from top of scrollback)
@@ -293,8 +292,10 @@ impl TerminalPane {
         let total = screen.scrollback_rows();
         let (cols, _) = self.dimensions();
 
-        // Parse line spec into (start_phys, end_phys) range (0-based)
-        let (start, end) = if let Some(rest) = line_spec.strip_prefix('-') {
+        // Parse line spec into (start_phys, end_phys) range (0-based), clamped to valid bounds.
+        let (start, end) = if total == 0 {
+            (0, 0)
+        } else if let Some(rest) = line_spec.strip_prefix('-') {
             // "-N" means last N lines
             let n: usize = rest.parse().unwrap_or(total);
             (total.saturating_sub(n), total)
@@ -302,12 +303,19 @@ impl TerminalPane {
             // "A-B" means lines A through B (1-based)
             let a: usize = a.parse().unwrap_or(1);
             let b: usize = b.parse().unwrap_or(total);
-            ((a.saturating_sub(1)).min(total), b.min(total))
+            let s = (a.saturating_sub(1)).min(total);
+            let e = b.min(total);
+            // Normalize reversed ranges
+            if s >= e {
+                (0, 0)
+            } else {
+                (s, e)
+            }
         } else {
             // Single line number
             let n: usize = line_spec.parse().unwrap_or(1);
             let idx = (n.saturating_sub(1)).min(total.saturating_sub(1));
-            (idx, idx + 1)
+            (idx, (idx + 1).min(total))
         };
 
         if ansi {


### PR DESCRIPTION
## Summary

Completes terminal feature parity across 8 sub-PRs (9a–9h), adding all remaining user-visible terminal features:

- **9a**: Font size controls (Cmd+/-, Cmd+0) with live cell dimension recalculation
- **9b**: Cmd+K scrollback clear, unfocused pane dimming, click-to-focus, DECSET 1004 focus events
- **9c**: Find/search bar (Cmd+F) with scrollback search, match highlighting, and navigation
- **9c fix**: Input latency bug — `request_repaint_after(50ms)` was overriding immediate repaint requests
- **9d**: Vi-style copy mode for scrollback navigation (hjkl, v/V visual select, y yank)
- **9e**: OSC 8 hyperlink support with hover underline and Cmd+click to open
- **9f**: `amux read-screen --ansi` and `--lines` flags for formatted/ranged output
- **9g**: IME support for CJK and other input methods (preedit overlay, candidate positioning)
- **9h**: Kitty image protocol rendering (wgpu texture cache, instanced image quads)

## Test plan

- [ ] Cmd+Plus/Minus/0 scales text and re-tiles panes
- [ ] Cmd+K clears scrollback; unfocused panes are dimmed
- [ ] Cmd+F opens find bar; Enter/Shift+Enter navigates matches; Escape closes
- [ ] Typing has no perceptible input latency
- [ ] Copy mode: enter → hjkl → v → move → y → verify clipboard
- [ ] `printf '\e]8;;https://example.com\e\\link\e]8;;\e\\'` → hover underline → Cmd+click opens browser
- [ ] `amux read-screen --lines 1-5 --ansi` returns formatted output
- [ ] Japanese/Chinese IME: preedit renders at cursor, committed text goes to PTY
- [ ] `timg image.png` or Kitty icat renders inline image
- [ ] `cargo build --no-default-features` (soft renderer fallback) still compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Find/search bar with full scrollback search, per-match highlights and navigation
  * Vi-style copy mode with visual selection and yank; input suppressed while active
  * Inline image support with decoding, caching and snapshotting
  * CLI read-text now accepts ANSI and line-range options; IME preedit positioned at cursor

* **Improvements**
  * Clickable hyperlinks (Cmd/Ctrl+click)
  * Unfocused panes dimmed; smarter repainting and scrollback clear shortcut
  * Text shaping and rendering caching for faster redraws

* **Chores**
  * Added workspace dependencies for image handling and opening URLs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->