### PR TITLE
Phase 10: Sidebar rewrite to match cmux look & feel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "portable-pty",
  "serde",
  "serde_json",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "wezterm-surface",
@@ -2986,7 +2987,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.8+spec-1.1.0",
 ]
 
 [[package]]
@@ -3452,6 +3453,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4011,6 +4021,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4021,14 +4052,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -4037,8 +4082,14 @@ version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -5165,6 +5216,15 @@ dependencies = [
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ winit = "0.30"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 url = "2"
 
 # UI framework

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -29,3 +29,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 dirs = { workspace = true }
 open = { workspace = true }
+toml = { workspace = true }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -2609,27 +2609,58 @@ impl AmuxApp {
                     ui.vertical_centered(|ui| {
                         ui.add_space(40.0);
                         ui.label(
-                            egui::RichText::new("No notifications yet")
-                                .color(egui::Color32::from_gray(100)),
+                            egui::RichText::new("\u{1f515}") // 🔕
+                                .size(32.0),
+                        );
+                        ui.add_space(8.0);
+                        ui.label(
+                            egui::RichText::new("No notifications")
+                                .color(egui::Color32::from_gray(140))
+                                .size(14.0),
+                        );
+                        ui.label(
+                            egui::RichText::new("Agent notifications will appear here")
+                                .color(egui::Color32::from_gray(80))
+                                .size(11.0),
                         );
                     });
                 } else {
                     egui::ScrollArea::vertical().show(ui, |ui| {
-                        // Iterate newest first
+                        // Group by workspace
+                        let mut last_ws_id: Option<u64> = None;
                         for notif in notifications.iter().rev() {
+                            // Workspace section header
+                            if last_ws_id != Some(notif.workspace_id) {
+                                last_ws_id = Some(notif.workspace_id);
+                                if let Some(ws) =
+                                    self.workspaces.iter().find(|w| w.id == notif.workspace_id)
+                                {
+                                    ui.add_space(4.0);
+                                    ui.label(
+                                        egui::RichText::new(&ws.title)
+                                            .strong()
+                                            .size(11.0)
+                                            .color(egui::Color32::from_gray(120)),
+                                    );
+                                    ui.add_space(2.0);
+                                }
+                            }
+
                             let response = ui.horizontal(|ui| {
-                                // Unread dot
+                                // Source icon + unread dot
+                                let source_icon = match notif.source {
+                                    NotificationSource::Bell => "\u{1f514}",  // 🔔
+                                    NotificationSource::Toast => "\u{1f4ac}", // 💬
+                                    NotificationSource::Cli => "\u{2328}",    // ⌨
+                                };
                                 let dot_color = if notif.read {
                                     egui::Color32::from_gray(60)
                                 } else {
-                                    egui::Color32::from_rgb(40, 120, 255)
+                                    egui::Color32::from_rgb(0, 145, 255)
                                 };
-                                let dot_rect = ui.allocate_exact_size(
-                                    egui::vec2(8.0, 8.0),
-                                    egui::Sense::hover(),
+                                ui.label(
+                                    egui::RichText::new(source_icon).size(10.0).color(dot_color),
                                 );
-                                ui.painter()
-                                    .circle_filled(dot_rect.0.center(), 3.0, dot_color);
 
                                 ui.vertical(|ui| {
                                     let title = if notif.title.is_empty() {

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -194,6 +194,8 @@ fn fresh_startup(
         sidebar: SidebarState {
             visible: true,
             width: DEFAULT_SIDEBAR_WIDTH,
+            renaming: None,
+            rename_buf: String::new(),
         },
         notifications: NotificationStore::new(),
     })
@@ -306,6 +308,8 @@ fn restore_session(
     let sidebar = SidebarState {
         visible: session.sidebar.visible,
         width: session.sidebar.width,
+        renaming: None,
+        rename_buf: String::new(),
     };
 
     // Restore notifications (without Instant-dependent fields)
@@ -428,6 +432,10 @@ pub(crate) struct Workspace {
 pub(crate) struct SidebarState {
     pub(crate) visible: bool,
     pub(crate) width: f32,
+    /// When set, the workspace at this index is being renamed in-place.
+    pub(crate) renaming: Option<usize>,
+    /// Buffer for the in-progress rename text.
+    pub(crate) rename_buf: String,
 }
 
 struct DragState {
@@ -903,6 +911,20 @@ impl eframe::App for AmuxApp {
                     }
                     sidebar::SidebarAction::CreateWorkspace => {
                         self.create_workspace(None);
+                    }
+                    sidebar::SidebarAction::CloseWorkspace(idx) => {
+                        self.close_workspace_at(idx);
+                    }
+                    sidebar::SidebarAction::RenameWorkspace(idx, new_name) => {
+                        if idx < self.workspaces.len() {
+                            self.workspaces[idx].title = new_name;
+                        }
+                    }
+                    sidebar::SidebarAction::MarkWorkspaceRead(idx) => {
+                        if idx < self.workspaces.len() {
+                            let pane_ids: Vec<u64> = self.workspaces[idx].tree.iter_panes();
+                            self.notifications.mark_workspace_read(&pane_ids);
+                        }
                     }
                 }
             }
@@ -1704,7 +1726,7 @@ impl AmuxApp {
                     return true;
                 }
 
-                // Jump to workspace 1-8
+                // Jump to workspace 1-9 (Cmd+9 = last workspace)
                 #[cfg(target_os = "macos")]
                 let is_jump_mod = is_cmd && !modifiers.shift;
                 #[cfg(not(target_os = "macos"))]
@@ -1720,9 +1742,13 @@ impl AmuxApp {
                         egui::Key::Num6 => Some(5),
                         egui::Key::Num7 => Some(6),
                         egui::Key::Num8 => Some(7),
+                        egui::Key::Num9 => Some(usize::MAX), // last workspace
                         _ => None,
                     };
-                    if let Some(idx) = num {
+                    if let Some(mut idx) = num {
+                        if idx == usize::MAX {
+                            idx = self.workspaces.len().saturating_sub(1);
+                        }
                         if idx < self.workspaces.len() {
                             self.active_workspace_idx = idx;
                             return true;

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -61,12 +61,136 @@ fn get_cwd_from_pid(pid: u32) -> Option<String> {
     None
 }
 
-const FONT_SIZE: f32 = 14.0;
+const DEFAULT_FONT_SIZE: f32 = 12.0;
 const DEFAULT_SIDEBAR_WIDTH: f32 = 200.0;
 const TAB_BAR_HEIGHT: f32 = 24.0;
 
+// ---------------------------------------------------------------------------
+// App config (loaded from ~/.config/amux/config.toml)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(default)]
+struct AppConfig {
+    font_size: f32,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            font_size: DEFAULT_FONT_SIZE,
+        }
+    }
+}
+
+fn load_app_config() -> AppConfig {
+    let config_path = if cfg!(target_os = "windows") {
+        dirs::config_dir().map(|d| d.join("amux").join("config.toml"))
+    } else {
+        dirs::home_dir().map(|d| d.join(".config").join("amux").join("config.toml"))
+    };
+
+    if let Some(path) = config_path {
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => match toml::from_str::<AppConfig>(&contents) {
+                Ok(config) => {
+                    tracing::info!("Loaded config from {}", path.display());
+                    return config;
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to parse {}: {}", path.display(), e);
+                }
+            },
+            Err(_) => {
+                tracing::debug!("No config file at {}", path.display());
+            }
+        }
+    }
+
+    AppConfig::default()
+}
+
+/// Load system fonts as fallbacks to egui's font families.
+/// This provides coverage for braille patterns, geometric shapes, and other symbols
+/// that egui's bundled Hack font doesn't include.
+fn install_system_font_fallback(ctx: &egui::Context) {
+    let mut fonts = egui::FontDefinitions::default();
+    let mut loaded = Vec::new();
+
+    // Platform-specific font candidates: (path, name, is_symbol_font)
+    // We try to load a monospace font + a symbols font for maximum coverage.
+    let candidates: &[(&str, &str, bool)] = if cfg!(target_os = "macos") {
+        &[
+            // SF Mono: single .ttf with good Unicode coverage
+            ("/System/Library/Fonts/SFNSMono.ttf", "sf_mono", false),
+            // Apple Symbols: broad Unicode symbol coverage
+            (
+                "/System/Library/Fonts/Apple Symbols.ttf",
+                "apple_symbols",
+                true,
+            ),
+            // Supplemental Andale Mono as another option
+            (
+                "/System/Library/Fonts/Supplemental/Andale Mono.ttf",
+                "andale_mono",
+                false,
+            ),
+        ]
+    } else if cfg!(target_os = "windows") {
+        &[
+            ("C:\\Windows\\Fonts\\consola.ttf", "consolas", false),
+            ("C:\\Windows\\Fonts\\segmdl2.ttf", "segoe_symbols", true),
+        ]
+    } else {
+        &[
+            (
+                "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+                "dejavu_mono",
+                false,
+            ),
+            (
+                "/usr/share/fonts/TTF/DejaVuSansMono.ttf",
+                "dejavu_mono",
+                false,
+            ),
+        ]
+    };
+
+    for &(path, name, _is_symbol) in candidates {
+        if fonts.font_data.contains_key(name) {
+            continue;
+        }
+        if let Ok(data) = std::fs::read(path) {
+            fonts
+                .font_data
+                .insert(name.to_owned(), egui::FontData::from_owned(data).into());
+            loaded.push(name);
+        }
+    }
+
+    if loaded.is_empty() {
+        tracing::debug!("No system font fallbacks found");
+        return;
+    }
+
+    // Add all loaded fonts as fallbacks to both families
+    for family_key in [egui::FontFamily::Monospace, egui::FontFamily::Proportional] {
+        if let Some(family) = fonts.families.get_mut(&family_key) {
+            for name in &loaded {
+                family.push((*name).to_owned());
+            }
+        }
+    }
+
+    tracing::info!("Loaded font fallbacks: {:?}", loaded);
+    ctx.set_fonts(fonts);
+}
+
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
+
+    let app_config = load_app_config();
+    let font_size = app_config.font_size;
 
     let (ipc_rx, ipc_addr) = amux_ipc::start_server()?;
     tracing::info!("IPC server: {}", ipc_addr);
@@ -104,10 +228,13 @@ fn main() -> anyhow::Result<()> {
         "amux",
         options,
         Box::new(move |_cc| {
+            // Add system monospace font as fallback for braille/symbol coverage
+            install_system_font_fallback(&_cc.egui_ctx);
+
             #[cfg(feature = "gpu-renderer")]
             let gpu_renderer = _cc.wgpu_render_state.as_ref().map(|rs| {
                 tracing::info!("GPU renderer initialized (wgpu backend)");
-                GpuRenderer::new(rs.clone(), FONT_SIZE)
+                GpuRenderer::new(rs.clone(), font_size)
             });
 
             Ok(Box::new(AmuxApp {
@@ -128,12 +255,13 @@ fn main() -> anyhow::Result<()> {
                 last_click_pos: egui::Pos2::ZERO,
                 click_count: 0,
                 wants_exit: false,
-                font_size: FONT_SIZE,
+                font_size,
                 find_state: None,
                 copy_mode: None,
                 hovered_hyperlink: None,
                 ime_preedit: None,
                 selection_changed: false,
+                tab_drag: None,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
             }))
@@ -182,6 +310,7 @@ fn fresh_startup(
         zoomed: None,
         dragging_divider: None,
         last_pane_sizes: HashMap::new(),
+        color: None,
     };
 
     Ok(StartupState {
@@ -196,6 +325,7 @@ fn fresh_startup(
             width: DEFAULT_SIDEBAR_WIDTH,
             renaming: None,
             rename_buf: String::new(),
+            drag: None,
         },
         notifications: NotificationStore::new(),
     })
@@ -290,6 +420,7 @@ fn restore_session(
             zoomed: saved_ws.zoomed.filter(|z| panes.contains_key(z)),
             dragging_divider: None,
             last_pane_sizes: HashMap::new(),
+            color: saved_ws.color,
         });
     }
 
@@ -310,6 +441,7 @@ fn restore_session(
         width: session.sidebar.width,
         renaming: None,
         rename_buf: String::new(),
+        drag: None,
     };
 
     // Restore notifications (without Instant-dependent fields)
@@ -427,6 +559,8 @@ pub(crate) struct Workspace {
     pub(crate) zoomed: Option<PaneId>,
     pub(crate) dragging_divider: Option<DragState>,
     pub(crate) last_pane_sizes: HashMap<PaneId, (usize, usize)>,
+    /// Optional workspace color for sidebar indicator.
+    pub(crate) color: Option<[u8; 4]>,
 }
 
 pub(crate) struct SidebarState {
@@ -436,6 +570,19 @@ pub(crate) struct SidebarState {
     pub(crate) renaming: Option<usize>,
     /// Buffer for the in-progress rename text.
     pub(crate) rename_buf: String,
+    /// Drag reorder state.
+    pub(crate) drag: Option<SidebarDragState>,
+}
+
+pub(crate) struct SidebarDragState {
+    /// Index of workspace being dragged.
+    pub(crate) source_idx: usize,
+    /// Current pointer Y position.
+    pub(crate) current_y: f32,
+    /// Computed drop target index.
+    pub(crate) drop_target_idx: usize,
+    /// Y midpoints of each row for computing drop position.
+    pub(crate) row_midpoints: Vec<f32>,
 }
 
 struct DragState {
@@ -617,8 +764,16 @@ struct AmuxApp {
     ime_preedit: Option<String>,
     /// Set during update() when selection changes; used for smart repaint.
     selection_changed: bool,
+    /// Drag state for tab reordering within a pane.
+    tab_drag: Option<TabDragState>,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
+}
+
+struct TabDragState {
+    pane_id: PaneId,
+    source_idx: usize,
+    drop_target_idx: usize,
 }
 
 impl AmuxApp {
@@ -633,7 +788,7 @@ impl AmuxApp {
                 return (cw, ch);
             }
         }
-        let font_id = egui::FontId::monospace(FONT_SIZE);
+        let font_id = egui::FontId::monospace(self.font_size);
         let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
         let cell_height = ui.fonts(|f| f.row_height(&font_id));
         (cell_width, cell_height)
@@ -742,6 +897,7 @@ impl AmuxApp {
                 focused_pane: ws.focused_pane,
                 zoomed: ws.zoomed,
                 panes: saved_panes,
+                color: ws.color,
             });
         }
 
@@ -926,6 +1082,30 @@ impl eframe::App for AmuxApp {
                             self.notifications.mark_workspace_read(&pane_ids);
                         }
                     }
+                    sidebar::SidebarAction::ReorderWorkspace(from, to) => {
+                        if from < self.workspaces.len() && to < self.workspaces.len() {
+                            let ws = self.workspaces.remove(from);
+                            let to = to.min(self.workspaces.len());
+                            self.workspaces.insert(to, ws);
+                            // Adjust active index to follow the moved workspace
+                            if self.active_workspace_idx == from {
+                                self.active_workspace_idx = to;
+                            } else if from < self.active_workspace_idx
+                                && to >= self.active_workspace_idx
+                            {
+                                self.active_workspace_idx -= 1;
+                            } else if from > self.active_workspace_idx
+                                && to <= self.active_workspace_idx
+                            {
+                                self.active_workspace_idx += 1;
+                            }
+                        }
+                    }
+                    sidebar::SidebarAction::SetWorkspaceColor(idx, color) => {
+                        if idx < self.workspaces.len() {
+                            self.workspaces[idx].color = color;
+                        }
+                    }
                 }
             }
         }
@@ -1103,23 +1283,29 @@ impl AmuxApp {
             let tab_font = egui::FontId::proportional(11.0);
             let mut x = tab_rect.min.x + 2.0;
 
+            // Get pointer state for hover detection and drag
+            let hover_pos = ui.input(|i| i.pointer.hover_pos());
+            let any_pressed = ui.input(|i| i.pointer.any_pressed());
+            let any_released = ui.input(|i| i.pointer.any_released());
+            let primary_down = ui.input(|i| i.pointer.primary_down());
+            let interact_pos = ui.input(|i| i.pointer.interact_pos());
+
             // Track actions to apply after rendering
             let mut switch_to: Option<usize> = None;
             let mut close_tab: Option<usize> = None;
+            let mut tab_rects: Vec<egui::Rect> = Vec::new();
+            let mut drag_start: Option<usize> = None;
 
             for (idx, surface) in managed.surfaces.iter().enumerate() {
                 let is_active = idx == active_idx;
                 let raw_title = surface.pane.title();
                 let label = if raw_title.is_empty() {
-                    format!("tab {}", idx + 1)
+                    format!("tab {}", surface.id)
+                } else if raw_title.chars().count() > 20 {
+                    let prefix: String = raw_title.chars().take(17).collect();
+                    format!("{prefix}...")
                 } else {
-                    // Truncate long titles (char-safe for UTF-8)
-                    if raw_title.chars().count() > 20 {
-                        let prefix: String = raw_title.chars().take(17).collect();
-                        format!("{prefix}...")
-                    } else {
-                        raw_title.to_string()
-                    }
+                    raw_title.to_string()
                 };
 
                 let text_galley =
@@ -1131,11 +1317,13 @@ impl AmuxApp {
                     egui::pos2(x, tab_rect.min.y),
                     egui::vec2(tab_w, TAB_BAR_HEIGHT),
                 );
+                tab_rects.push(this_tab);
+
+                let tab_hovered = hover_pos.is_some_and(|p| this_tab.contains(p));
 
                 // Tab background
                 if is_active {
                     painter.rect_filled(this_tab, 0.0, egui::Color32::from_gray(50));
-                    // Active underline
                     let underline = egui::Rect::from_min_size(
                         egui::pos2(x, tab_rect.max.y - 2.0),
                         egui::vec2(tab_w, 2.0),
@@ -1156,31 +1344,106 @@ impl AmuxApp {
                     text_color,
                 );
 
-                // Close button
-                let close_rect = egui::Rect::from_center_size(
-                    egui::pos2(x + tab_w - 10.0, tab_rect.center().y),
-                    egui::vec2(12.0, 12.0),
-                );
-                painter.text(
-                    close_rect.center(),
-                    egui::Align2::CENTER_CENTER,
-                    "x",
-                    egui::FontId::proportional(9.0),
-                    egui::Color32::from_gray(90),
-                );
+                // Close button — only visible on hover
+                let close_center = egui::pos2(x + tab_w - 10.0, tab_rect.center().y);
+                let close_rect = egui::Rect::from_center_size(close_center, egui::vec2(12.0, 12.0));
+                if tab_hovered {
+                    let close_hovered = hover_pos.is_some_and(|p| close_rect.contains(p));
+                    let close_color = if close_hovered {
+                        egui::Color32::WHITE
+                    } else {
+                        egui::Color32::from_gray(90)
+                    };
+                    sidebar::paint_close_x(painter, close_center, 3.5, close_color);
+                }
 
                 // Hit testing
-                if ui.input(|i| i.pointer.any_pressed()) {
-                    if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
-                        if close_rect.contains(pos) {
+                if any_pressed {
+                    if let Some(pos) = interact_pos {
+                        if tab_hovered && close_rect.contains(pos) {
                             close_tab = Some(idx);
                         } else if this_tab.contains(pos) && !is_active {
                             switch_to = Some(idx);
+                        }
+                        // Start tab drag
+                        if this_tab.contains(pos)
+                            && !close_rect.contains(pos)
+                            && self.tab_drag.is_none()
+                        {
+                            drag_start = Some(idx);
                         }
                     }
                 }
 
                 x += tab_w + 1.0;
+            }
+
+            // Tab drag reorder logic
+            if let Some(src) = drag_start {
+                self.tab_drag = Some(TabDragState {
+                    pane_id,
+                    source_idx: src,
+                    drop_target_idx: src,
+                });
+            }
+
+            if let Some(drag) = &mut self.tab_drag {
+                if drag.pane_id == pane_id {
+                    if any_released || !primary_down {
+                        let from = drag.source_idx;
+                        let to = drag.drop_target_idx;
+                        self.tab_drag = None;
+                        if from != to {
+                            if let Some(m) = self.panes.get_mut(&pane_id) {
+                                let surface = m.surfaces.remove(from);
+                                let to = to.min(m.surfaces.len());
+                                m.surfaces.insert(to, surface);
+                                if m.active_surface_idx == from {
+                                    m.active_surface_idx = to;
+                                } else if from < m.active_surface_idx && to >= m.active_surface_idx
+                                {
+                                    m.active_surface_idx -= 1;
+                                } else if from > m.active_surface_idx && to <= m.active_surface_idx
+                                {
+                                    m.active_surface_idx += 1;
+                                }
+                            }
+                            return;
+                        }
+                    } else if let Some(pos) = hover_pos {
+                        // Compute drop target from X position vs tab midpoints
+                        let tab_midpoints: Vec<f32> =
+                            tab_rects.iter().map(|r| r.center().x).collect();
+                        let mut target = tab_midpoints.len();
+                        for (i, &mid) in tab_midpoints.iter().enumerate() {
+                            if pos.x < mid {
+                                target = i;
+                                break;
+                            }
+                        }
+                        drag.drop_target_idx = target;
+
+                        // Paint drop indicator
+                        let drop_x = if target == 0 {
+                            tab_rects.first().map(|r| r.min.x).unwrap_or(x)
+                        } else if target < tab_rects.len() {
+                            let left = tab_rects[target - 1].max.x;
+                            let right = tab_rects[target].min.x;
+                            (left + right) / 2.0
+                        } else {
+                            tab_rects.last().map(|r| r.max.x).unwrap_or(x)
+                        };
+                        let indicator_rect = egui::Rect::from_min_size(
+                            egui::pos2(drop_x - 1.0, tab_rect.min.y + 2.0),
+                            egui::vec2(2.0, TAB_BAR_HEIGHT - 4.0),
+                        );
+                        painter.rect_filled(
+                            indicator_rect,
+                            1.0,
+                            egui::Color32::from_rgb(0, 145, 255),
+                        );
+                    }
+                }
             }
 
             // "+" button to add tab
@@ -1195,8 +1458,8 @@ impl AmuxApp {
                 egui::FontId::proportional(14.0),
                 egui::Color32::from_gray(100),
             );
-            if ui.input(|i| i.pointer.any_pressed()) {
-                if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
+            if any_pressed {
+                if let Some(pos) = interact_pos {
                     if plus_rect.contains(pos) {
                         let ws_id = self.active_workspace().id;
                         let sf_id = self.next_surface_id;
@@ -1494,6 +1757,7 @@ impl AmuxApp {
                     zoomed: None,
                     dragging_divider: None,
                     last_pane_sizes: HashMap::new(),
+                    color: None,
                 };
 
                 self.workspaces.push(workspace);
@@ -1887,7 +2151,7 @@ impl AmuxApp {
             if let Some(pane_id) = target_pane {
                 if let Some(managed) = self.panes.get_mut(&pane_id) {
                     let surface = managed.active_surface_mut();
-                    let font_id = egui::FontId::monospace(FONT_SIZE);
+                    let font_id = egui::FontId::monospace(self.font_size);
                     let cell_height = ctx.fonts(|f| f.row_height(&font_id));
 
                     surface.scroll_accum += -scroll_delta / cell_height;
@@ -2021,9 +2285,14 @@ impl AmuxApp {
         let focused_id = self.focused_pane_id();
         if let Some(managed) = self.panes.get_mut(&focused_id) {
             let surface = managed.active_surface_mut();
+            // 1. Clear visible screen and move cursor home via terminal state machine
+            surface.pane.feed_bytes(b"\x1b[2J\x1b[H");
+            // 2. Erase scrollback buffer
             surface.pane.erase_scrollback();
             surface.scroll_offset = 0;
             surface.scroll_accum = 0.0;
+            // 3. Send Ctrl+L to the PTY so the shell redraws its prompt
+            let _ = surface.pane.write_bytes(b"\x0c");
         }
     }
 
@@ -4080,7 +4349,7 @@ fn render_pane(
     // Scroll indicator
     if scroll_offset > 0 {
         let indicator = format!("[+{}]", scroll_offset);
-        let indicator_font = egui::FontId::monospace(FONT_SIZE * 0.8);
+        let indicator_font = egui::FontId::monospace(font_size * 0.8);
         let text_color = egui::Color32::from_rgba_unmultiplied(255, 200, 50, 200);
         let bg_color = egui::Color32::from_rgba_unmultiplied(40, 40, 40, 180);
 

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -93,8 +93,9 @@ fn load_app_config() -> AppConfig {
     if let Some(path) = config_path {
         match std::fs::read_to_string(&path) {
             Ok(contents) => match toml::from_str::<AppConfig>(&contents) {
-                Ok(config) => {
+                Ok(mut config) => {
                     tracing::info!("Loaded config from {}", path.display());
+                    config.font_size = validate_font_size(config.font_size);
                     return config;
                 }
                 Err(e) => {
@@ -108,6 +109,16 @@ fn load_app_config() -> AppConfig {
     }
 
     AppConfig::default()
+}
+
+fn validate_font_size(size: f32) -> f32 {
+    const MIN_FONT_SIZE: f32 = 4.0;
+    const MAX_FONT_SIZE: f32 = 96.0;
+    if !size.is_finite() || size <= 0.0 {
+        DEFAULT_FONT_SIZE
+    } else {
+        size.clamp(MIN_FONT_SIZE, MAX_FONT_SIZE)
+    }
 }
 
 /// Load system fonts as fallbacks to egui's font families.
@@ -325,6 +336,7 @@ fn fresh_startup(
             width: DEFAULT_SIDEBAR_WIDTH,
             renaming: None,
             rename_buf: String::new(),
+            rename_just_opened: false,
             drag: None,
         },
         notifications: NotificationStore::new(),
@@ -441,6 +453,7 @@ fn restore_session(
         width: session.sidebar.width,
         renaming: None,
         rename_buf: String::new(),
+        rename_just_opened: false,
         drag: None,
     };
 
@@ -570,6 +583,8 @@ pub(crate) struct SidebarState {
     pub(crate) renaming: Option<usize>,
     /// Buffer for the in-progress rename text.
     pub(crate) rename_buf: String,
+    /// True on the first frame after rename starts (to skip focus-loss exit).
+    pub(crate) rename_just_opened: bool,
     /// Drag reorder state.
     pub(crate) drag: Option<SidebarDragState>,
 }
@@ -1083,19 +1098,23 @@ impl eframe::App for AmuxApp {
                         }
                     }
                     sidebar::SidebarAction::ReorderWorkspace(from, to) => {
-                        if from < self.workspaces.len() && to < self.workspaces.len() {
+                        if from < self.workspaces.len() && to <= self.workspaces.len() {
                             let ws = self.workspaces.remove(from);
-                            let to = to.min(self.workspaces.len());
-                            self.workspaces.insert(to, ws);
-                            // Adjust active index to follow the moved workspace
+                            // After removal, adjust insertion index for the shift
+                            let insert_idx = if from < to {
+                                (to - 1).min(self.workspaces.len())
+                            } else {
+                                to.min(self.workspaces.len())
+                            };
+                            self.workspaces.insert(insert_idx, ws);
                             if self.active_workspace_idx == from {
-                                self.active_workspace_idx = to;
+                                self.active_workspace_idx = insert_idx;
                             } else if from < self.active_workspace_idx
-                                && to >= self.active_workspace_idx
+                                && insert_idx >= self.active_workspace_idx
                             {
                                 self.active_workspace_idx -= 1;
                             } else if from > self.active_workspace_idx
-                                && to <= self.active_workspace_idx
+                                && insert_idx <= self.active_workspace_idx
                             {
                                 self.active_workspace_idx += 1;
                             }
@@ -1285,7 +1304,7 @@ impl AmuxApp {
 
             // Get pointer state for hover detection and drag
             let hover_pos = ui.input(|i| i.pointer.hover_pos());
-            let any_pressed = ui.input(|i| i.pointer.any_pressed());
+            let primary_pressed = ui.input(|i| i.pointer.primary_pressed());
             let any_released = ui.input(|i| i.pointer.any_released());
             let primary_down = ui.input(|i| i.pointer.primary_down());
             let interact_pos = ui.input(|i| i.pointer.interact_pos());
@@ -1357,8 +1376,8 @@ impl AmuxApp {
                     sidebar::paint_close_x(painter, close_center, 3.5, close_color);
                 }
 
-                // Hit testing
-                if any_pressed {
+                // Hit testing (primary button only)
+                if primary_pressed {
                     if let Some(pos) = interact_pos {
                         if tab_hovered && close_rect.contains(pos) {
                             close_tab = Some(idx);
@@ -1396,14 +1415,20 @@ impl AmuxApp {
                         if from != to {
                             if let Some(m) = self.panes.get_mut(&pane_id) {
                                 let surface = m.surfaces.remove(from);
-                                let to = to.min(m.surfaces.len());
-                                m.surfaces.insert(to, surface);
+                                let insert_idx = if from < to {
+                                    (to - 1).min(m.surfaces.len())
+                                } else {
+                                    to.min(m.surfaces.len())
+                                };
+                                m.surfaces.insert(insert_idx, surface);
                                 if m.active_surface_idx == from {
-                                    m.active_surface_idx = to;
-                                } else if from < m.active_surface_idx && to >= m.active_surface_idx
+                                    m.active_surface_idx = insert_idx;
+                                } else if from < m.active_surface_idx
+                                    && insert_idx >= m.active_surface_idx
                                 {
                                     m.active_surface_idx -= 1;
-                                } else if from > m.active_surface_idx && to <= m.active_surface_idx
+                                } else if from > m.active_surface_idx
+                                    && insert_idx <= m.active_surface_idx
                                 {
                                     m.active_surface_idx += 1;
                                 }
@@ -1458,7 +1483,7 @@ impl AmuxApp {
                 egui::FontId::proportional(14.0),
                 egui::Color32::from_gray(100),
             );
-            if any_pressed {
+            if primary_pressed {
                 if let Some(pos) = interact_pos {
                     if plus_rect.contains(pos) {
                         let ws_id = self.active_workspace().id;
@@ -1854,6 +1879,23 @@ impl AmuxApp {
 
                 // Copy selection if active; otherwise fall through to send Ctrl+C
                 if is_copy && self.copy_selection() {
+                    return true;
+                }
+
+                // Paste: Cmd+V (macOS) / Ctrl+Shift+V (other)
+                #[cfg(target_os = "macos")]
+                let is_paste = is_cmd && !modifiers.shift && *key == egui::Key::V;
+                #[cfg(not(target_os = "macos"))]
+                let is_paste = modifiers.ctrl && modifiers.shift && *key == egui::Key::V;
+
+                if is_paste {
+                    if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                        if let Ok(text) = clipboard.get_text() {
+                            if !text.is_empty() {
+                                self.do_paste(&text);
+                            }
+                        }
+                    }
                     return true;
                 }
 
@@ -2921,9 +2963,11 @@ impl AmuxApp {
                     });
                 } else {
                     egui::ScrollArea::vertical().show(ui, |ui| {
-                        // Group by workspace
+                        // Group by workspace, most recent notifications first within each
+                        let mut grouped: Vec<_> = notifications.iter().rev().collect();
+                        grouped.sort_by_key(|n| n.workspace_id);
                         let mut last_ws_id: Option<u64> = None;
-                        for notif in notifications.iter().rev() {
+                        for notif in &grouped {
                             // Workspace section header
                             if last_ws_id != Some(notif.workspace_id) {
                                 last_ws_id = Some(notif.workspace_id);
@@ -3126,6 +3170,22 @@ impl AmuxApp {
             }
         }
         true
+    }
+
+    fn do_paste(&mut self, text: &str) {
+        let focused_id = self.focused_pane_id();
+        if let Some(managed) = self.panes.get_mut(&focused_id) {
+            let surface = managed.active_surface_mut();
+            surface.scroll_offset = 0;
+            surface.scroll_accum = 0.0;
+            if surface.pane.bracketed_paste_enabled() {
+                let _ = surface.pane.write_bytes(b"\x1b[200~");
+                let _ = surface.pane.write_bytes(text.as_bytes());
+                let _ = surface.pane.write_bytes(b"\x1b[201~");
+            } else {
+                let _ = surface.pane.write_bytes(text.as_bytes());
+            }
+        }
     }
 
     fn select_all_visible(&mut self) {

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1,3 +1,5 @@
+mod sidebar;
+
 use std::collections::HashMap;
 use std::io::Read;
 use std::sync::{mpsc, Arc};
@@ -413,19 +415,19 @@ impl ManagedPane {
 }
 
 /// A workspace shown in the sidebar. Owns the split tree.
-struct Workspace {
-    id: u64,
-    title: String,
-    tree: PaneTree,
-    focused_pane: PaneId,
-    zoomed: Option<PaneId>,
-    dragging_divider: Option<DragState>,
-    last_pane_sizes: HashMap<PaneId, (usize, usize)>,
+pub(crate) struct Workspace {
+    pub(crate) id: u64,
+    pub(crate) title: String,
+    pub(crate) tree: PaneTree,
+    pub(crate) focused_pane: PaneId,
+    pub(crate) zoomed: Option<PaneId>,
+    pub(crate) dragging_divider: Option<DragState>,
+    pub(crate) last_pane_sizes: HashMap<PaneId, (usize, usize)>,
 }
 
-struct SidebarState {
-    visible: bool,
-    width: f32,
+pub(crate) struct SidebarState {
+    pub(crate) visible: bool,
+    pub(crate) width: f32,
 }
 
 struct DragState {
@@ -887,7 +889,23 @@ impl eframe::App for AmuxApp {
 
         // Render sidebar
         if self.sidebar.visible {
-            self.render_sidebar(ctx);
+            let sidebar_actions = sidebar::render_sidebar(
+                ctx,
+                &mut self.sidebar,
+                &self.workspaces,
+                self.active_workspace_idx,
+                &self.notifications,
+            );
+            for action in sidebar_actions {
+                match action {
+                    sidebar::SidebarAction::SwitchWorkspace(idx) => {
+                        self.active_workspace_idx = idx;
+                    }
+                    sidebar::SidebarAction::CreateWorkspace => {
+                        self.create_workspace(None);
+                    }
+                }
+            }
         }
 
         // Render main content
@@ -1351,146 +1369,6 @@ impl AmuxApp {
                 }
             }
         }
-    }
-
-    // --- Sidebar ---
-
-    fn render_sidebar(&mut self, ctx: &egui::Context) {
-        egui::SidePanel::left("sidebar")
-            .resizable(true)
-            .default_width(self.sidebar.width)
-            .min_width(120.0)
-            .max_width(400.0)
-            .frame(
-                egui::Frame::new()
-                    .fill(egui::Color32::from_gray(30))
-                    .inner_margin(8.0),
-            )
-            .show(ctx, |ui| {
-                ui.spacing_mut().item_spacing.y = 4.0;
-
-                ui.label(
-                    egui::RichText::new("Workspaces")
-                        .strong()
-                        .color(egui::Color32::from_gray(180)),
-                );
-                ui.add_space(4.0);
-
-                let active_idx = self.active_workspace_idx;
-                let mut switch_to: Option<usize> = None;
-
-                for (idx, ws) in self.workspaces.iter().enumerate() {
-                    let is_active = idx == active_idx;
-                    let bg = if is_active {
-                        egui::Color32::from_gray(55)
-                    } else {
-                        egui::Color32::TRANSPARENT
-                    };
-
-                    let pane_ids: Vec<u64> = ws.tree.iter_panes();
-                    let unread = self.notifications.workspace_unread_count(&pane_ids);
-                    let has_status = self.notifications.workspace_status(ws.id).is_some();
-                    let row_height = if has_status { 38.0 } else { 24.0 };
-
-                    let response = ui.horizontal(|ui| {
-                        let (rect, response) = ui.allocate_exact_size(
-                            egui::vec2(ui.available_width(), row_height),
-                            egui::Sense::click(),
-                        );
-                        if ui.is_rect_visible(rect) {
-                            ui.painter().rect_filled(rect, 4.0, bg);
-                            let text_color = if is_active {
-                                egui::Color32::WHITE
-                            } else {
-                                egui::Color32::from_gray(160)
-                            };
-                            ui.painter().text(
-                                rect.min + egui::vec2(8.0, 4.0),
-                                egui::Align2::LEFT_TOP,
-                                &ws.title,
-                                egui::FontId::proportional(14.0),
-                                text_color,
-                            );
-
-                            // Unread badge or pane count
-                            if unread > 0 {
-                                let badge_center =
-                                    egui::pos2(rect.right() - 16.0, rect.min.y + 12.0);
-                                ui.painter().circle_filled(
-                                    badge_center,
-                                    8.0,
-                                    egui::Color32::from_rgb(40, 120, 255),
-                                );
-                                ui.painter().text(
-                                    badge_center,
-                                    egui::Align2::CENTER_CENTER,
-                                    format!("{}", unread),
-                                    egui::FontId::proportional(9.0),
-                                    egui::Color32::WHITE,
-                                );
-                            } else {
-                                let count = ws.tree.iter_panes().len();
-                                ui.painter().text(
-                                    egui::pos2(rect.right() - 8.0, rect.min.y + 4.0),
-                                    egui::Align2::RIGHT_TOP,
-                                    format!("{}", count),
-                                    egui::FontId::proportional(11.0),
-                                    egui::Color32::from_gray(100),
-                                );
-                            }
-
-                            // Status pill
-                            if let Some(status) = self.notifications.workspace_status(ws.id) {
-                                let (pill_color, default_text) = match status.state {
-                                    amux_notify::AgentState::Active => {
-                                        (egui::Color32::from_rgb(50, 180, 80), "active")
-                                    }
-                                    amux_notify::AgentState::Waiting => {
-                                        (egui::Color32::from_rgb(230, 170, 40), "waiting")
-                                    }
-                                    amux_notify::AgentState::Idle => {
-                                        (egui::Color32::from_gray(100), "idle")
-                                    }
-                                };
-                                let label = status.label.as_deref().unwrap_or(default_text);
-                                let pill_pos = egui::pos2(rect.min.x + 8.0, rect.min.y + 22.0);
-                                let text_width = label.len() as f32 * 5.5 + 8.0;
-                                let pill_rect = egui::Rect::from_min_size(
-                                    pill_pos,
-                                    egui::vec2(text_width.min(rect.width() - 32.0), 14.0),
-                                );
-                                ui.painter().rect_filled(pill_rect, 7.0, pill_color);
-                                ui.painter().text(
-                                    pill_rect.center(),
-                                    egui::Align2::CENTER_CENTER,
-                                    label,
-                                    egui::FontId::proportional(9.0),
-                                    egui::Color32::WHITE,
-                                );
-                            }
-                        }
-                        response
-                    });
-                    if response.inner.clicked() && !is_active {
-                        switch_to = Some(idx);
-                    }
-                }
-
-                if let Some(idx) = switch_to {
-                    self.active_workspace_idx = idx;
-                }
-
-                ui.add_space(8.0);
-
-                if ui
-                    .button(
-                        egui::RichText::new("+ New Workspace").color(egui::Color32::from_gray(140)),
-                    )
-                    .clicked()
-                {
-                    self.create_workspace(None);
-                }
-            });
     }
 
     // --- Resize ---

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -129,6 +129,9 @@ pub(crate) fn render_sidebar(
                 .inner_margin(egui::Margin::symmetric(ROW_OUTER_H_PAD as i8, 0)),
         )
         .show(ctx, |ui| {
+            // Persist the actual panel width back to state for session save/restore
+            state.width = ui.available_width() + ROW_OUTER_H_PAD * 2.0;
+
             #[cfg(target_os = "macos")]
             ui.add_space(TRAFFIC_LIGHT_SPACER);
             #[cfg(not(target_os = "macos"))]
@@ -181,8 +184,12 @@ pub(crate) fn render_sidebar(
                             // After last row: at the bottom edge
                             row_rects.last().map(|r| r.max.y).unwrap_or_default()
                         };
+                        let indicator_x = row_rects
+                            .first()
+                            .map(|r| r.min.x)
+                            .unwrap_or_else(|| ui.min_rect().min.x);
                         let indicator_rect = egui::Rect::from_min_size(
-                            egui::pos2(0.0, drop_y - DROP_INDICATOR_HEIGHT / 2.0),
+                            egui::pos2(indicator_x, drop_y - DROP_INDICATOR_HEIGHT / 2.0),
                             egui::vec2(avail_w, DROP_INDICATOR_HEIGHT),
                         );
                         ui.painter().rect_filled(indicator_rect, 1.0, ACCENT_BLUE);
@@ -342,6 +349,7 @@ fn render_workspace_row(
         if ui.button("Rename Workspace").clicked() {
             state.renaming = Some(idx);
             state.rename_buf = ws.title.clone();
+            state.rename_just_opened = true;
             ui.close_menu();
         }
         if ui.button("Close Workspace").clicked() {
@@ -440,7 +448,10 @@ fn render_workspace_row(
         let confirmed = ui.input(|i| i.key_pressed(egui::Key::Enter));
         let cancelled = ui.input(|i| i.key_pressed(egui::Key::Escape));
 
-        if confirmed || (!te_response.has_focus() && !cancelled) {
+        let lost_focus = !te_response.has_focus() && !state.rename_just_opened;
+        state.rename_just_opened = false;
+
+        if confirmed || (lost_focus && !cancelled) {
             let new_name = state.rename_buf.trim().to_string();
             if !new_name.is_empty() && new_name != ws.title {
                 actions.push(SidebarAction::RenameWorkspace(idx, new_name));

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -1,7 +1,7 @@
 use amux_notify::NotificationStore;
 use egui::Color32;
 
-use crate::{SidebarState, Workspace};
+use crate::{SidebarDragState, SidebarState, Workspace};
 
 // ---------------------------------------------------------------------------
 // Colors (cmux dark mode equivalents)
@@ -20,7 +20,8 @@ const STATUS_ORANGE: Color32 = Color32::from_rgb(230, 170, 40);
 const STATUS_GRAY: Color32 = Color32::from_gray(100);
 const NEW_BTN_TEXT: Color32 = Color32::from_gray(140);
 const NEW_BTN_HOVER: Color32 = Color32::from_rgba_premultiplied(15, 15, 15, 15);
-const CLOSE_BTN_COLOR: Color32 = Color32::from_rgba_premultiplied(140, 140, 140, 179); // secondary@0.7
+const CLOSE_BTN_COLOR: Color32 = Color32::from_rgba_premultiplied(140, 140, 140, 179);
+const PROGRESS_TRACK: Color32 = Color32::from_rgba_premultiplied(20, 20, 20, 20);
 
 // ---------------------------------------------------------------------------
 // Layout constants (matching cmux points)
@@ -41,11 +42,25 @@ const PILL_HEIGHT: f32 = 14.0;
 const PILL_CORNER_RADIUS: f32 = 7.0;
 const COUNT_FONT_SIZE: f32 = 10.0;
 const NOTIF_FONT_SIZE: f32 = 10.0;
-const NOTIF_PREVIEW_HEIGHT: f32 = 24.0; // ~2 lines at 10pt
+const NOTIF_PREVIEW_HEIGHT: f32 = 24.0;
 const CLOSE_BTN_SIZE: f32 = 16.0;
-const CLOSE_BTN_FONT_SIZE: f32 = 9.0;
+const COLOR_CAPSULE_WIDTH: f32 = 3.0;
+const PROGRESS_BAR_HEIGHT: f32 = 3.0;
+const DROP_INDICATOR_HEIGHT: f32 = 2.0;
 #[cfg(target_os = "macos")]
 const TRAFFIC_LIGHT_SPACER: f32 = 28.0;
+
+// Preset workspace colors (8 options matching cmux)
+const PRESET_COLORS: &[([u8; 4], &str)] = &[
+    ([255, 59, 48, 255], "Red"),
+    ([255, 149, 0, 255], "Orange"),
+    ([255, 204, 0, 255], "Yellow"),
+    ([52, 199, 89, 255], "Green"),
+    ([0, 199, 190, 255], "Teal"),
+    ([0, 122, 255, 255], "Blue"),
+    ([88, 86, 214, 255], "Purple"),
+    ([255, 45, 85, 255], "Pink"),
+];
 
 // ---------------------------------------------------------------------------
 // Actions returned from sidebar rendering
@@ -57,6 +72,37 @@ pub(crate) enum SidebarAction {
     CloseWorkspace(usize),
     RenameWorkspace(usize, String),
     MarkWorkspaceRead(usize),
+    ReorderWorkspace(usize, usize),
+    SetWorkspaceColor(usize, Option<[u8; 4]>),
+}
+
+// ---------------------------------------------------------------------------
+// Shared close-X painter
+// ---------------------------------------------------------------------------
+
+/// Paint an X icon (two diagonal lines) centered at `center` with the given `size` and `color`.
+pub(crate) fn paint_close_x(
+    painter: &egui::Painter,
+    center: egui::Pos2,
+    size: f32,
+    color: Color32,
+) {
+    let half = size / 2.0;
+    let stroke = egui::Stroke::new(1.2, color);
+    painter.line_segment(
+        [
+            egui::pos2(center.x - half, center.y - half),
+            egui::pos2(center.x + half, center.y + half),
+        ],
+        stroke,
+    );
+    painter.line_segment(
+        [
+            egui::pos2(center.x + half, center.y - half),
+            egui::pos2(center.x - half, center.y + half),
+        ],
+        stroke,
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -83,7 +129,6 @@ pub(crate) fn render_sidebar(
                 .inner_margin(egui::Margin::symmetric(ROW_OUTER_H_PAD as i8, 0)),
         )
         .show(ctx, |ui| {
-            // Traffic light spacer (macOS) or small top margin (other)
             #[cfg(target_os = "macos")]
             ui.add_space(TRAFFIC_LIGHT_SPACER);
             #[cfg(not(target_os = "macos"))]
@@ -94,11 +139,53 @@ pub(crate) fn render_sidebar(
             egui::ScrollArea::vertical()
                 .auto_shrink([false, false])
                 .show(ui, |ui| {
+                    // Collect row rects for drag indicator positioning
+                    let mut row_rects: Vec<egui::Rect> = Vec::with_capacity(workspaces.len());
+
                     for (idx, ws) in workspaces.iter().enumerate() {
                         let is_active = idx == active_workspace_idx;
-                        let row_actions =
-                            render_workspace_row(ui, ws, idx, is_active, notifications, state);
+                        let is_being_dragged =
+                            state.drag.as_ref().is_some_and(|d| d.source_idx == idx);
+                        let (row_actions, row_rect) = render_workspace_row(
+                            ui,
+                            ws,
+                            idx,
+                            is_active,
+                            is_being_dragged,
+                            notifications,
+                            state,
+                        );
                         actions.extend(row_actions);
+                        row_rects.push(row_rect);
+                    }
+
+                    // Compute row midpoints from actual rects
+                    let row_midpoints: Vec<f32> = row_rects.iter().map(|r| r.center().y).collect();
+
+                    // --- Drag reorder logic ---
+                    handle_drag_reorder(ui, ctx, state, &row_midpoints, &mut actions);
+
+                    // --- Drop indicator ---
+                    if let Some(drag) = &state.drag {
+                        let avail_w = ui.available_width();
+                        // Place indicator at the edge between rows
+                        let drop_y = if drag.drop_target_idx == 0 {
+                            // Before first row: at the top edge
+                            row_rects.first().map(|r| r.min.y).unwrap_or_default()
+                        } else if drag.drop_target_idx < row_rects.len() {
+                            // Between rows: at the boundary
+                            let above = row_rects[drag.drop_target_idx - 1].max.y;
+                            let below = row_rects[drag.drop_target_idx].min.y;
+                            (above + below) / 2.0
+                        } else {
+                            // After last row: at the bottom edge
+                            row_rects.last().map(|r| r.max.y).unwrap_or_default()
+                        };
+                        let indicator_rect = egui::Rect::from_min_size(
+                            egui::pos2(0.0, drop_y - DROP_INDICATOR_HEIGHT / 2.0),
+                            egui::vec2(avail_w, DROP_INDICATOR_HEIGHT),
+                        );
+                        ui.painter().rect_filled(indicator_rect, 1.0, ACCENT_BLUE);
                     }
 
                     ui.add_space(8.0);
@@ -145,25 +232,71 @@ pub(crate) fn render_sidebar(
     actions
 }
 
+/// Handle drag reorder state machine.
+fn handle_drag_reorder(
+    ui: &egui::Ui,
+    ctx: &egui::Context,
+    state: &mut SidebarState,
+    row_midpoints: &[f32],
+    actions: &mut Vec<SidebarAction>,
+) {
+    let (hover_pos, any_released, primary_down) = ui.input(|i| {
+        (
+            i.pointer.hover_pos(),
+            i.pointer.any_released(),
+            i.pointer.primary_down(),
+        )
+    });
+
+    if let Some(drag) = &mut state.drag {
+        if any_released || !primary_down {
+            let from = drag.source_idx;
+            let to = drag.drop_target_idx;
+            state.drag = None;
+            if from != to {
+                actions.push(SidebarAction::ReorderWorkspace(from, to));
+            }
+        } else if let Some(pos) = hover_pos {
+            drag.current_y = pos.y;
+            drag.row_midpoints = row_midpoints.to_vec();
+
+            // Compute drop target from pointer Y vs row midpoints
+            let mut target = row_midpoints.len();
+            for (i, &mid) in row_midpoints.iter().enumerate() {
+                if pos.y < mid {
+                    target = i;
+                    break;
+                }
+            }
+            drag.drop_target_idx = target;
+            ctx.request_repaint();
+        }
+    }
+}
+
+/// Renders a workspace row. Returns (actions, allocated_rect).
 fn render_workspace_row(
     ui: &mut egui::Ui,
     ws: &Workspace,
     idx: usize,
     is_active: bool,
+    is_being_dragged: bool,
     notifications: &NotificationStore,
     state: &mut SidebarState,
-) -> Vec<SidebarAction> {
+) -> (Vec<SidebarAction>, egui::Rect) {
     let mut actions = Vec::new();
     let pane_ids: Vec<u64> = ws.tree.iter_panes();
     let unread = notifications.workspace_unread_count(&pane_ids);
     let status = notifications.workspace_status(ws.id);
     let has_status = status.is_some();
+    let has_progress = status.as_ref().and_then(|s| s.progress).is_some();
     let latest_notif = notifications.latest_for_workspace(ws.id);
     let has_notif_text = latest_notif.is_some_and(|n| !n.body.is_empty());
     let is_renaming = state.renaming == Some(idx);
+    let has_color = ws.color.is_some();
 
     // Dynamic row height
-    let title_line_h = TITLE_FONT_SIZE + 2.0; // text + small buffer
+    let title_line_h = TITLE_FONT_SIZE + 2.0;
     let mut row_h = ROW_V_PAD * 2.0 + title_line_h;
     if has_status {
         row_h += PILL_HEIGHT + 4.0;
@@ -171,23 +304,37 @@ fn render_workspace_row(
     if has_notif_text {
         row_h += NOTIF_PREVIEW_HEIGHT + 2.0;
     }
+    if has_progress {
+        row_h += PROGRESS_BAR_HEIGHT + 4.0;
+    }
 
     let avail_w = ui.available_width();
-    let (rect, response) = ui.allocate_exact_size(egui::vec2(avail_w, row_h), egui::Sense::click());
+    let (rect, response) =
+        ui.allocate_exact_size(egui::vec2(avail_w, row_h), egui::Sense::click_and_drag());
 
     if !ui.is_rect_visible(rect) {
         if response.clicked() && !is_active {
             actions.push(SidebarAction::SwitchWorkspace(idx));
         }
-        return actions;
+        return (actions, rect);
     }
 
     let hovered = response.hovered();
 
+    // --- Drag initiation ---
+    if response.drag_started() && state.drag.is_none() && !is_renaming {
+        state.drag = Some(SidebarDragState {
+            source_idx: idx,
+            current_y: rect.center().y,
+            drop_target_idx: idx,
+            row_midpoints: Vec::new(),
+        });
+    }
+
     // --- Middle-click to close ---
     if response.middle_clicked() {
         actions.push(SidebarAction::CloseWorkspace(idx));
-        return actions;
+        return (actions, rect);
     }
 
     // --- Context menu ---
@@ -206,17 +353,54 @@ fn render_workspace_row(
             actions.push(SidebarAction::MarkWorkspaceRead(idx));
             ui.close_menu();
         }
+        ui.separator();
+        ui.menu_button("Set Color", |ui| {
+            for &(color, name) in PRESET_COLORS {
+                let c = Color32::from_rgba_premultiplied(color[0], color[1], color[2], color[3]);
+                ui.horizontal(|ui| {
+                    let (swatch_rect, _) =
+                        ui.allocate_exact_size(egui::vec2(12.0, 12.0), egui::Sense::hover());
+                    ui.painter().circle_filled(swatch_rect.center(), 5.0, c);
+                    if ui.button(name).clicked() {
+                        actions.push(SidebarAction::SetWorkspaceColor(idx, Some(color)));
+                        ui.close_menu();
+                    }
+                });
+            }
+            ui.separator();
+            if ui.button("Clear").clicked() {
+                actions.push(SidebarAction::SetWorkspaceColor(idx, None));
+                ui.close_menu();
+            }
+        });
     });
 
     // --- Background ---
+    let opacity = if is_being_dragged { 0.6 } else { 1.0 };
     let bg = if is_active {
-        ROW_ACTIVE_BG
+        with_opacity(ROW_ACTIVE_BG, opacity)
     } else if hovered {
-        ROW_HOVER_BG
+        with_opacity(ROW_HOVER_BG, opacity)
     } else {
         Color32::TRANSPARENT
     };
     ui.painter().rect_filled(rect, ROW_CORNER_RADIUS, bg);
+
+    // --- Workspace color capsule (leading edge) ---
+    let content_left = if has_color {
+        if let Some(c) = ws.color {
+            let capsule_rect = egui::Rect::from_min_size(
+                egui::pos2(rect.min.x + 2.0, rect.min.y + ROW_V_PAD),
+                egui::vec2(COLOR_CAPSULE_WIDTH, row_h - ROW_V_PAD * 2.0),
+            );
+            let color = Color32::from_rgba_premultiplied(c[0], c[1], c[2], c[3]);
+            ui.painter()
+                .rect_filled(capsule_rect, COLOR_CAPSULE_WIDTH / 2.0, color);
+        }
+        ROW_H_PAD + COLOR_CAPSULE_WIDTH + 4.0
+    } else {
+        ROW_H_PAD
+    };
 
     // --- Title (or rename TextEdit) ---
     let title_color = if is_active {
@@ -227,18 +411,16 @@ fn render_workspace_row(
 
     let close_btn_reserve = CLOSE_BTN_SIZE + 4.0;
     let badge_reserve = BADGE_RADIUS * 2.0 + 4.0;
-    // When hovered, reserve space for close button instead of badge
     let right_reserve = if hovered && !is_renaming {
         close_btn_reserve
     } else {
         badge_reserve
     };
-    let max_title_w = avail_w - ROW_H_PAD * 2.0 - right_reserve;
+    let max_title_w = avail_w - content_left - ROW_H_PAD - right_reserve;
 
     if is_renaming {
-        // Render inline rename TextEdit
         let title_rect = egui::Rect::from_min_size(
-            rect.min + egui::vec2(ROW_H_PAD, ROW_V_PAD),
+            rect.min + egui::vec2(content_left, ROW_V_PAD),
             egui::vec2(max_title_w, title_line_h),
         );
         let rename_id = ui.id().with("rename").with(idx);
@@ -248,17 +430,13 @@ fn render_workspace_row(
             .text_color(title_color)
             .desired_width(max_title_w)
             .frame(false);
-        // Dark background for the rename field
         text_edit = text_edit.background_color(Color32::from_rgba_premultiplied(0, 0, 0, 180));
 
         let te_response = ui.put(title_rect, text_edit);
-
-        // Request focus on first frame
         if !te_response.has_focus() {
             te_response.request_focus();
         }
 
-        // Confirm on Enter, cancel on Escape, confirm on focus loss
         let confirmed = ui.input(|i| i.key_pressed(egui::Key::Enter));
         let cancelled = ui.input(|i| i.key_pressed(egui::Key::Escape));
 
@@ -274,7 +452,7 @@ fn render_workspace_row(
             state.rename_buf.clear();
         }
     } else {
-        let title_pos = rect.min + egui::vec2(ROW_H_PAD, ROW_V_PAD);
+        let title_pos = rect.min + egui::vec2(content_left, ROW_V_PAD);
         let title_font = egui::FontId::proportional(TITLE_FONT_SIZE);
         let truncated_title = truncate_text(ui, &ws.title, &title_font, max_title_w);
         ui.painter().text(
@@ -290,37 +468,24 @@ fn render_workspace_row(
     let badge_center_y = rect.min.y + ROW_V_PAD + title_line_h / 2.0;
 
     if hovered && !is_renaming {
-        // Close button (✕) on the right
         let btn_center = egui::pos2(
             rect.right() - ROW_H_PAD - CLOSE_BTN_SIZE / 2.0,
             badge_center_y,
         );
         let btn_rect =
             egui::Rect::from_center_size(btn_center, egui::vec2(CLOSE_BTN_SIZE, CLOSE_BTN_SIZE));
-
-        // Check if pointer is over close button
         let pointer_over_btn = ui
             .input(|i| i.pointer.hover_pos())
             .is_some_and(|p| btn_rect.contains(p));
-
         let btn_color = if pointer_over_btn {
             TEXT_ACTIVE
         } else {
             CLOSE_BTN_COLOR
         };
-
-        ui.painter().text(
-            btn_center,
-            egui::Align2::CENTER_CENTER,
-            "\u{2715}", // ✕
-            egui::FontId::proportional(CLOSE_BTN_FONT_SIZE),
-            btn_color,
-        );
-
-        // If clicked on the close button specifically, close instead of switch
+        paint_close_x(ui.painter(), btn_center, 4.0, btn_color);
         if response.clicked() && pointer_over_btn {
             actions.push(SidebarAction::CloseWorkspace(idx));
-            return actions;
+            return (actions, rect);
         }
     } else if unread > 0 {
         let badge_center = egui::pos2(rect.right() - ROW_H_PAD - BADGE_RADIUS, badge_center_y);
@@ -350,22 +515,24 @@ fn render_workspace_row(
     }
 
     // --- Status pill ---
-    if let Some(status) = status {
+    let mut content_bottom = rect.min.y + ROW_V_PAD + title_line_h;
+    if let Some(status) = &status {
         let (pill_color, default_text) = match status.state {
             amux_notify::AgentState::Active => (STATUS_GREEN, "active"),
             amux_notify::AgentState::Waiting => (STATUS_ORANGE, "waiting"),
             amux_notify::AgentState::Idle => (STATUS_GRAY, "idle"),
         };
         let label = status.label.as_deref().unwrap_or(default_text);
-        let pill_y = rect.min.y + ROW_V_PAD + title_line_h + 4.0;
-        let pill_x = rect.min.x + ROW_H_PAD;
+        content_bottom += 4.0;
+        let pill_y = content_bottom;
+        let pill_x = rect.min.x + content_left;
 
         let pill_font = egui::FontId::proportional(PILL_FONT_SIZE);
         let text_galley =
             ui.painter()
                 .layout_no_wrap(label.to_string(), pill_font.clone(), Color32::WHITE);
         let text_w = text_galley.size().x;
-        let pill_w = (text_w + 10.0).min(avail_w - ROW_H_PAD * 2.0);
+        let pill_w = (text_w + 10.0).min(avail_w - content_left - ROW_H_PAD);
 
         let pill_rect =
             egui::Rect::from_min_size(egui::pos2(pill_x, pill_y), egui::vec2(pill_w, PILL_HEIGHT));
@@ -378,36 +545,56 @@ fn render_workspace_row(
             pill_font,
             Color32::WHITE,
         );
+        content_bottom += PILL_HEIGHT;
     }
 
     // --- Notification preview text ---
     if let Some(notif) = latest_notif.filter(|n| !n.body.is_empty()) {
         let notif_color = if is_active {
-            Color32::from_rgba_premultiplied(204, 204, 204, 204) // white@0.8
+            Color32::from_rgba_premultiplied(204, 204, 204, 204)
         } else {
             TEXT_SECONDARY
         };
-        let notif_y = if has_status {
-            rect.min.y + ROW_V_PAD + title_line_h + 4.0 + PILL_HEIGHT + 2.0
-        } else {
-            rect.min.y + ROW_V_PAD + title_line_h + 2.0
-        };
-        let notif_x = rect.min.x + ROW_H_PAD;
-        let max_w = avail_w - ROW_H_PAD * 2.0;
+        content_bottom += 2.0;
+        let notif_x = rect.min.x + content_left;
+        let max_w = avail_w - content_left - ROW_H_PAD;
         let notif_font = egui::FontId::proportional(NOTIF_FONT_SIZE);
 
         let galley = ui
             .painter()
             .layout(notif.body.clone(), notif_font, notif_color, max_w);
         let clip_rect = egui::Rect::from_min_size(
-            egui::pos2(notif_x, notif_y),
+            egui::pos2(notif_x, content_bottom),
             egui::vec2(max_w, NOTIF_PREVIEW_HEIGHT),
         );
         ui.painter().with_clip_rect(clip_rect).galley(
-            egui::pos2(notif_x, notif_y),
+            egui::pos2(notif_x, content_bottom),
             galley,
             notif_color,
         );
+        content_bottom += NOTIF_PREVIEW_HEIGHT;
+    }
+
+    // --- Progress bar ---
+    if let Some(progress) = status.as_ref().and_then(|s| s.progress) {
+        content_bottom += 4.0;
+        let bar_x = rect.min.x + content_left;
+        let bar_w = avail_w - content_left - ROW_H_PAD;
+        let track_rect = egui::Rect::from_min_size(
+            egui::pos2(bar_x, content_bottom),
+            egui::vec2(bar_w, PROGRESS_BAR_HEIGHT),
+        );
+        ui.painter()
+            .rect_filled(track_rect, PROGRESS_BAR_HEIGHT / 2.0, PROGRESS_TRACK);
+        let fill_w = bar_w * progress.clamp(0.0, 1.0);
+        if fill_w > 0.0 {
+            let fill_rect = egui::Rect::from_min_size(
+                egui::pos2(bar_x, content_bottom),
+                egui::vec2(fill_w, PROGRESS_BAR_HEIGHT),
+            );
+            ui.painter()
+                .rect_filled(fill_rect, PROGRESS_BAR_HEIGHT / 2.0, ACCENT_BLUE);
+        }
     }
 
     // --- Click to switch workspace ---
@@ -415,7 +602,16 @@ fn render_workspace_row(
         actions.push(SidebarAction::SwitchWorkspace(idx));
     }
 
-    actions
+    (actions, rect)
+}
+
+fn with_opacity(color: Color32, opacity: f32) -> Color32 {
+    Color32::from_rgba_premultiplied(
+        (color.r() as f32 * opacity) as u8,
+        (color.g() as f32 * opacity) as u8,
+        (color.b() as f32 * opacity) as u8,
+        (color.a() as f32 * opacity) as u8,
+    )
 }
 
 /// Truncate text to fit within `max_width`, appending "\u{2026}" if needed.

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -39,6 +39,8 @@ const PILL_FONT_SIZE: f32 = 9.0;
 const PILL_HEIGHT: f32 = 14.0;
 const PILL_CORNER_RADIUS: f32 = 7.0;
 const COUNT_FONT_SIZE: f32 = 10.0;
+const NOTIF_FONT_SIZE: f32 = 10.0;
+const NOTIF_PREVIEW_HEIGHT: f32 = 24.0; // ~2 lines at 10pt
 #[cfg(target_os = "macos")]
 const TRAFFIC_LIGHT_SPACER: f32 = 28.0;
 
@@ -151,12 +153,17 @@ fn render_workspace_row(
     let unread = notifications.workspace_unread_count(&pane_ids);
     let status = notifications.workspace_status(ws.id);
     let has_status = status.is_some();
+    let latest_notif = notifications.latest_for_workspace(ws.id);
+    let has_notif_text = latest_notif.is_some_and(|n| !n.body.is_empty());
 
     // Dynamic row height
     let title_line_h = TITLE_FONT_SIZE + 2.0; // text + small buffer
     let mut row_h = ROW_V_PAD * 2.0 + title_line_h;
     if has_status {
         row_h += PILL_HEIGHT + 4.0;
+    }
+    if has_notif_text {
+        row_h += NOTIF_PREVIEW_HEIGHT + 2.0;
     }
 
     let avail_w = ui.available_width();
@@ -263,6 +270,38 @@ fn render_workspace_row(
             label,
             pill_font,
             Color32::WHITE,
+        );
+    }
+
+    // --- Notification preview text ---
+    if let Some(notif) = latest_notif.filter(|n| !n.body.is_empty()) {
+        let notif_color = if is_active {
+            Color32::from_rgba_premultiplied(204, 204, 204, 204) // white@0.8
+        } else {
+            TEXT_SECONDARY
+        };
+        // Position below pill or title
+        let notif_y = if has_status {
+            rect.min.y + ROW_V_PAD + title_line_h + 4.0 + PILL_HEIGHT + 2.0
+        } else {
+            rect.min.y + ROW_V_PAD + title_line_h + 2.0
+        };
+        let notif_x = rect.min.x + ROW_H_PAD;
+        let max_w = avail_w - ROW_H_PAD * 2.0;
+        let notif_font = egui::FontId::proportional(NOTIF_FONT_SIZE);
+
+        // Use galley for word-wrap, clip to 2 lines
+        let galley = ui
+            .painter()
+            .layout(notif.body.clone(), notif_font, notif_color, max_w);
+        let clip_rect = egui::Rect::from_min_size(
+            egui::pos2(notif_x, notif_y),
+            egui::vec2(max_w, NOTIF_PREVIEW_HEIGHT),
+        );
+        ui.painter().with_clip_rect(clip_rect).galley(
+            egui::pos2(notif_x, notif_y),
+            galley,
+            notif_color,
         );
     }
 

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -20,6 +20,7 @@ const STATUS_ORANGE: Color32 = Color32::from_rgb(230, 170, 40);
 const STATUS_GRAY: Color32 = Color32::from_gray(100);
 const NEW_BTN_TEXT: Color32 = Color32::from_gray(140);
 const NEW_BTN_HOVER: Color32 = Color32::from_rgba_premultiplied(15, 15, 15, 15);
+const CLOSE_BTN_COLOR: Color32 = Color32::from_rgba_premultiplied(140, 140, 140, 179); // secondary@0.7
 
 // ---------------------------------------------------------------------------
 // Layout constants (matching cmux points)
@@ -41,6 +42,8 @@ const PILL_CORNER_RADIUS: f32 = 7.0;
 const COUNT_FONT_SIZE: f32 = 10.0;
 const NOTIF_FONT_SIZE: f32 = 10.0;
 const NOTIF_PREVIEW_HEIGHT: f32 = 24.0; // ~2 lines at 10pt
+const CLOSE_BTN_SIZE: f32 = 16.0;
+const CLOSE_BTN_FONT_SIZE: f32 = 9.0;
 #[cfg(target_os = "macos")]
 const TRAFFIC_LIGHT_SPACER: f32 = 28.0;
 
@@ -51,6 +54,9 @@ const TRAFFIC_LIGHT_SPACER: f32 = 28.0;
 pub(crate) enum SidebarAction {
     SwitchWorkspace(usize),
     CreateWorkspace,
+    CloseWorkspace(usize),
+    RenameWorkspace(usize, String),
+    MarkWorkspaceRead(usize),
 }
 
 // ---------------------------------------------------------------------------
@@ -90,11 +96,9 @@ pub(crate) fn render_sidebar(
                 .show(ui, |ui| {
                     for (idx, ws) in workspaces.iter().enumerate() {
                         let is_active = idx == active_workspace_idx;
-                        let action =
+                        let row_actions =
                             render_workspace_row(ui, ws, idx, is_active, notifications, state);
-                        if let Some(a) = action {
-                            actions.push(a);
-                        }
+                        actions.extend(row_actions);
                     }
 
                     ui.add_space(8.0);
@@ -147,14 +151,16 @@ fn render_workspace_row(
     idx: usize,
     is_active: bool,
     notifications: &NotificationStore,
-    state: &SidebarState,
-) -> Option<SidebarAction> {
+    state: &mut SidebarState,
+) -> Vec<SidebarAction> {
+    let mut actions = Vec::new();
     let pane_ids: Vec<u64> = ws.tree.iter_panes();
     let unread = notifications.workspace_unread_count(&pane_ids);
     let status = notifications.workspace_status(ws.id);
     let has_status = status.is_some();
     let latest_notif = notifications.latest_for_workspace(ws.id);
     let has_notif_text = latest_notif.is_some_and(|n| !n.body.is_empty());
+    let is_renaming = state.renaming == Some(idx);
 
     // Dynamic row height
     let title_line_h = TITLE_FONT_SIZE + 2.0; // text + small buffer
@@ -170,15 +176,37 @@ fn render_workspace_row(
     let (rect, response) = ui.allocate_exact_size(egui::vec2(avail_w, row_h), egui::Sense::click());
 
     if !ui.is_rect_visible(rect) {
-        return if response.clicked() && !is_active {
-            Some(SidebarAction::SwitchWorkspace(idx))
-        } else {
-            None
-        };
+        if response.clicked() && !is_active {
+            actions.push(SidebarAction::SwitchWorkspace(idx));
+        }
+        return actions;
     }
 
     let hovered = response.hovered();
-    let _ = state; // will use in later PRs
+
+    // --- Middle-click to close ---
+    if response.middle_clicked() {
+        actions.push(SidebarAction::CloseWorkspace(idx));
+        return actions;
+    }
+
+    // --- Context menu ---
+    response.context_menu(|ui| {
+        if ui.button("Rename Workspace").clicked() {
+            state.renaming = Some(idx);
+            state.rename_buf = ws.title.clone();
+            ui.close_menu();
+        }
+        if ui.button("Close Workspace").clicked() {
+            actions.push(SidebarAction::CloseWorkspace(idx));
+            ui.close_menu();
+        }
+        ui.separator();
+        if ui.button("Mark All Read").clicked() {
+            actions.push(SidebarAction::MarkWorkspaceRead(idx));
+            ui.close_menu();
+        }
+    });
 
     // --- Background ---
     let bg = if is_active {
@@ -190,31 +218,111 @@ fn render_workspace_row(
     };
     ui.painter().rect_filled(rect, ROW_CORNER_RADIUS, bg);
 
-    // --- Title ---
+    // --- Title (or rename TextEdit) ---
     let title_color = if is_active {
         TEXT_ACTIVE
     } else {
         TEXT_INACTIVE
     };
-    let title_pos = rect.min + egui::vec2(ROW_H_PAD, ROW_V_PAD);
 
-    // Measure and truncate title with ellipsis
-    let badge_reserve = BADGE_RADIUS * 2.0 + 4.0; // space for badge/count on right
-    let max_title_w = avail_w - ROW_H_PAD * 2.0 - badge_reserve;
-    let title_font = egui::FontId::proportional(TITLE_FONT_SIZE);
+    let close_btn_reserve = CLOSE_BTN_SIZE + 4.0;
+    let badge_reserve = BADGE_RADIUS * 2.0 + 4.0;
+    // When hovered, reserve space for close button instead of badge
+    let right_reserve = if hovered && !is_renaming {
+        close_btn_reserve
+    } else {
+        badge_reserve
+    };
+    let max_title_w = avail_w - ROW_H_PAD * 2.0 - right_reserve;
 
-    let truncated_title = truncate_text(ui, &ws.title, &title_font, max_title_w);
-    ui.painter().text(
-        title_pos,
-        egui::Align2::LEFT_TOP,
-        &truncated_title,
-        title_font.clone(),
-        title_color,
-    );
+    if is_renaming {
+        // Render inline rename TextEdit
+        let title_rect = egui::Rect::from_min_size(
+            rect.min + egui::vec2(ROW_H_PAD, ROW_V_PAD),
+            egui::vec2(max_title_w, title_line_h),
+        );
+        let rename_id = ui.id().with("rename").with(idx);
+        let mut text_edit = egui::TextEdit::singleline(&mut state.rename_buf)
+            .id(rename_id)
+            .font(egui::FontId::proportional(TITLE_FONT_SIZE))
+            .text_color(title_color)
+            .desired_width(max_title_w)
+            .frame(false);
+        // Dark background for the rename field
+        text_edit = text_edit.background_color(Color32::from_rgba_premultiplied(0, 0, 0, 180));
 
-    // --- Unread badge or pane count (right-aligned) ---
+        let te_response = ui.put(title_rect, text_edit);
+
+        // Request focus on first frame
+        if !te_response.has_focus() {
+            te_response.request_focus();
+        }
+
+        // Confirm on Enter, cancel on Escape, confirm on focus loss
+        let confirmed = ui.input(|i| i.key_pressed(egui::Key::Enter));
+        let cancelled = ui.input(|i| i.key_pressed(egui::Key::Escape));
+
+        if confirmed || (!te_response.has_focus() && !cancelled) {
+            let new_name = state.rename_buf.trim().to_string();
+            if !new_name.is_empty() && new_name != ws.title {
+                actions.push(SidebarAction::RenameWorkspace(idx, new_name));
+            }
+            state.renaming = None;
+            state.rename_buf.clear();
+        } else if cancelled {
+            state.renaming = None;
+            state.rename_buf.clear();
+        }
+    } else {
+        let title_pos = rect.min + egui::vec2(ROW_H_PAD, ROW_V_PAD);
+        let title_font = egui::FontId::proportional(TITLE_FONT_SIZE);
+        let truncated_title = truncate_text(ui, &ws.title, &title_font, max_title_w);
+        ui.painter().text(
+            title_pos,
+            egui::Align2::LEFT_TOP,
+            &truncated_title,
+            title_font,
+            title_color,
+        );
+    }
+
+    // --- Close button on hover (replaces badge) or badge/count ---
     let badge_center_y = rect.min.y + ROW_V_PAD + title_line_h / 2.0;
-    if unread > 0 {
+
+    if hovered && !is_renaming {
+        // Close button (✕) on the right
+        let btn_center = egui::pos2(
+            rect.right() - ROW_H_PAD - CLOSE_BTN_SIZE / 2.0,
+            badge_center_y,
+        );
+        let btn_rect =
+            egui::Rect::from_center_size(btn_center, egui::vec2(CLOSE_BTN_SIZE, CLOSE_BTN_SIZE));
+
+        // Check if pointer is over close button
+        let pointer_over_btn = ui
+            .input(|i| i.pointer.hover_pos())
+            .is_some_and(|p| btn_rect.contains(p));
+
+        let btn_color = if pointer_over_btn {
+            TEXT_ACTIVE
+        } else {
+            CLOSE_BTN_COLOR
+        };
+
+        ui.painter().text(
+            btn_center,
+            egui::Align2::CENTER_CENTER,
+            "\u{2715}", // ✕
+            egui::FontId::proportional(CLOSE_BTN_FONT_SIZE),
+            btn_color,
+        );
+
+        // If clicked on the close button specifically, close instead of switch
+        if response.clicked() && pointer_over_btn {
+            actions.push(SidebarAction::CloseWorkspace(idx));
+            return actions;
+        }
+    } else if unread > 0 {
         let badge_center = egui::pos2(rect.right() - ROW_H_PAD - BADGE_RADIUS, badge_center_y);
         let badge_color = if is_active {
             BADGE_ACTIVE_BG
@@ -252,7 +360,6 @@ fn render_workspace_row(
         let pill_y = rect.min.y + ROW_V_PAD + title_line_h + 4.0;
         let pill_x = rect.min.x + ROW_H_PAD;
 
-        // Measure pill text width
         let pill_font = egui::FontId::proportional(PILL_FONT_SIZE);
         let text_galley =
             ui.painter()
@@ -280,7 +387,6 @@ fn render_workspace_row(
         } else {
             TEXT_SECONDARY
         };
-        // Position below pill or title
         let notif_y = if has_status {
             rect.min.y + ROW_V_PAD + title_line_h + 4.0 + PILL_HEIGHT + 2.0
         } else {
@@ -290,7 +396,6 @@ fn render_workspace_row(
         let max_w = avail_w - ROW_H_PAD * 2.0;
         let notif_font = egui::FontId::proportional(NOTIF_FONT_SIZE);
 
-        // Use galley for word-wrap, clip to 2 lines
         let galley = ui
             .painter()
             .layout(notif.body.clone(), notif_font, notif_color, max_w);
@@ -305,14 +410,15 @@ fn render_workspace_row(
         );
     }
 
-    if response.clicked() && !is_active {
-        Some(SidebarAction::SwitchWorkspace(idx))
-    } else {
-        None
+    // --- Click to switch workspace ---
+    if response.clicked() && !is_active && !is_renaming {
+        actions.push(SidebarAction::SwitchWorkspace(idx));
     }
+
+    actions
 }
 
-/// Truncate text to fit within `max_width`, appending "…" if needed.
+/// Truncate text to fit within `max_width`, appending "\u{2026}" if needed.
 fn truncate_text(ui: &egui::Ui, text: &str, font: &egui::FontId, max_width: f32) -> String {
     let full_galley = ui
         .painter()
@@ -321,8 +427,7 @@ fn truncate_text(ui: &egui::Ui, text: &str, font: &egui::FontId, max_width: f32)
         return text.to_string();
     }
 
-    // Binary search for the longest prefix that fits with "…"
-    let ellipsis = "…";
+    let ellipsis = "\u{2026}";
     let ellipsis_w = ui
         .painter()
         .layout_no_wrap(ellipsis.to_string(), font.clone(), Color32::WHITE)

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -1,0 +1,314 @@
+use amux_notify::NotificationStore;
+use egui::Color32;
+
+use crate::{SidebarState, Workspace};
+
+// ---------------------------------------------------------------------------
+// Colors (cmux dark mode equivalents)
+// ---------------------------------------------------------------------------
+
+const ACCENT_BLUE: Color32 = Color32::from_rgb(0, 145, 255);
+const SIDEBAR_BG: Color32 = Color32::from_rgba_premultiplied(20, 20, 20, 230);
+const ROW_ACTIVE_BG: Color32 = Color32::from_rgb(0, 145, 255);
+const ROW_HOVER_BG: Color32 = Color32::from_rgba_premultiplied(15, 15, 15, 15);
+const TEXT_ACTIVE: Color32 = Color32::WHITE;
+const TEXT_INACTIVE: Color32 = Color32::from_gray(180);
+const TEXT_SECONDARY: Color32 = Color32::from_gray(140);
+const BADGE_ACTIVE_BG: Color32 = Color32::from_rgba_premultiplied(64, 64, 64, 64);
+const STATUS_GREEN: Color32 = Color32::from_rgb(50, 180, 80);
+const STATUS_ORANGE: Color32 = Color32::from_rgb(230, 170, 40);
+const STATUS_GRAY: Color32 = Color32::from_gray(100);
+const NEW_BTN_TEXT: Color32 = Color32::from_gray(140);
+const NEW_BTN_HOVER: Color32 = Color32::from_rgba_premultiplied(15, 15, 15, 15);
+
+// ---------------------------------------------------------------------------
+// Layout constants (matching cmux points)
+// ---------------------------------------------------------------------------
+
+pub(crate) const SIDEBAR_MIN_WIDTH: f32 = 180.0;
+pub(crate) const SIDEBAR_MAX_WIDTH: f32 = 600.0;
+const ROW_H_PAD: f32 = 10.0;
+const ROW_V_PAD: f32 = 8.0;
+const ROW_OUTER_H_PAD: f32 = 6.0;
+const ROW_SPACING: f32 = 2.0;
+const ROW_CORNER_RADIUS: f32 = 6.0;
+const TITLE_FONT_SIZE: f32 = 12.5;
+const BADGE_RADIUS: f32 = 8.0;
+const BADGE_FONT_SIZE: f32 = 9.0;
+const PILL_FONT_SIZE: f32 = 9.0;
+const PILL_HEIGHT: f32 = 14.0;
+const PILL_CORNER_RADIUS: f32 = 7.0;
+const COUNT_FONT_SIZE: f32 = 10.0;
+#[cfg(target_os = "macos")]
+const TRAFFIC_LIGHT_SPACER: f32 = 28.0;
+
+// ---------------------------------------------------------------------------
+// Actions returned from sidebar rendering
+// ---------------------------------------------------------------------------
+
+pub(crate) enum SidebarAction {
+    SwitchWorkspace(usize),
+    CreateWorkspace,
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+pub(crate) fn render_sidebar(
+    ctx: &egui::Context,
+    state: &mut SidebarState,
+    workspaces: &[Workspace],
+    active_workspace_idx: usize,
+    notifications: &NotificationStore,
+) -> Vec<SidebarAction> {
+    let mut actions = Vec::new();
+
+    egui::SidePanel::left("sidebar")
+        .resizable(true)
+        .default_width(state.width)
+        .min_width(SIDEBAR_MIN_WIDTH)
+        .max_width(SIDEBAR_MAX_WIDTH)
+        .frame(
+            egui::Frame::new()
+                .fill(SIDEBAR_BG)
+                .inner_margin(egui::Margin::symmetric(ROW_OUTER_H_PAD as i8, 0)),
+        )
+        .show(ctx, |ui| {
+            // Traffic light spacer (macOS) or small top margin (other)
+            #[cfg(target_os = "macos")]
+            ui.add_space(TRAFFIC_LIGHT_SPACER);
+            #[cfg(not(target_os = "macos"))]
+            ui.add_space(8.0);
+
+            ui.spacing_mut().item_spacing.y = ROW_SPACING;
+
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    for (idx, ws) in workspaces.iter().enumerate() {
+                        let is_active = idx == active_workspace_idx;
+                        let action =
+                            render_workspace_row(ui, ws, idx, is_active, notifications, state);
+                        if let Some(a) = action {
+                            actions.push(a);
+                        }
+                    }
+
+                    ui.add_space(8.0);
+
+                    // "+ New Workspace" button
+                    let avail_w = ui.available_width();
+                    let (btn_rect, btn_response) =
+                        ui.allocate_exact_size(egui::vec2(avail_w, 28.0), egui::Sense::click());
+                    if ui.is_rect_visible(btn_rect) {
+                        if btn_response.hovered() {
+                            ui.painter()
+                                .rect_filled(btn_rect, ROW_CORNER_RADIUS, NEW_BTN_HOVER);
+                        }
+                        ui.painter().text(
+                            btn_rect.center(),
+                            egui::Align2::CENTER_CENTER,
+                            "+ New Workspace",
+                            egui::FontId::proportional(11.0),
+                            if btn_response.hovered() {
+                                TEXT_INACTIVE
+                            } else {
+                                NEW_BTN_TEXT
+                            },
+                        );
+                    }
+                    if btn_response.clicked() {
+                        actions.push(SidebarAction::CreateWorkspace);
+                    }
+
+                    // Fill remaining space (double-click to create workspace)
+                    let remaining = ui.available_height().max(0.0);
+                    if remaining > 0.0 {
+                        let (_, empty_response) = ui.allocate_exact_size(
+                            egui::vec2(avail_w, remaining),
+                            egui::Sense::click(),
+                        );
+                        if empty_response.double_clicked() {
+                            actions.push(SidebarAction::CreateWorkspace);
+                        }
+                    }
+                });
+        });
+
+    actions
+}
+
+fn render_workspace_row(
+    ui: &mut egui::Ui,
+    ws: &Workspace,
+    idx: usize,
+    is_active: bool,
+    notifications: &NotificationStore,
+    state: &SidebarState,
+) -> Option<SidebarAction> {
+    let pane_ids: Vec<u64> = ws.tree.iter_panes();
+    let unread = notifications.workspace_unread_count(&pane_ids);
+    let status = notifications.workspace_status(ws.id);
+    let has_status = status.is_some();
+
+    // Dynamic row height
+    let title_line_h = TITLE_FONT_SIZE + 2.0; // text + small buffer
+    let mut row_h = ROW_V_PAD * 2.0 + title_line_h;
+    if has_status {
+        row_h += PILL_HEIGHT + 4.0;
+    }
+
+    let avail_w = ui.available_width();
+    let (rect, response) = ui.allocate_exact_size(egui::vec2(avail_w, row_h), egui::Sense::click());
+
+    if !ui.is_rect_visible(rect) {
+        return if response.clicked() && !is_active {
+            Some(SidebarAction::SwitchWorkspace(idx))
+        } else {
+            None
+        };
+    }
+
+    let hovered = response.hovered();
+    let _ = state; // will use in later PRs
+
+    // --- Background ---
+    let bg = if is_active {
+        ROW_ACTIVE_BG
+    } else if hovered {
+        ROW_HOVER_BG
+    } else {
+        Color32::TRANSPARENT
+    };
+    ui.painter().rect_filled(rect, ROW_CORNER_RADIUS, bg);
+
+    // --- Title ---
+    let title_color = if is_active {
+        TEXT_ACTIVE
+    } else {
+        TEXT_INACTIVE
+    };
+    let title_pos = rect.min + egui::vec2(ROW_H_PAD, ROW_V_PAD);
+
+    // Measure and truncate title with ellipsis
+    let badge_reserve = BADGE_RADIUS * 2.0 + 4.0; // space for badge/count on right
+    let max_title_w = avail_w - ROW_H_PAD * 2.0 - badge_reserve;
+    let title_font = egui::FontId::proportional(TITLE_FONT_SIZE);
+
+    let truncated_title = truncate_text(ui, &ws.title, &title_font, max_title_w);
+    ui.painter().text(
+        title_pos,
+        egui::Align2::LEFT_TOP,
+        &truncated_title,
+        title_font.clone(),
+        title_color,
+    );
+
+    // --- Unread badge or pane count (right-aligned) ---
+    let badge_center_y = rect.min.y + ROW_V_PAD + title_line_h / 2.0;
+    if unread > 0 {
+        let badge_center = egui::pos2(rect.right() - ROW_H_PAD - BADGE_RADIUS, badge_center_y);
+        let badge_color = if is_active {
+            BADGE_ACTIVE_BG
+        } else {
+            ACCENT_BLUE
+        };
+        ui.painter()
+            .circle_filled(badge_center, BADGE_RADIUS, badge_color);
+        ui.painter().text(
+            badge_center,
+            egui::Align2::CENTER_CENTER,
+            format!("{unread}"),
+            egui::FontId::proportional(BADGE_FONT_SIZE),
+            Color32::WHITE,
+        );
+    } else {
+        let count = pane_ids.len();
+        ui.painter().text(
+            egui::pos2(rect.right() - ROW_H_PAD, rect.min.y + ROW_V_PAD),
+            egui::Align2::RIGHT_TOP,
+            format!("{count}"),
+            egui::FontId::proportional(COUNT_FONT_SIZE),
+            TEXT_SECONDARY,
+        );
+    }
+
+    // --- Status pill ---
+    if let Some(status) = status {
+        let (pill_color, default_text) = match status.state {
+            amux_notify::AgentState::Active => (STATUS_GREEN, "active"),
+            amux_notify::AgentState::Waiting => (STATUS_ORANGE, "waiting"),
+            amux_notify::AgentState::Idle => (STATUS_GRAY, "idle"),
+        };
+        let label = status.label.as_deref().unwrap_or(default_text);
+        let pill_y = rect.min.y + ROW_V_PAD + title_line_h + 4.0;
+        let pill_x = rect.min.x + ROW_H_PAD;
+
+        // Measure pill text width
+        let pill_font = egui::FontId::proportional(PILL_FONT_SIZE);
+        let text_galley =
+            ui.painter()
+                .layout_no_wrap(label.to_string(), pill_font.clone(), Color32::WHITE);
+        let text_w = text_galley.size().x;
+        let pill_w = (text_w + 10.0).min(avail_w - ROW_H_PAD * 2.0);
+
+        let pill_rect =
+            egui::Rect::from_min_size(egui::pos2(pill_x, pill_y), egui::vec2(pill_w, PILL_HEIGHT));
+        ui.painter()
+            .rect_filled(pill_rect, PILL_CORNER_RADIUS, pill_color);
+        ui.painter().text(
+            pill_rect.center(),
+            egui::Align2::CENTER_CENTER,
+            label,
+            pill_font,
+            Color32::WHITE,
+        );
+    }
+
+    if response.clicked() && !is_active {
+        Some(SidebarAction::SwitchWorkspace(idx))
+    } else {
+        None
+    }
+}
+
+/// Truncate text to fit within `max_width`, appending "…" if needed.
+fn truncate_text(ui: &egui::Ui, text: &str, font: &egui::FontId, max_width: f32) -> String {
+    let full_galley = ui
+        .painter()
+        .layout_no_wrap(text.to_string(), font.clone(), Color32::WHITE);
+    if full_galley.size().x <= max_width {
+        return text.to_string();
+    }
+
+    // Binary search for the longest prefix that fits with "…"
+    let ellipsis = "…";
+    let ellipsis_w = ui
+        .painter()
+        .layout_no_wrap(ellipsis.to_string(), font.clone(), Color32::WHITE)
+        .size()
+        .x;
+    let target_w = max_width - ellipsis_w;
+
+    let chars: Vec<char> = text.chars().collect();
+    let mut lo = 0usize;
+    let mut hi = chars.len();
+    while lo < hi {
+        let mid = (lo + hi).div_ceil(2);
+        let prefix: String = chars[..mid].iter().collect();
+        let w = ui
+            .painter()
+            .layout_no_wrap(prefix, font.clone(), Color32::WHITE)
+            .size()
+            .x;
+        if w <= target_w {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+
+    let prefix: String = chars[..lo].iter().collect();
+    format!("{prefix}{ellipsis}")
+}

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -46,6 +46,8 @@ pub struct WorkspaceStatus {
     pub state: AgentState,
     pub label: Option<String>,
     pub updated_at: Instant,
+    /// Optional progress value (0.0–1.0) for progress bar display.
+    pub progress: Option<f32>,
 }
 
 /// A single notification entry.
@@ -334,14 +336,28 @@ impl NotificationStore {
 
     /// Set workspace agent status.
     pub fn set_status(&mut self, workspace_id: u64, state: AgentState, label: Option<String>) {
+        // Preserve existing progress when updating status without explicit progress.
+        let progress = self
+            .workspace_statuses
+            .get(&workspace_id)
+            .and_then(|s| s.progress);
         self.workspace_statuses.insert(
             workspace_id,
             WorkspaceStatus {
                 state,
                 label,
                 updated_at: Instant::now(),
+                progress,
             },
         );
+    }
+
+    /// Set workspace progress (0.0–1.0). Pass `None` to clear.
+    pub fn set_progress(&mut self, workspace_id: u64, progress: Option<f32>) {
+        if let Some(status) = self.workspace_statuses.get_mut(&workspace_id) {
+            status.progress = progress;
+            status.updated_at = Instant::now();
+        }
     }
 
     /// Get workspace agent status.

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
@@ -228,8 +228,9 @@ impl NotificationStore {
 
     /// Mark all notifications for a workspace as read.
     pub fn mark_workspace_read(&mut self, pane_ids: &[u64]) {
+        let pane_set: HashSet<u64> = pane_ids.iter().copied().collect();
         for n in &mut self.notifications {
-            if !n.read && pane_ids.contains(&n.pane_id) {
+            if !n.read && pane_set.contains(&n.pane_id) {
                 n.read = true;
             }
         }
@@ -334,20 +335,15 @@ impl NotificationStore {
             .find(|n| n.workspace_id == workspace_id)
     }
 
-    /// Set workspace agent status.
+    /// Set workspace agent status. Clears any existing progress bar.
     pub fn set_status(&mut self, workspace_id: u64, state: AgentState, label: Option<String>) {
-        // Preserve existing progress when updating status without explicit progress.
-        let progress = self
-            .workspace_statuses
-            .get(&workspace_id)
-            .and_then(|s| s.progress);
         self.workspace_statuses.insert(
             workspace_id,
             WorkspaceStatus {
                 state,
                 label,
                 updated_at: Instant::now(),
-                progress,
+                progress: None,
             },
         );
     }
@@ -602,5 +598,73 @@ mod tests {
         assert_eq!(store.all_notifications().len(), 0);
         assert_eq!(store.pane_unread(10), 0);
         assert_eq!(store.pane_unread(20), 0);
+    }
+
+    #[test]
+    fn mark_workspace_read_only_affects_given_panes() {
+        let mut store = NotificationStore::new();
+        // Workspace 1 panes: 10, 11
+        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
+        store.push(1, 11, 101, "B".into(), "b".into(), NotificationSource::Bell);
+        // Workspace 2 pane: 20
+        store.push(2, 20, 200, "C".into(), "c".into(), NotificationSource::Bell);
+
+        store.mark_workspace_read(&[10, 11]);
+        assert_eq!(store.pane_unread(10), 0);
+        assert_eq!(store.pane_unread(11), 0);
+        assert_eq!(store.pane_unread(20), 1); // unaffected
+    }
+
+    #[test]
+    fn latest_for_workspace_returns_most_recent() {
+        let mut store = NotificationStore::new();
+        store.push(
+            1,
+            10,
+            100,
+            "First".into(),
+            "a".into(),
+            NotificationSource::Bell,
+        );
+        store.push(
+            2,
+            20,
+            200,
+            "Other".into(),
+            "b".into(),
+            NotificationSource::Bell,
+        );
+        store.push(
+            1,
+            10,
+            101,
+            "Latest".into(),
+            "c".into(),
+            NotificationSource::Bell,
+        );
+
+        let latest = store.latest_for_workspace(1).unwrap();
+        assert_eq!(latest.title, "Latest");
+
+        let latest2 = store.latest_for_workspace(2).unwrap();
+        assert_eq!(latest2.title, "Other");
+
+        assert!(store.latest_for_workspace(99).is_none());
+    }
+
+    #[test]
+    fn progress_lifecycle() {
+        let mut store = NotificationStore::new();
+        // set_status creates entry with no progress
+        store.set_status(1, AgentState::Active, Some("Building".into()));
+        assert!(store.workspace_status(1).unwrap().progress.is_none());
+
+        // set_progress adds progress
+        store.set_progress(1, Some(0.5));
+        assert_eq!(store.workspace_status(1).unwrap().progress, Some(0.5));
+
+        // set_status clears progress
+        store.set_status(1, AgentState::Idle, None);
+        assert!(store.workspace_status(1).unwrap().progress.is_none());
     }
 }

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -306,6 +306,14 @@ impl NotificationStore {
         self.notifications.iter().rev().find(|n| !n.read)
     }
 
+    /// Find the most recent notification for a workspace (read or unread).
+    pub fn latest_for_workspace(&self, workspace_id: u64) -> Option<&Notification> {
+        self.notifications
+            .iter()
+            .rev()
+            .find(|n| n.workspace_id == workspace_id)
+    }
+
     /// Set workspace agent status.
     pub fn set_status(&mut self, workspace_id: u64, state: AgentState, label: Option<String>) {
         self.workspace_statuses.insert(

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -224,6 +224,24 @@ impl NotificationStore {
         }
     }
 
+    /// Mark all notifications for a workspace as read.
+    pub fn mark_workspace_read(&mut self, pane_ids: &[u64]) {
+        for n in &mut self.notifications {
+            if !n.read && pane_ids.contains(&n.pane_id) {
+                n.read = true;
+            }
+        }
+        for &pid in pane_ids {
+            if let Some(state) = self.pane_states.get_mut(&pid) {
+                if state.unread_count > 0 {
+                    state.unread_count = 0;
+                    state.flash_started_at = Some(Instant::now());
+                    state.flash_reason = Some(FlashReason::NotificationDismiss);
+                }
+            }
+        }
+    }
+
     /// Mark all notifications as read.
     pub fn mark_all_read(&mut self) {
         for n in &mut self.notifications {

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -32,6 +32,8 @@ pub struct SavedWorkspace {
     #[serde(default)]
     pub zoomed: Option<u64>,
     pub panes: HashMap<u64, SavedManagedPane>,
+    #[serde(default)]
+    pub color: Option<[u8; 4]>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -183,6 +185,7 @@ mod tests {
                 focused_pane: 0,
                 zoomed: None,
                 panes,
+                color: None,
             }],
             active_workspace_idx: 0,
             next_pane_id: 1,


### PR DESCRIPTION
## Summary
- **PR 10a**: Extract sidebar to own module, match cmux styling (colors, layout, fonts, row rendering)
- **PR 10b**: Notification previews in sidebar rows, improved notification panel
- **PR 10c**: Hover close button, context menu (rename/close/mark read), Cmd+1-9 shortcuts, in-place rename
- **PR 10d**: Drag reorder (workspaces + tabs), workspace colors, progress bars, font config, system font fallbacks, Cmd+K fix

## Bug fixes included
- Drop indicator positioning using actual row rects
- Close icon rendered with line segments (not Unicode)
- Panic on tab drag to end (index clamp)
- Tab names persist through reorder (use surface ID)
- Braille/spinner characters render via system font fallbacks
- Cmd+K clear scrollback: clear screen + erase scrollback + redraw prompt

## Test plan
- [ ] Sidebar renders with cmux-style colors, layout, and fonts
- [ ] Workspace switching via click and Cmd+1-9
- [ ] Hover shows close button, right-click shows context menu
- [ ] Rename workspace via context menu
- [ ] Drag reorder workspaces in sidebar and tabs in tab bar
- [ ] Workspace colors set via context menu, persist across sessions
- [ ] Notification previews appear in sidebar rows
- [ ] Cmd+K clears scrollback and redraws prompt
- [ ] Font size configurable via config.toml
- [ ] `cargo build --no-default-features` (soft renderer fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable font size via user config
  * Workspace colors with persistence
  * Drag-and-drop workspace and in-pane tab reordering
  * Workspace progress indicators and grouped notifications

* **Improvements**
  * Refreshed sidebar with rename, create, close, color, and drag interactions
  * Notification panel shows workspace headers, icons, and improved unread styling
  * Clear-scrollback now forces shell redraw; clipboard paste and last-workspace shortcut added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->