### PR TITLE
Phase 11: Rich workspace metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "amux-session",
  "anyhow",
  "clap",
+ "dirs",
  "serde_json",
  "tokio",
 ]

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -531,6 +531,104 @@ fn default_shell() -> String {
     }
 }
 
+/// Write shell integration files to ~/.config/amux/shell/ and set env vars to
+/// auto-inject them. For zsh: ZDOTDIR override. For bash: PROMPT_COMMAND bootstrap.
+/// Matching cmux's approach — no user dotfile modification required.
+fn inject_shell_integration(shell: &str, cmd: &mut CommandBuilder) {
+    let shell_name = std::path::Path::new(shell)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("");
+
+    let Some(integration_dir) = ensure_shell_integration_dir() else {
+        return;
+    };
+
+    cmd.env(
+        "AMUX_SHELL_INTEGRATION_DIR",
+        integration_dir.to_string_lossy().as_ref(),
+    );
+
+    match shell_name {
+        "zsh" => {
+            let zsh_dir = integration_dir.join("zsh");
+            // Save user's original ZDOTDIR (if set) so bootstrap can restore it
+            if let Ok(original) = std::env::var("ZDOTDIR") {
+                cmd.env("AMUX_ZSH_ZDOTDIR", &original);
+            }
+            cmd.env("ZDOTDIR", zsh_dir.to_string_lossy().as_ref());
+        }
+        "bash" => {
+            // Bootstrap integration via PROMPT_COMMAND on first interactive prompt.
+            // This runs once, then restores any original PROMPT_COMMAND.
+            let bash_script = integration_dir.join("amux-bash-integration.bash");
+            let bootstrap = format!(
+                concat!(
+                    "unset PROMPT_COMMAND; ",
+                    "if [[ -r \"{}\" ]]; then source \"{}\"; fi",
+                ),
+                bash_script.display(),
+                bash_script.display(),
+            );
+            cmd.env("PROMPT_COMMAND", &bootstrap);
+        }
+        _ => {}
+    }
+}
+
+/// Ensure shell integration scripts are written to ~/.config/amux/shell/.
+/// Returns the directory path, or None on failure.
+fn ensure_shell_integration_dir() -> Option<std::path::PathBuf> {
+    let config_dir = dirs::config_dir()?.join("amux").join("shell");
+
+    // Write zsh bootstrap files
+    let zsh_dir = config_dir.join("zsh");
+    if std::fs::create_dir_all(&zsh_dir).is_err() {
+        return None;
+    }
+
+    // Embed integration scripts at compile time
+    let files: &[(&str, &str)] = &[
+        (
+            "zsh/.zshenv",
+            include_str!("../../../resources/shell-integration/zsh/.zshenv"),
+        ),
+        (
+            "zsh/.zprofile",
+            include_str!("../../../resources/shell-integration/zsh/.zprofile"),
+        ),
+        (
+            "zsh/.zshrc",
+            include_str!("../../../resources/shell-integration/zsh/.zshrc"),
+        ),
+        (
+            "zsh/.zlogin",
+            include_str!("../../../resources/shell-integration/zsh/.zlogin"),
+        ),
+        (
+            "amux-zsh-integration.zsh",
+            include_str!("../../../resources/shell-integration/amux-zsh-integration.zsh"),
+        ),
+        (
+            "amux-bash-integration.bash",
+            include_str!("../../../resources/shell-integration/amux-bash-integration.bash"),
+        ),
+    ];
+
+    for (name, content) in files {
+        let path = config_dir.join(name);
+        // Only write if content changed (avoid unnecessary disk writes)
+        let needs_write = std::fs::read_to_string(&path)
+            .map(|existing| existing != *content)
+            .unwrap_or(true);
+        if needs_write && std::fs::write(&path, content).is_err() {
+            return None;
+        }
+    }
+
+    Some(config_dir)
+}
+
 fn cleanup_addr(addr: &amux_ipc::IpcAddr) {
     match addr {
         #[cfg(unix)]
@@ -554,6 +652,8 @@ pub(crate) struct SurfaceMetadata {
     pub(crate) pr_number: Option<u32>,
     pub(crate) pr_title: Option<String>,
     pub(crate) pr_state: Option<String>, // "open", "merged", "closed"
+    /// Surface title from OSC 0/2 (window title set by shell/agent).
+    pub(crate) surface_title: Option<String>,
 }
 
 /// A terminal tab within a pane. Each pane can have multiple surfaces.
@@ -716,6 +816,20 @@ fn spawn_surface(
     cmd.env("AMUX_WORKSPACE_ID", workspace_id.to_string());
     cmd.env("AMUX_SURFACE_ID", surface_id.to_string());
     cmd.env("TERM", "xterm-256color");
+
+    // Point AMUX_BIN to the CLI binary so shell integration scripts can invoke it
+    // without relying on PATH (macOS path_helper in /etc/zprofile rebuilds PATH).
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(exe_dir) = exe.parent() {
+            let cli_bin = exe_dir.join("amux");
+            if cli_bin.exists() {
+                cmd.env("AMUX_BIN", cli_bin.to_string_lossy().as_ref());
+            }
+        }
+    }
+
+    // Auto-inject shell integration (matching cmux's ZDOTDIR/PROMPT_COMMAND approach)
+    inject_shell_integration(&shell, &mut cmd);
 
     let actual_cwd = if let Some(dir) = cwd {
         let path = std::path::Path::new(dir);
@@ -2455,7 +2569,16 @@ impl AmuxApp {
     fn workspace_metadata(&self, workspace: &Workspace) -> SurfaceMetadata {
         self.panes
             .get(&workspace.focused_pane)
-            .map(|mp| mp.active_surface().metadata.clone())
+            .map(|mp| {
+                let sf = mp.active_surface();
+                let mut meta = sf.metadata.clone();
+                // Capture the surface's OSC title for sidebar display
+                let title = sf.pane.title();
+                if !title.is_empty() {
+                    meta.surface_title = Some(title.to_string());
+                }
+                meta
+            })
             .unwrap_or_default()
     }
 

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1102,12 +1102,19 @@ impl eframe::App for AmuxApp {
 
         // Render sidebar
         if self.sidebar.visible {
+            // Build workspace metadata map for sidebar display
+            let workspace_metadata: std::collections::HashMap<u64, SurfaceMetadata> = self
+                .workspaces
+                .iter()
+                .map(|ws| (ws.id, self.workspace_metadata(ws)))
+                .collect();
             let sidebar_actions = sidebar::render_sidebar(
                 ctx,
                 &mut self.sidebar,
                 &self.workspaces,
                 self.active_workspace_idx,
                 &self.notifications,
+                &workspace_metadata,
             );
             for action in sidebar_actions {
                 match action {
@@ -2438,8 +2445,6 @@ impl AmuxApp {
     }
 
     /// Aggregate metadata from the focused surface of the focused pane in a workspace.
-    /// Used by sidebar rendering in PR 11d.
-    #[allow(dead_code)]
     fn workspace_metadata(&self, workspace: &Workspace) -> SurfaceMetadata {
         self.panes
             .get(&workspace.focused_pane)

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -465,44 +465,30 @@ fn restore_session(
         drag: None,
     };
 
-    // Restore notifications (without Instant-dependent fields)
+    // Restore only already-read notifications (unread ones are stale — the
+    // agent that created them is gone after restart).
     let mut store = NotificationStore::new();
     for saved_n in &session.notifications {
+        if !saved_n.read {
+            continue;
+        }
         let source = match saved_n.source.as_str() {
             "toast" => NotificationSource::Toast,
             "bell" => NotificationSource::Bell,
             _ => NotificationSource::Cli,
         };
-        if saved_n.read {
-            store.push_read(
-                saved_n.workspace_id,
-                saved_n.pane_id,
-                saved_n.surface_id,
-                saved_n.title.clone(),
-                saved_n.body.clone(),
-                source,
-            );
-        } else {
-            store.push(
-                saved_n.workspace_id,
-                saved_n.pane_id,
-                saved_n.surface_id,
-                saved_n.title.clone(),
-                saved_n.body.clone(),
-                source,
-            );
-        }
+        store.push_read(
+            saved_n.workspace_id,
+            saved_n.pane_id,
+            saved_n.surface_id,
+            saved_n.title.clone(),
+            saved_n.body.clone(),
+            source,
+        );
     }
 
-    // Restore workspace statuses
-    for (ws_id, saved_status) in &session.workspace_statuses {
-        let state = match saved_status.state.as_str() {
-            "active" => amux_notify::AgentState::Active,
-            "waiting" => amux_notify::AgentState::Waiting,
-            _ => amux_notify::AgentState::Idle,
-        };
-        store.set_status(*ws_id, state, saved_status.label.clone(), None, None);
-    }
+    // Don't restore workspace statuses — agent processes don't survive restart,
+    // so any Active/Waiting state would be stale. They start as Idle implicitly.
 
     let active_idx = session
         .active_workspace_idx
@@ -629,6 +615,38 @@ fn ensure_shell_integration_dir() -> Option<std::path::PathBuf> {
     Some(config_dir)
 }
 
+/// Ensure the claude wrapper script is written to ~/.config/amux/bin/claude.
+/// Returns the bin directory path, or None on failure.
+fn ensure_claude_wrapper_dir() -> Option<std::path::PathBuf> {
+    // Use ~/.config/amux/bin/ instead of dirs::config_dir() because on macOS
+    // that returns ~/Library/Application Support/ which has a space — spaces
+    // in PATH entries break many tools.
+    let bin_dir = dirs::home_dir()?.join(".config").join("amux").join("bin");
+    if std::fs::create_dir_all(&bin_dir).is_err() {
+        return None;
+    }
+
+    let wrapper_path = bin_dir.join("claude");
+    let wrapper_content = include_str!("../../../resources/bin/claude");
+
+    let needs_write = std::fs::read_to_string(&wrapper_path)
+        .map(|existing| existing != wrapper_content)
+        .unwrap_or(true);
+
+    if needs_write {
+        if std::fs::write(&wrapper_path, wrapper_content).is_err() {
+            return None;
+        }
+        // Make executable (unix)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755));
+        }
+    }
+
+    Some(bin_dir)
+}
 fn cleanup_addr(addr: &amux_ipc::IpcAddr) {
     match addr {
         #[cfg(unix)]
@@ -825,6 +843,17 @@ fn spawn_surface(
             if cli_bin.exists() {
                 cmd.env("AMUX_BIN", cli_bin.to_string_lossy().as_ref());
             }
+        }
+    }
+
+    // Prepend amux bin dir (containing claude wrapper) to PATH so hooks are
+    // injected at runtime via --settings, scoped to amux sessions only.
+    if let Some(bin_dir) = ensure_claude_wrapper_dir() {
+        let current_path = std::env::var("PATH").unwrap_or_default();
+        let bin_str = bin_dir.to_string_lossy();
+        if !current_path.split(':').any(|d| d == bin_str.as_ref()) {
+            let sep = if current_path.is_empty() { "" } else { ":" };
+            cmd.env("PATH", format!("{bin_str}{sep}{current_path}"));
         }
     }
 
@@ -1241,6 +1270,11 @@ impl eframe::App for AmuxApp {
                 match action {
                     sidebar::SidebarAction::SwitchWorkspace(idx) => {
                         self.active_workspace_idx = idx;
+                        // Mark notifications read when switching to a workspace
+                        if idx < self.workspaces.len() {
+                            let pane_ids: Vec<u64> = self.workspaces[idx].tree.iter_panes();
+                            self.notifications.mark_workspace_read(&pane_ids);
+                        }
                     }
                     sidebar::SidebarAction::CreateWorkspace => {
                         self.create_workspace(None);

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -501,7 +501,13 @@ fn restore_session(
             "waiting" => amux_notify::AgentState::Waiting,
             _ => amux_notify::AgentState::Idle,
         };
-        store.set_status(*ws_id, state, saved_status.label.clone(), None, None);
+        store.set_status(
+            *ws_id,
+            state,
+            saved_status.label.clone(),
+            saved_status.task.clone(),
+            saved_status.message.clone(),
+        );
     }
 
     let active_idx = session
@@ -717,17 +723,23 @@ fn spawn_surface(
     cmd.env("AMUX_SURFACE_ID", surface_id.to_string());
     cmd.env("TERM", "xterm-256color");
 
-    if let Some(dir) = cwd {
+    let actual_cwd = if let Some(dir) = cwd {
         let path = std::path::Path::new(dir);
         if path.is_dir() {
             cmd.cwd(path);
+            Some(dir.to_string())
         } else {
             tracing::warn!("Saved working dir no longer exists: {}", dir);
             if let Some(home) = dirs::home_dir() {
-                cmd.cwd(home);
+                cmd.cwd(&home);
+                Some(home.to_string_lossy().to_string())
+            } else {
+                None
             }
         }
-    }
+    } else {
+        None
+    };
 
     let mut pane = TerminalPane::spawn(cols, rows, cmd, config.clone())?;
 
@@ -763,9 +775,9 @@ fn spawn_surface(
         }
     });
 
-    // Initialize metadata with CWD if provided (e.g. from session restore)
+    // Initialize metadata with the actual CWD used (may differ from saved if dir was removed)
     let metadata = SurfaceMetadata {
-        cwd: cwd.map(|s| s.to_string()),
+        cwd: actual_cwd,
         ..Default::default()
     };
 
@@ -3591,7 +3603,7 @@ impl AmuxApp {
                         let surface = self.resolve_surface_mut(&params.surface_id);
                         match surface {
                             Some(sf) => {
-                                sf.metadata.cwd = Some(params.cwd);
+                                sf.metadata.cwd = params.cwd.filter(|s| !s.is_empty());
                                 Response::ok(req.id.clone(), serde_json::json!({}))
                             }
                             None => Response::err(req.id.clone(), "not_found", "surface not found"),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -501,13 +501,7 @@ fn restore_session(
             "waiting" => amux_notify::AgentState::Waiting,
             _ => amux_notify::AgentState::Idle,
         };
-        store.set_status(
-            *ws_id,
-            state,
-            saved_status.label.clone(),
-            saved_status.task.clone(),
-            saved_status.message.clone(),
-        );
+        store.set_status(*ws_id, state, saved_status.label.clone(), None, None);
     }
 
     let active_idx = session
@@ -914,15 +908,15 @@ impl AmuxApp {
                         .surfaces
                         .iter()
                         .map(|sf| {
-                            let working_dir = sf
-                                .pane
-                                .working_dir()
-                                .and_then(|url| url.to_file_path().ok())
-                                .map(|p| p.to_string_lossy().to_string())
-                                .or_else(|| {
-                                    // Fallback: query the child process's cwd via OS APIs
-                                    sf.pane.child_pid().and_then(get_cwd_from_pid)
-                                });
+                            // Prefer shell-reported CWD (metadata.cwd from set-cwd/OSC 7),
+                            // then fall back to pane.working_dir() and OS-level queries.
+                            let working_dir = sf.metadata.cwd.clone().or_else(|| {
+                                sf.pane
+                                    .working_dir()
+                                    .and_then(|url| url.to_file_path().ok())
+                                    .map(|p| p.to_string_lossy().to_string())
+                                    .or_else(|| sf.pane.child_pid().and_then(get_cwd_from_pid))
+                            });
                             let scrollback = sf.pane.read_scrollback_text(4096);
                             let (cols, rows) = sf.pane.dimensions();
                             amux_session::SavedSurface {
@@ -996,8 +990,9 @@ impl AmuxApp {
                                 }
                                 .to_string(),
                                 label: status.label.clone(),
-                                task: status.task.clone(),
-                                message: status.message.clone(),
+                                // task/message are transient agent state — don't persist
+                                task: None,
+                                message: None,
                             },
                         )
                     })

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -501,7 +501,7 @@ fn restore_session(
             "waiting" => amux_notify::AgentState::Waiting,
             _ => amux_notify::AgentState::Idle,
         };
-        store.set_status(*ws_id, state, saved_status.label.clone());
+        store.set_status(*ws_id, state, saved_status.label.clone(), None, None);
     }
 
     let active_idx = session
@@ -984,6 +984,8 @@ impl AmuxApp {
                                 }
                                 .to_string(),
                                 label: status.label.clone(),
+                                task: status.task.clone(),
+                                message: status.message.clone(),
                             },
                         )
                     })
@@ -3577,6 +3579,56 @@ impl AmuxApp {
                 }
                 Response::ok(req.id.clone(), serde_json::json!({"surfaces": surfaces}))
             }
+            "surface.set_cwd" => {
+                match serde_json::from_value::<amux_ipc::methods::SetCwdParams>(req.params.clone())
+                {
+                    Ok(params) => {
+                        let surface = self.resolve_surface_mut(&params.surface_id);
+                        match surface {
+                            Some(sf) => {
+                                sf.metadata.cwd = Some(params.cwd);
+                                Response::ok(req.id.clone(), serde_json::json!({}))
+                            }
+                            None => Response::err(req.id.clone(), "not_found", "surface not found"),
+                        }
+                    }
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
+            "surface.set_git" => {
+                match serde_json::from_value::<amux_ipc::methods::SetGitParams>(req.params.clone())
+                {
+                    Ok(params) => {
+                        let surface = self.resolve_surface_mut(&params.surface_id);
+                        match surface {
+                            Some(sf) => {
+                                sf.metadata.git_branch = params.branch;
+                                sf.metadata.git_dirty = params.dirty;
+                                Response::ok(req.id.clone(), serde_json::json!({}))
+                            }
+                            None => Response::err(req.id.clone(), "not_found", "surface not found"),
+                        }
+                    }
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
+            "surface.set_pr" => {
+                match serde_json::from_value::<amux_ipc::methods::SetPrParams>(req.params.clone()) {
+                    Ok(params) => {
+                        let surface = self.resolve_surface_mut(&params.surface_id);
+                        match surface {
+                            Some(sf) => {
+                                sf.metadata.pr_number = params.number;
+                                sf.metadata.pr_title = params.title;
+                                sf.metadata.pr_state = params.state;
+                                Response::ok(req.id.clone(), serde_json::json!({}))
+                            }
+                            None => Response::err(req.id.clone(), "not_found", "surface not found"),
+                        }
+                    }
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
             "surface.send_text" => {
                 match serde_json::from_value::<amux_ipc::methods::SendTextParams>(
                     req.params.clone(),
@@ -3998,7 +4050,13 @@ impl AmuxApp {
                             "waiting" => amux_notify::AgentState::Waiting,
                             _ => amux_notify::AgentState::Idle,
                         };
-                        self.notifications.set_status(ws_id, state, params.label);
+                        self.notifications.set_status(
+                            ws_id,
+                            state,
+                            params.label,
+                            params.task,
+                            params.message,
+                        );
                         Response::ok(req.id.clone(), serde_json::json!({}))
                     }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -373,7 +373,15 @@ fn restore_session(
                     cwd,
                     scrollback,
                 ) {
-                    Ok(surface) => surfaces.push(surface),
+                    Ok(mut surface) => {
+                        // Restore git/PR metadata from session
+                        surface.metadata.git_branch = saved_sf.git_branch.clone();
+                        surface.metadata.git_dirty = saved_sf.git_dirty;
+                        surface.metadata.pr_number = saved_sf.pr_number;
+                        surface.metadata.pr_title = saved_sf.pr_title.clone();
+                        surface.metadata.pr_state = saved_sf.pr_state.clone();
+                        surfaces.push(surface);
+                    }
                     Err(e) => {
                         tracing::warn!(
                             "Failed to restore surface {} in pane {}: {}",
@@ -537,6 +545,17 @@ fn cleanup_addr(addr: &amux_ipc::IpcAddr) {
 // --- Data Model ---
 // Hierarchy: Workspace > PaneTree (splits) > Pane (each has tab bar) > Surface (terminal tab)
 
+/// Per-surface metadata reported by shell integration, agent hooks, or OSC sequences.
+#[derive(Default, Clone)]
+pub(crate) struct SurfaceMetadata {
+    pub(crate) cwd: Option<String>,
+    pub(crate) git_branch: Option<String>,
+    pub(crate) git_dirty: bool,
+    pub(crate) pr_number: Option<u32>,
+    pub(crate) pr_title: Option<String>,
+    pub(crate) pr_state: Option<String>, // "open", "merged", "closed"
+}
+
 /// A terminal tab within a pane. Each pane can have multiple surfaces.
 struct PaneSurface {
     id: u64,
@@ -544,6 +563,7 @@ struct PaneSurface {
     byte_rx: mpsc::Receiver<Vec<u8>>,
     scroll_offset: usize,
     scroll_accum: f32,
+    metadata: SurfaceMetadata,
 }
 
 /// A leaf in the split tree. Each pane has its own tab bar with surfaces.
@@ -743,12 +763,19 @@ fn spawn_surface(
         }
     });
 
+    // Initialize metadata with CWD if provided (e.g. from session restore)
+    let metadata = SurfaceMetadata {
+        cwd: cwd.map(|s| s.to_string()),
+        ..Default::default()
+    };
+
     Ok(PaneSurface {
         id: surface_id,
         pane,
         byte_rx,
         scroll_offset: 0,
         scroll_accum: 0.0,
+        metadata,
     })
 }
 
@@ -893,6 +920,11 @@ impl AmuxApp {
                                 scrollback,
                                 cols: cols as u16,
                                 rows: rows as u16,
+                                git_branch: sf.metadata.git_branch.clone(),
+                                git_dirty: sf.metadata.git_dirty,
+                                pr_number: sf.metadata.pr_number,
+                                pr_title: sf.metadata.pr_title.clone(),
+                                pr_state: sf.metadata.pr_state.clone(),
                             }
                         })
                         .collect();
@@ -2362,8 +2394,25 @@ impl AmuxApp {
                 NotificationEvent::Bell => {
                     (String::new(), "Bell".to_string(), NotificationSource::Bell)
                 }
-                // Title and directory changes are not user-facing notifications
-                NotificationEvent::TitleChanged(_) | NotificationEvent::WorkingDirectoryChanged => {
+                NotificationEvent::TitleChanged(_) => {
+                    continue;
+                }
+                NotificationEvent::WorkingDirectoryChanged => {
+                    // Store the CWD from OSC 7 into surface metadata
+                    if let Some(managed) = self.panes.get_mut(&pane_id) {
+                        for surface in &mut managed.surfaces {
+                            if surface.id == surface_id {
+                                let cwd = surface
+                                    .pane
+                                    .working_dir()
+                                    .and_then(|url| url.to_file_path().ok())
+                                    .map(|p| p.to_string_lossy().to_string());
+                                if cwd.is_some() {
+                                    surface.metadata.cwd = cwd;
+                                }
+                            }
+                        }
+                    }
                     continue;
                 }
             };
@@ -2384,6 +2433,16 @@ impl AmuxApp {
             .iter()
             .find(|ws| ws.tree.iter_panes().contains(&pane_id))
             .map(|ws| ws.id)
+    }
+
+    /// Aggregate metadata from the focused surface of the focused pane in a workspace.
+    /// Used by sidebar rendering in PR 11d.
+    #[allow(dead_code)]
+    fn workspace_metadata(&self, workspace: &Workspace) -> SurfaceMetadata {
+        self.panes
+            .get(&workspace.focused_pane)
+            .map(|mp| mp.active_surface().metadata.clone())
+            .unwrap_or_default()
     }
 
     fn jump_to_latest_unread(&mut self) {

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -17,9 +17,6 @@ const TEXT_ACTIVE: Color32 = Color32::WHITE;
 const TEXT_INACTIVE: Color32 = Color32::from_gray(180);
 const TEXT_SECONDARY: Color32 = Color32::from_gray(140);
 const BADGE_ACTIVE_BG: Color32 = Color32::from_rgba_premultiplied(64, 64, 64, 64);
-const STATUS_GREEN: Color32 = Color32::from_rgb(50, 180, 80);
-const STATUS_ORANGE: Color32 = Color32::from_rgb(230, 170, 40);
-const STATUS_GRAY: Color32 = Color32::from_gray(100);
 const NEW_BTN_TEXT: Color32 = Color32::from_gray(140);
 const NEW_BTN_HOVER: Color32 = Color32::from_rgba_premultiplied(15, 15, 15, 15);
 const CLOSE_BTN_COLOR: Color32 = Color32::from_rgba_premultiplied(140, 140, 140, 179);
@@ -39,9 +36,6 @@ const ROW_CORNER_RADIUS: f32 = 6.0;
 const TITLE_FONT_SIZE: f32 = 12.5;
 const BADGE_RADIUS: f32 = 8.0;
 const BADGE_FONT_SIZE: f32 = 9.0;
-const PILL_FONT_SIZE: f32 = 9.0;
-const PILL_HEIGHT: f32 = 14.0;
-const PILL_CORNER_RADIUS: f32 = 7.0;
 const COUNT_FONT_SIZE: f32 = 10.0;
 const NOTIF_FONT_SIZE: f32 = 10.0;
 const NOTIF_PREVIEW_HEIGHT: f32 = 24.0;
@@ -51,9 +45,6 @@ const PROGRESS_BAR_HEIGHT: f32 = 3.0;
 const DROP_INDICATOR_HEIGHT: f32 = 2.0;
 const METADATA_FONT_SIZE: f32 = 10.0;
 const METADATA_LINE_HEIGHT: f32 = 16.0;
-const PR_MERGED_COLOR: Color32 = Color32::from_rgb(130, 80, 223); // purple for merged
-const PR_OPEN_COLOR: Color32 = Color32::from_rgb(0, 145, 255);
-const PR_CLOSED_COLOR: Color32 = Color32::from_gray(100);
 #[cfg(target_os = "macos")]
 const TRAFFIC_LIGHT_SPACER: f32 = 28.0;
 
@@ -324,7 +315,7 @@ fn render_workspace_row(
         row_h += METADATA_LINE_HEIGHT + 2.0;
     }
     if has_status {
-        row_h += PILL_HEIGHT + 4.0;
+        row_h += METADATA_LINE_HEIGHT + 4.0;
     }
     if has_git_or_cwd {
         row_h += METADATA_LINE_HEIGHT + 2.0;
@@ -489,9 +480,12 @@ fn render_workspace_row(
     } else {
         let title_pos = rect.min + egui::vec2(content_left, ROW_V_PAD);
         let title_font = egui::FontId::proportional(TITLE_FONT_SIZE);
-        // Show agent task as title if available, with star prefix like cmux
+        // Show agent task as title if available, with star prefix like cmux.
+        // Fall back to surface title (OSC 0/2), then workspace title.
         let display_title = if let Some(task) = status.as_ref().and_then(|s| s.task.as_ref()) {
             format!("\u{2731} {task}")
+        } else if let Some(st) = metadata.and_then(|m| m.surface_title.as_ref()) {
+            st.clone()
         } else {
             ws.title.clone()
         };
@@ -555,47 +549,44 @@ fn render_workspace_row(
         );
     }
 
-    // --- Status pill ---
+    // --- Status indicator (icon + text, matching cmux) ---
     let mut content_bottom = rect.min.y + ROW_V_PAD + title_line_h;
+
+    // Metadata text color: light grey
+    let meta_color = Color32::from_gray(190);
+    // Status indicator color: blue when unselected, white when selected
+    let status_color = if is_active {
+        Color32::WHITE
+    } else {
+        ACCENT_BLUE
+    };
+
     if let Some(status) = &status {
-        let (pill_color, default_text) = match status.state {
-            amux_notify::AgentState::Active => (STATUS_GREEN, "active"),
-            amux_notify::AgentState::Waiting => (STATUS_ORANGE, "waiting"),
-            amux_notify::AgentState::Idle => (STATUS_GRAY, "idle"),
+        let (icon, default_text) = match status.state {
+            amux_notify::AgentState::Active => ("\u{26A1}", "Running"), // ⚡
+            amux_notify::AgentState::Waiting => ("\u{1F514}", "Needs input"), // 🔔
+            amux_notify::AgentState::Idle => ("\u{23F8}\u{FE0E}", "Idle"), // ⏸︎
         };
         let label = status.label.as_deref().unwrap_or(default_text);
         content_bottom += 4.0;
-        let pill_y = content_bottom;
-        let pill_x = rect.min.x + content_left;
-
-        let pill_font = egui::FontId::proportional(PILL_FONT_SIZE);
-        let text_galley =
-            ui.painter()
-                .layout_no_wrap(label.to_string(), pill_font.clone(), Color32::WHITE);
-        let text_w = text_galley.size().x;
-        let pill_w = (text_w + 10.0).min(avail_w - content_left - ROW_H_PAD);
-
-        let pill_rect =
-            egui::Rect::from_min_size(egui::pos2(pill_x, pill_y), egui::vec2(pill_w, PILL_HEIGHT));
-        ui.painter()
-            .rect_filled(pill_rect, PILL_CORNER_RADIUS, pill_color);
+        let status_x = rect.min.x + content_left;
+        let max_w = avail_w - content_left - ROW_H_PAD;
+        let status_font = egui::FontId::proportional(METADATA_FONT_SIZE);
+        let status_text = format!("{icon} {label}");
+        let truncated = truncate_text(ui, &status_text, &status_font, max_w);
         ui.painter().text(
-            pill_rect.center(),
-            egui::Align2::CENTER_CENTER,
-            label,
-            pill_font,
-            Color32::WHITE,
+            egui::pos2(status_x, content_bottom),
+            egui::Align2::LEFT_TOP,
+            &truncated,
+            status_font,
+            status_color,
         );
-        content_bottom += PILL_HEIGHT;
+        content_bottom += METADATA_LINE_HEIGHT;
     }
 
     // --- Agent message (subtitle) ---
     if let Some(message) = status.as_ref().and_then(|s| s.message.as_ref()) {
-        let msg_color = if is_active {
-            Color32::from_rgba_premultiplied(204, 204, 204, 204)
-        } else {
-            TEXT_SECONDARY
-        };
+        let msg_color = meta_color;
         content_bottom += 2.0;
         let msg_x = rect.min.x + content_left;
         let max_w = avail_w - content_left - ROW_H_PAD;
@@ -618,11 +609,7 @@ fn render_workspace_row(
     // --- Git branch + CWD line ---
     if let Some(meta) = metadata {
         if meta.git_branch.is_some() || meta.cwd.is_some() {
-            let line_color = if is_active {
-                Color32::from_rgba_premultiplied(180, 180, 180, 204)
-            } else {
-                TEXT_SECONDARY
-            };
+            let line_color = meta_color;
             content_bottom += 2.0;
             let line_x = rect.min.x + content_left;
             let max_w = avail_w - content_left - ROW_H_PAD;
@@ -652,11 +639,7 @@ fn render_workspace_row(
         // --- PR badge ---
         if let Some(pr_num) = meta.pr_number {
             let pr_state = meta.pr_state.as_deref().unwrap_or("open");
-            let pr_color = match pr_state {
-                "merged" => PR_MERGED_COLOR,
-                "open" => PR_OPEN_COLOR,
-                _ => PR_CLOSED_COLOR,
-            };
+            let pr_color = meta_color;
             content_bottom += 2.0;
             let pr_x = rect.min.x + content_left;
             let max_w = avail_w - content_left - ROW_H_PAD;
@@ -679,11 +662,7 @@ fn render_workspace_row(
         .filter(|_| !has_agent_message)
         .filter(|n| !n.body.is_empty())
     {
-        let notif_color = if is_active {
-            Color32::from_rgba_premultiplied(204, 204, 204, 204)
-        } else {
-            TEXT_SECONDARY
-        };
+        let notif_color = meta_color;
         content_bottom += 2.0;
         let notif_x = rect.min.x + content_left;
         let max_w = avail_w - content_left - ROW_H_PAD;

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -785,9 +785,14 @@ fn truncate_text(ui: &egui::Ui, text: &str, font: &egui::FontId, max_width: f32)
 /// Shorten a path for sidebar display: replace $HOME with ~.
 fn shorten_path(path: &str) -> String {
     if let Some(home) = dirs::home_dir() {
-        let home_str = home.to_string_lossy();
-        if let Some(rest) = path.strip_prefix(home_str.as_ref()) {
-            return format!("~{rest}");
+        let p = std::path::Path::new(path);
+        if let Ok(rest) = p.strip_prefix(&home) {
+            let rest_str = rest.to_string_lossy();
+            return if rest_str.is_empty() {
+                "~".to_string()
+            } else {
+                format!("~/{rest_str}")
+            };
         }
     }
     path.to_string()

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
+
 use amux_notify::NotificationStore;
 use egui::Color32;
 
-use crate::{SidebarDragState, SidebarState, Workspace};
+use crate::{SidebarDragState, SidebarState, SurfaceMetadata, Workspace};
 
 // ---------------------------------------------------------------------------
 // Colors (cmux dark mode equivalents)
@@ -47,6 +49,11 @@ const CLOSE_BTN_SIZE: f32 = 16.0;
 const COLOR_CAPSULE_WIDTH: f32 = 3.0;
 const PROGRESS_BAR_HEIGHT: f32 = 3.0;
 const DROP_INDICATOR_HEIGHT: f32 = 2.0;
+const METADATA_FONT_SIZE: f32 = 10.0;
+const METADATA_LINE_HEIGHT: f32 = 16.0;
+const PR_MERGED_COLOR: Color32 = Color32::from_rgb(130, 80, 223); // purple for merged
+const PR_OPEN_COLOR: Color32 = Color32::from_rgb(0, 145, 255);
+const PR_CLOSED_COLOR: Color32 = Color32::from_gray(100);
 #[cfg(target_os = "macos")]
 const TRAFFIC_LIGHT_SPACER: f32 = 28.0;
 
@@ -115,6 +122,7 @@ pub(crate) fn render_sidebar(
     workspaces: &[Workspace],
     active_workspace_idx: usize,
     notifications: &NotificationStore,
+    workspace_metadata: &HashMap<u64, SurfaceMetadata>,
 ) -> Vec<SidebarAction> {
     let mut actions = Vec::new();
 
@@ -149,6 +157,7 @@ pub(crate) fn render_sidebar(
                         let is_active = idx == active_workspace_idx;
                         let is_being_dragged =
                             state.drag.as_ref().is_some_and(|d| d.source_idx == idx);
+                        let meta = workspace_metadata.get(&ws.id);
                         let (row_actions, row_rect) = render_workspace_row(
                             ui,
                             ws,
@@ -157,6 +166,7 @@ pub(crate) fn render_sidebar(
                             is_being_dragged,
                             notifications,
                             state,
+                            meta,
                         );
                         actions.extend(row_actions);
                         row_rects.push(row_rect);
@@ -282,6 +292,7 @@ fn handle_drag_reorder(
 }
 
 /// Renders a workspace row. Returns (actions, allocated_rect).
+#[allow(clippy::too_many_arguments)]
 fn render_workspace_row(
     ui: &mut egui::Ui,
     ws: &Workspace,
@@ -290,6 +301,7 @@ fn render_workspace_row(
     is_being_dragged: bool,
     notifications: &NotificationStore,
     state: &mut SidebarState,
+    metadata: Option<&SurfaceMetadata>,
 ) -> (Vec<SidebarAction>, egui::Rect) {
     let mut actions = Vec::new();
     let pane_ids: Vec<u64> = ws.tree.iter_panes();
@@ -297,16 +309,28 @@ fn render_workspace_row(
     let status = notifications.workspace_status(ws.id);
     let has_status = status.is_some();
     let has_progress = status.as_ref().and_then(|s| s.progress).is_some();
+    let has_agent_message = status.as_ref().and_then(|s| s.message.as_ref()).is_some();
     let latest_notif = notifications.latest_for_workspace(ws.id);
-    let has_notif_text = latest_notif.is_some_and(|n| !n.body.is_empty());
+    let has_notif_text = !has_agent_message && latest_notif.is_some_and(|n| !n.body.is_empty());
     let is_renaming = state.renaming == Some(idx);
     let has_color = ws.color.is_some();
+    let has_git_or_cwd = metadata.is_some_and(|m| m.git_branch.is_some() || m.cwd.is_some());
+    let has_pr = metadata.is_some_and(|m| m.pr_number.is_some());
 
     // Dynamic row height
     let title_line_h = TITLE_FONT_SIZE + 2.0;
     let mut row_h = ROW_V_PAD * 2.0 + title_line_h;
+    if has_agent_message {
+        row_h += METADATA_LINE_HEIGHT + 2.0;
+    }
     if has_status {
         row_h += PILL_HEIGHT + 4.0;
+    }
+    if has_git_or_cwd {
+        row_h += METADATA_LINE_HEIGHT + 2.0;
+    }
+    if has_pr {
+        row_h += METADATA_LINE_HEIGHT + 2.0;
     }
     if has_notif_text {
         row_h += NOTIF_PREVIEW_HEIGHT + 2.0;
@@ -465,7 +489,13 @@ fn render_workspace_row(
     } else {
         let title_pos = rect.min + egui::vec2(content_left, ROW_V_PAD);
         let title_font = egui::FontId::proportional(TITLE_FONT_SIZE);
-        let truncated_title = truncate_text(ui, &ws.title, &title_font, max_title_w);
+        // Show agent task as title if available, with star prefix like cmux
+        let display_title = if let Some(task) = status.as_ref().and_then(|s| s.task.as_ref()) {
+            format!("\u{2731} {task}")
+        } else {
+            ws.title.clone()
+        };
+        let truncated_title = truncate_text(ui, &display_title, &title_font, max_title_w);
         ui.painter().text(
             title_pos,
             egui::Align2::LEFT_TOP,
@@ -559,8 +589,96 @@ fn render_workspace_row(
         content_bottom += PILL_HEIGHT;
     }
 
-    // --- Notification preview text ---
-    if let Some(notif) = latest_notif.filter(|n| !n.body.is_empty()) {
+    // --- Agent message (subtitle) ---
+    if let Some(message) = status.as_ref().and_then(|s| s.message.as_ref()) {
+        let msg_color = if is_active {
+            Color32::from_rgba_premultiplied(204, 204, 204, 204)
+        } else {
+            TEXT_SECONDARY
+        };
+        content_bottom += 2.0;
+        let msg_x = rect.min.x + content_left;
+        let max_w = avail_w - content_left - ROW_H_PAD;
+        let msg_font = egui::FontId::proportional(METADATA_FONT_SIZE);
+        let galley = ui
+            .painter()
+            .layout(message.clone(), msg_font, msg_color, max_w);
+        let clip_rect = egui::Rect::from_min_size(
+            egui::pos2(msg_x, content_bottom),
+            egui::vec2(max_w, METADATA_LINE_HEIGHT),
+        );
+        ui.painter().with_clip_rect(clip_rect).galley(
+            egui::pos2(msg_x, content_bottom),
+            galley,
+            msg_color,
+        );
+        content_bottom += METADATA_LINE_HEIGHT;
+    }
+
+    // --- Git branch + CWD line ---
+    if let Some(meta) = metadata {
+        if meta.git_branch.is_some() || meta.cwd.is_some() {
+            let line_color = if is_active {
+                Color32::from_rgba_premultiplied(180, 180, 180, 204)
+            } else {
+                TEXT_SECONDARY
+            };
+            content_bottom += 2.0;
+            let line_x = rect.min.x + content_left;
+            let max_w = avail_w - content_left - ROW_H_PAD;
+            let line_font = egui::FontId::monospace(METADATA_FONT_SIZE);
+
+            let mut parts = Vec::new();
+            if let Some(branch) = &meta.git_branch {
+                let dirty = if meta.git_dirty { "*" } else { "" };
+                parts.push(format!("{branch}{dirty}"));
+            }
+            if let Some(cwd) = &meta.cwd {
+                parts.push(shorten_path(cwd));
+            }
+            let text = parts.join(" \u{2022} "); // bullet separator
+
+            let truncated = truncate_text(ui, &text, &line_font, max_w);
+            ui.painter().text(
+                egui::pos2(line_x, content_bottom),
+                egui::Align2::LEFT_TOP,
+                &truncated,
+                line_font,
+                line_color,
+            );
+            content_bottom += METADATA_LINE_HEIGHT;
+        }
+
+        // --- PR badge ---
+        if let Some(pr_num) = meta.pr_number {
+            let pr_state = meta.pr_state.as_deref().unwrap_or("open");
+            let pr_color = match pr_state {
+                "merged" => PR_MERGED_COLOR,
+                "open" => PR_OPEN_COLOR,
+                _ => PR_CLOSED_COLOR,
+            };
+            content_bottom += 2.0;
+            let pr_x = rect.min.x + content_left;
+            let max_w = avail_w - content_left - ROW_H_PAD;
+            let pr_font = egui::FontId::proportional(METADATA_FONT_SIZE);
+            let pr_text = format!("\u{1F517} PR #{pr_num} {pr_state}");
+            let truncated = truncate_text(ui, &pr_text, &pr_font, max_w);
+            ui.painter().text(
+                egui::pos2(pr_x, content_bottom),
+                egui::Align2::LEFT_TOP,
+                &truncated,
+                pr_font,
+                pr_color,
+            );
+            content_bottom += METADATA_LINE_HEIGHT;
+        }
+    }
+
+    // --- Notification preview text (only when no agent message) ---
+    if let Some(notif) = latest_notif
+        .filter(|_| !has_agent_message)
+        .filter(|n| !n.body.is_empty())
+    {
         let notif_color = if is_active {
             Color32::from_rgba_premultiplied(204, 204, 204, 204)
         } else {
@@ -662,4 +780,15 @@ fn truncate_text(ui: &egui::Ui, text: &str, font: &egui::FontId, max_width: f32)
 
     let prefix: String = chars[..lo].iter().collect();
     format!("{prefix}{ellipsis}")
+}
+
+/// Shorten a path for sidebar display: replace $HOME with ~.
+fn shorten_path(path: &str) -> String {
+    if let Some(home) = dirs::home_dir() {
+        let home_str = home.to_string_lossy();
+        if let Some(rest) = path.strip_prefix(home_str.as_ref()) {
+            return format!("~{rest}");
+        }
+    }
+    path.to_string()
 }

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -705,9 +705,13 @@ fn render_workspace_row(
         }
     }
 
-    // --- Click to switch workspace ---
-    if response.clicked() && !is_active && !is_renaming {
-        actions.push(SidebarAction::SwitchWorkspace(idx));
+    // --- Click to switch workspace or mark read ---
+    if response.clicked() && !is_renaming {
+        if is_active {
+            actions.push(SidebarAction::MarkWorkspaceRead(idx));
+        } else {
+            actions.push(SidebarAction::SwitchWorkspace(idx));
+        }
     }
 
     (actions, rect)

--- a/crates/amux-cli/Cargo.toml
+++ b/crates/amux-cli/Cargo.toml
@@ -16,3 +16,4 @@ clap = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
+dirs = { workspace = true }

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -106,6 +106,50 @@ enum Command {
         /// Surface ID to focus
         surface_id: String,
     },
+    /// Set the working directory for a surface
+    #[command(name = "set-cwd")]
+    SetCwd {
+        /// Working directory path
+        cwd: String,
+        /// Target surface ID (defaults to AMUX_SURFACE_ID)
+        #[arg(long)]
+        surface: Option<String>,
+    },
+    /// Set git branch info for a surface
+    #[command(name = "set-git")]
+    SetGit {
+        /// Branch name (omit to clear)
+        #[arg(long)]
+        branch: Option<String>,
+        /// Working tree has uncommitted changes
+        #[arg(long)]
+        dirty: bool,
+        /// Clear git info
+        #[arg(long)]
+        clear: bool,
+        /// Target surface ID (defaults to AMUX_SURFACE_ID)
+        #[arg(long)]
+        surface: Option<String>,
+    },
+    /// Set PR info for a surface
+    #[command(name = "set-pr")]
+    SetPr {
+        /// PR number
+        #[arg(long)]
+        number: Option<u32>,
+        /// PR title
+        #[arg(long)]
+        title: Option<String>,
+        /// PR state: open, merged, closed
+        #[arg(long)]
+        state: Option<String>,
+        /// Clear PR info
+        #[arg(long)]
+        clear: bool,
+        /// Target surface ID (defaults to AMUX_SURFACE_ID)
+        #[arg(long)]
+        surface: Option<String>,
+    },
     /// Set workspace agent status (displayed as a sidebar pill)
     #[command(name = "set-status")]
     SetStatus {
@@ -113,6 +157,12 @@ enum Command {
         state: String,
         /// Optional label text
         label: Option<String>,
+        /// Agent's current task description
+        #[arg(long)]
+        task: Option<String>,
+        /// Agent's latest message
+        #[arg(long)]
+        message: Option<String>,
         /// Target workspace ID (defaults to AMUX_WORKSPACE_ID)
         #[arg(long)]
         workspace: Option<String>,
@@ -440,10 +490,94 @@ async fn main() -> anyhow::Result<()> {
                 print_response(&resp, false);
             }
         }
+        // --- Metadata commands ---
+        Command::SetCwd { cwd, surface } => {
+            let surface_id = surface
+                .or_else(|| std::env::var("AMUX_SURFACE_ID").ok())
+                .unwrap_or_else(|| "default".to_string());
+            let resp = client
+                .call(
+                    "surface.set_cwd",
+                    serde_json::json!({
+                        "surface_id": surface_id,
+                        "cwd": cwd,
+                    }),
+                )
+                .await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                println!("CWD set");
+            } else {
+                print_response(&resp, false);
+            }
+        }
+        Command::SetGit {
+            branch,
+            dirty,
+            clear,
+            surface,
+        } => {
+            let surface_id = surface
+                .or_else(|| std::env::var("AMUX_SURFACE_ID").ok())
+                .unwrap_or_else(|| "default".to_string());
+            let params = if clear {
+                serde_json::json!({
+                    "surface_id": surface_id,
+                })
+            } else {
+                serde_json::json!({
+                    "surface_id": surface_id,
+                    "branch": branch,
+                    "dirty": dirty,
+                })
+            };
+            let resp = client.call("surface.set_git", params).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                println!("Git info set");
+            } else {
+                print_response(&resp, false);
+            }
+        }
+        Command::SetPr {
+            number,
+            title,
+            state,
+            clear,
+            surface,
+        } => {
+            let surface_id = surface
+                .or_else(|| std::env::var("AMUX_SURFACE_ID").ok())
+                .unwrap_or_else(|| "default".to_string());
+            let params = if clear {
+                serde_json::json!({
+                    "surface_id": surface_id,
+                })
+            } else {
+                serde_json::json!({
+                    "surface_id": surface_id,
+                    "number": number,
+                    "title": title,
+                    "state": state,
+                })
+            };
+            let resp = client.call("surface.set_pr", params).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                println!("PR info set");
+            } else {
+                print_response(&resp, false);
+            }
+        }
         // --- Notification / Status commands ---
         Command::SetStatus {
             state,
             label,
+            task,
+            message,
             workspace,
         } => {
             let ws_id = workspace
@@ -455,6 +589,12 @@ async fn main() -> anyhow::Result<()> {
             });
             if let Some(l) = label {
                 params["label"] = serde_json::json!(l);
+            }
+            if let Some(t) = task {
+                params["task"] = serde_json::json!(t);
+            }
+            if let Some(m) = message {
+                params["message"] = serde_json::json!(m);
             }
             let resp = client.call("status.set", params).await?;
             if cli.json {

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -109,8 +109,11 @@ enum Command {
     /// Set the working directory for a surface
     #[command(name = "set-cwd")]
     SetCwd {
-        /// Working directory path
-        cwd: String,
+        /// Working directory path (omit to clear)
+        cwd: Option<String>,
+        /// Clear CWD metadata
+        #[arg(long)]
+        clear: bool,
         /// Target surface ID (defaults to AMUX_SURFACE_ID)
         #[arg(long)]
         surface: Option<String>,
@@ -497,19 +500,20 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         // --- Metadata commands ---
-        Command::SetCwd { cwd, surface } => {
+        Command::SetCwd {
+            cwd,
+            clear,
+            surface,
+        } => {
             let surface_id = surface
                 .or_else(|| std::env::var("AMUX_SURFACE_ID").ok())
                 .unwrap_or_else(|| "default".to_string());
-            let resp = client
-                .call(
-                    "surface.set_cwd",
-                    serde_json::json!({
-                        "surface_id": surface_id,
-                        "cwd": cwd,
-                    }),
-                )
-                .await?;
+            let params = if clear {
+                serde_json::json!({ "surface_id": surface_id })
+            } else {
+                serde_json::json!({ "surface_id": surface_id, "cwd": cwd })
+            };
+            let resp = client.call("surface.set_cwd", params).await?;
             if cli.json {
                 print_response(&resp, true);
             } else if resp.ok {

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -1042,104 +1042,40 @@ fn describe_tool_use(tool_name: &str, tool_input: Option<&serde_json::Value>) ->
 // ---------------------------------------------------------------------------
 
 fn install_claude_hooks() -> anyhow::Result<()> {
-    let settings_path = dirs::home_dir()
-        .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
-        .join(".claude")
-        .join("settings.json");
-
-    let mut settings: serde_json::Value = if settings_path.exists() {
-        let content = std::fs::read_to_string(&settings_path)?;
-        serde_json::from_str(&content)?
-    } else {
-        std::fs::create_dir_all(settings_path.parent().unwrap())?;
-        serde_json::json!({})
-    };
-
-    // Build hook entries for each event
-    let amux_hook = |event: &str, timeout: u64| -> serde_json::Value {
-        serde_json::json!({
-            "matcher": "",
-            "hooks": [{
-                "type": "command",
-                "command": format!("\"${{AMUX_BIN:-amux}}\" claude-hook {event}"),
-                "timeout": timeout
-            }]
-        })
-    };
-
-    let hooks = serde_json::json!({
-        "UserPromptSubmit": [amux_hook("UserPromptSubmit", 5)],
-        "PreToolUse": [amux_hook("PreToolUse", 5)],
-        "Notification": [amux_hook("Notification", 5)],
-        "Stop": [amux_hook("Stop", 5)],
-        "SubagentStart": [amux_hook("SubagentStart", 5)],
-    });
-
-    // Merge with existing hooks (don't clobber non-amux hooks)
-    if let Some(existing_hooks) = settings.get_mut("hooks") {
-        if let Some(existing_obj) = existing_hooks.as_object_mut() {
-            for (event, hook_entries) in hooks.as_object().unwrap() {
-                // Remove any existing amux hooks for this event, keep others
-                if let Some(existing_entries) = existing_obj.get_mut(event) {
-                    if let Some(arr) = existing_entries.as_array_mut() {
-                        arr.retain(|entry| {
-                            !entry
-                                .get("hooks")
-                                .and_then(|h| h.as_array())
-                                .map(|hooks| {
-                                    hooks.iter().any(|h| {
-                                        h.get("command")
-                                            .and_then(|c| c.as_str())
-                                            .is_some_and(|c| c.contains("amux claude-hook"))
-                                    })
-                                })
-                                .unwrap_or(false)
-                        });
-                        // Append our hooks
-                        if let Some(new_arr) = hook_entries.as_array() {
-                            arr.extend(new_arr.iter().cloned());
-                        }
-                    }
-                } else {
-                    existing_obj.insert(event.clone(), hook_entries.clone());
-                }
-            }
-        }
-    } else {
-        settings["hooks"] = hooks;
+    // Hooks are now injected automatically via a claude wrapper script that
+    // amux-app writes to ~/.config/amux/bin/claude and prepends to PATH.
+    // This command cleans up any old settings.json hooks and informs the user.
+    let removed = cleanup_legacy_claude_hooks()?;
+    if removed {
+        println!("Cleaned up legacy hooks from ~/.claude/settings.json.");
     }
-
-    let formatted = serde_json::to_string_pretty(&settings)?;
-    std::fs::write(&settings_path, formatted)?;
-
-    println!("Claude Code hooks installed to {}", settings_path.display());
-    println!();
-    println!(
-        "Hooks registered for: UserPromptSubmit, PreToolUse, Notification, Stop, SubagentStart"
-    );
-    println!("Restart Claude Code for hooks to take effect.");
-
+    println!("Claude Code hooks are now automatic — no manual installation needed.");
+    println!("amux injects hooks via a wrapper script when Claude Code is launched inside amux.");
+    println!("Hooks only activate inside amux terminals; outside amux, Claude Code runs normally.");
     Ok(())
 }
 
-fn uninstall_claude_hooks() -> anyhow::Result<()> {
+/// Remove any amux claude-hook entries from ~/.claude/settings.json.
+/// Returns true if any were removed.
+fn cleanup_legacy_claude_hooks() -> anyhow::Result<bool> {
     let settings_path = dirs::home_dir()
         .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
         .join(".claude")
         .join("settings.json");
 
     if !settings_path.exists() {
-        println!("No Claude Code settings found. Nothing to uninstall.");
-        return Ok(());
+        return Ok(false);
     }
 
     let content = std::fs::read_to_string(&settings_path)?;
     let mut settings: serde_json::Value = serde_json::from_str(&content)?;
 
+    let mut removed_any = false;
     if let Some(hooks) = settings.get_mut("hooks") {
         if let Some(hooks_obj) = hooks.as_object_mut() {
             for (_event, entries) in hooks_obj.iter_mut() {
                 if let Some(arr) = entries.as_array_mut() {
+                    let before = arr.len();
                     arr.retain(|entry| {
                         !entry
                             .get("hooks")
@@ -1148,27 +1084,39 @@ fn uninstall_claude_hooks() -> anyhow::Result<()> {
                                 hooks.iter().any(|h| {
                                     h.get("command")
                                         .and_then(|c| c.as_str())
-                                        .is_some_and(|c| c.contains("amux claude-hook"))
+                                        .is_some_and(|c| c.contains("claude-hook"))
                                 })
                             })
                             .unwrap_or(false)
                     });
+                    if arr.len() < before {
+                        removed_any = true;
+                    }
                 }
             }
             // Remove empty event arrays
             hooks_obj.retain(|_, v| v.as_array().map(|a| !a.is_empty()).unwrap_or(true));
-            // Remove hooks key entirely if empty
             if hooks_obj.is_empty() {
                 settings.as_object_mut().unwrap().remove("hooks");
             }
         }
     }
 
-    let formatted = serde_json::to_string_pretty(&settings)?;
-    std::fs::write(&settings_path, formatted)?;
+    if removed_any {
+        let formatted = serde_json::to_string_pretty(&settings)?;
+        std::fs::write(&settings_path, formatted)?;
+    }
 
-    println!("Claude Code hooks uninstalled.");
+    Ok(removed_any)
+}
 
+fn uninstall_claude_hooks() -> anyhow::Result<()> {
+    let removed = cleanup_legacy_claude_hooks()?;
+    if removed {
+        println!("Claude Code hooks removed from ~/.claude/settings.json.");
+    } else {
+        println!("No amux hooks found in ~/.claude/settings.json.");
+    }
     Ok(())
 }
 

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -110,6 +110,7 @@ enum Command {
     #[command(name = "set-cwd")]
     SetCwd {
         /// Working directory path (omit to clear)
+        #[arg(conflicts_with = "clear")]
         cwd: Option<String>,
         /// Clear CWD metadata
         #[arg(long)]
@@ -122,10 +123,10 @@ enum Command {
     #[command(name = "set-git")]
     SetGit {
         /// Branch name (omit to clear)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "clear")]
         branch: Option<String>,
         /// Working tree has uncommitted changes
-        #[arg(long)]
+        #[arg(long, conflicts_with = "clear")]
         dirty: bool,
         /// Clear git info
         #[arg(long)]
@@ -138,13 +139,13 @@ enum Command {
     #[command(name = "set-pr")]
     SetPr {
         /// PR number
-        #[arg(long)]
+        #[arg(long, conflicts_with = "clear")]
         number: Option<u32>,
         /// PR title
-        #[arg(long)]
+        #[arg(long, conflicts_with = "clear")]
         title: Option<String>,
         /// PR state: open, merged, closed
-        #[arg(long)]
+        #[arg(long, conflicts_with = "clear")]
         state: Option<String>,
         /// Clear PR info
         #[arg(long)]

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -1,5 +1,6 @@
 use amux_ipc::{read_last_addr, IpcAddr, IpcClient};
 use clap::{Parser, Subcommand};
+use std::io::Read as _;
 
 #[derive(Parser)]
 #[command(name = "amux", about = "Terminal multiplexer for AI coding agents")]
@@ -200,6 +201,22 @@ enum Command {
     /// Install shell integration scripts
     #[command(name = "install-shell-integration")]
     InstallShellIntegration,
+    /// Handle a Claude Code hook event (reads JSON from stdin)
+    #[command(name = "claude-hook")]
+    ClaudeHook {
+        /// Hook event name (PreToolUse, Stop, UserPromptSubmit, etc.)
+        event: String,
+    },
+    /// Install agent hooks into Claude Code settings
+    #[command(name = "install-hooks")]
+    InstallHooks {
+        /// Install Claude Code hooks
+        #[arg(long)]
+        claude: bool,
+        /// Uninstall hooks instead of installing
+        #[arg(long)]
+        uninstall: bool,
+    },
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -209,6 +226,19 @@ async fn main() -> anyhow::Result<()> {
     // These commands are direct filesystem operations — handle before IPC connection.
     if matches!(cli.command, Command::InstallShellIntegration) {
         install_shell_integration()?;
+        return Ok(());
+    }
+    if let Command::InstallHooks { claude, uninstall } = &cli.command {
+        if *claude {
+            if *uninstall {
+                uninstall_claude_hooks()?;
+            } else {
+                install_claude_hooks()?;
+            }
+        } else {
+            eprintln!("Specify --claude to install Claude Code hooks");
+            std::process::exit(1);
+        }
         return Ok(());
     }
     if matches!(cli.command, Command::SessionClear) {
@@ -677,7 +707,10 @@ async fn main() -> anyhow::Result<()> {
                 print_response(&resp, false);
             }
         }
-        Command::SessionClear | Command::InstallShellIntegration => {
+        Command::ClaudeHook { event } => {
+            handle_claude_hook(&mut client, &event).await?;
+        }
+        Command::SessionClear | Command::InstallShellIntegration | Command::InstallHooks { .. } => {
             unreachable!("handled before IPC connection");
         }
     }
@@ -839,6 +872,304 @@ fn print_pane_list(result: &serde_json::Value) {
             println!("pane:{}{} {}x{} [{}]", id, focus_marker, cols, rows, status);
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code hook handling
+// ---------------------------------------------------------------------------
+
+/// Read stdin JSON and translate Claude Code hook events into amux status updates.
+async fn handle_claude_hook(client: &mut IpcClient, event: &str) -> anyhow::Result<()> {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input)?;
+    let data: serde_json::Value = serde_json::from_str(&input).unwrap_or_default();
+
+    let ws_id = std::env::var("AMUX_WORKSPACE_ID").unwrap_or_else(|_| "0".to_string());
+
+    match event {
+        "UserPromptSubmit" => {
+            // User submitted a prompt — set status to active with the prompt as task
+            let prompt = data
+                .get("prompt")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let task = if prompt.len() > 80 {
+                format!("{}...", &prompt[..77])
+            } else {
+                prompt
+            };
+            let mut params = serde_json::json!({
+                "workspace_id": ws_id,
+                "state": "active",
+                "label": "Running",
+            });
+            if !task.is_empty() {
+                params["task"] = serde_json::json!(task);
+            }
+            // Clear previous message on new prompt
+            params["message"] = serde_json::json!("");
+            client.call("status.set", params).await?;
+        }
+        "PreToolUse" => {
+            // Claude is about to use a tool — update message with tool description
+            let tool_name = data.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
+            let tool_input = data.get("tool_input");
+            let description = describe_tool_use(tool_name, tool_input);
+            let params = serde_json::json!({
+                "workspace_id": ws_id,
+                "state": "active",
+                "label": "Running",
+                "message": description,
+            });
+            client.call("status.set", params).await?;
+        }
+        "Notification" => {
+            // Claude needs attention (permission prompt, etc.)
+            let params = serde_json::json!({
+                "workspace_id": ws_id,
+                "state": "waiting",
+                "label": "Needs input",
+            });
+            client.call("status.set", params).await?;
+        }
+        "Stop" => {
+            // Claude finished its turn — set to idle, clear task/message
+            let params = serde_json::json!({
+                "workspace_id": ws_id,
+                "state": "idle",
+                "label": "Idle",
+                "task": "",
+                "message": "",
+            });
+            client.call("status.set", params).await?;
+        }
+        "SubagentStart" => {
+            let agent_name = data
+                .get("agent_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("subagent");
+            let description = format!("Running {agent_name}");
+            let params = serde_json::json!({
+                "workspace_id": ws_id,
+                "state": "active",
+                "label": "Running",
+                "message": description,
+            });
+            client.call("status.set", params).await?;
+        }
+        _ => {
+            // SessionStart, SessionEnd, PostToolUse, SubagentStop — no status change needed
+        }
+    }
+
+    Ok(())
+}
+
+/// Generate a human-readable description of a tool use, matching cmux's describeToolUse().
+fn describe_tool_use(tool_name: &str, tool_input: Option<&serde_json::Value>) -> String {
+    let input = tool_input.unwrap_or(&serde_json::Value::Null);
+
+    match tool_name {
+        "Read" => {
+            let path = input
+                .get("file_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let filename = std::path::Path::new(path)
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or(path);
+            format!("Reading {filename}")
+        }
+        "Edit" => {
+            let path = input
+                .get("file_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let filename = std::path::Path::new(path)
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or(path);
+            format!("Editing {filename}")
+        }
+        "Write" => {
+            let path = input
+                .get("file_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let filename = std::path::Path::new(path)
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or(path);
+            format!("Writing {filename}")
+        }
+        "Bash" => {
+            let cmd = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
+            let short = if cmd.len() > 60 {
+                format!("{}...", &cmd[..57])
+            } else {
+                cmd.to_string()
+            };
+            format!("Running {short}")
+        }
+        "Glob" => {
+            let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("*");
+            format!("Searching {pattern}")
+        }
+        "Grep" => {
+            let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+            format!("Grep {pattern}")
+        }
+        "WebFetch" => "Fetching URL".to_string(),
+        "WebSearch" => {
+            let query = input.get("query").and_then(|v| v.as_str()).unwrap_or("");
+            format!("Search: {query}")
+        }
+        "Agent" => {
+            let desc = input
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("subagent");
+            desc.to_string()
+        }
+        _ => tool_name.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code hook installation
+// ---------------------------------------------------------------------------
+
+fn install_claude_hooks() -> anyhow::Result<()> {
+    let settings_path = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
+        .join(".claude")
+        .join("settings.json");
+
+    let mut settings: serde_json::Value = if settings_path.exists() {
+        let content = std::fs::read_to_string(&settings_path)?;
+        serde_json::from_str(&content)?
+    } else {
+        std::fs::create_dir_all(settings_path.parent().unwrap())?;
+        serde_json::json!({})
+    };
+
+    // Build hook entries for each event
+    let amux_hook = |event: &str, timeout: u64| -> serde_json::Value {
+        serde_json::json!({
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": format!("\"${{AMUX_BIN:-amux}}\" claude-hook {event}"),
+                "timeout": timeout
+            }]
+        })
+    };
+
+    let hooks = serde_json::json!({
+        "UserPromptSubmit": [amux_hook("UserPromptSubmit", 5)],
+        "PreToolUse": [amux_hook("PreToolUse", 5)],
+        "Notification": [amux_hook("Notification", 5)],
+        "Stop": [amux_hook("Stop", 5)],
+        "SubagentStart": [amux_hook("SubagentStart", 5)],
+    });
+
+    // Merge with existing hooks (don't clobber non-amux hooks)
+    if let Some(existing_hooks) = settings.get_mut("hooks") {
+        if let Some(existing_obj) = existing_hooks.as_object_mut() {
+            for (event, hook_entries) in hooks.as_object().unwrap() {
+                // Remove any existing amux hooks for this event, keep others
+                if let Some(existing_entries) = existing_obj.get_mut(event) {
+                    if let Some(arr) = existing_entries.as_array_mut() {
+                        arr.retain(|entry| {
+                            !entry
+                                .get("hooks")
+                                .and_then(|h| h.as_array())
+                                .map(|hooks| {
+                                    hooks.iter().any(|h| {
+                                        h.get("command")
+                                            .and_then(|c| c.as_str())
+                                            .is_some_and(|c| c.contains("amux claude-hook"))
+                                    })
+                                })
+                                .unwrap_or(false)
+                        });
+                        // Append our hooks
+                        if let Some(new_arr) = hook_entries.as_array() {
+                            arr.extend(new_arr.iter().cloned());
+                        }
+                    }
+                } else {
+                    existing_obj.insert(event.clone(), hook_entries.clone());
+                }
+            }
+        }
+    } else {
+        settings["hooks"] = hooks;
+    }
+
+    let formatted = serde_json::to_string_pretty(&settings)?;
+    std::fs::write(&settings_path, formatted)?;
+
+    println!("Claude Code hooks installed to {}", settings_path.display());
+    println!();
+    println!(
+        "Hooks registered for: UserPromptSubmit, PreToolUse, Notification, Stop, SubagentStart"
+    );
+    println!("Restart Claude Code for hooks to take effect.");
+
+    Ok(())
+}
+
+fn uninstall_claude_hooks() -> anyhow::Result<()> {
+    let settings_path = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
+        .join(".claude")
+        .join("settings.json");
+
+    if !settings_path.exists() {
+        println!("No Claude Code settings found. Nothing to uninstall.");
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(&settings_path)?;
+    let mut settings: serde_json::Value = serde_json::from_str(&content)?;
+
+    if let Some(hooks) = settings.get_mut("hooks") {
+        if let Some(hooks_obj) = hooks.as_object_mut() {
+            for (_event, entries) in hooks_obj.iter_mut() {
+                if let Some(arr) = entries.as_array_mut() {
+                    arr.retain(|entry| {
+                        !entry
+                            .get("hooks")
+                            .and_then(|h| h.as_array())
+                            .map(|hooks| {
+                                hooks.iter().any(|h| {
+                                    h.get("command")
+                                        .and_then(|c| c.as_str())
+                                        .is_some_and(|c| c.contains("amux claude-hook"))
+                                })
+                            })
+                            .unwrap_or(false)
+                    });
+                }
+            }
+            // Remove empty event arrays
+            hooks_obj.retain(|_, v| v.as_array().map(|a| !a.is_empty()).unwrap_or(true));
+            // Remove hooks key entirely if empty
+            if hooks_obj.is_empty() {
+                settings.as_object_mut().unwrap().remove("hooks");
+            }
+        }
+    }
+
+    let formatted = serde_json::to_string_pretty(&settings)?;
+    std::fs::write(&settings_path, formatted)?;
+
+    println!("Claude Code hooks uninstalled.");
+
+    Ok(())
 }
 
 fn install_shell_integration() -> anyhow::Result<()> {

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -193,14 +193,20 @@ enum Command {
     /// Clear saved session data
     #[command(name = "session-clear")]
     SessionClear,
+    /// Install shell integration scripts
+    #[command(name = "install-shell-integration")]
+    InstallShellIntegration,
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
-    // SessionClear is a direct filesystem operation — handle before IPC connection
-    // so it works even when the server isn't running.
+    // These commands are direct filesystem operations — handle before IPC connection.
+    if matches!(cli.command, Command::InstallShellIntegration) {
+        install_shell_integration()?;
+        return Ok(());
+    }
     if matches!(cli.command, Command::SessionClear) {
         match amux_session::clear() {
             Ok(()) => {
@@ -666,7 +672,7 @@ async fn main() -> anyhow::Result<()> {
                 print_response(&resp, false);
             }
         }
-        Command::SessionClear => {
+        Command::SessionClear | Command::InstallShellIntegration => {
             unreachable!("handled before IPC connection");
         }
     }
@@ -828,4 +834,42 @@ fn print_pane_list(result: &serde_json::Value) {
             println!("pane:{}{} {}x{} [{}]", id, focus_marker, cols, rows, status);
         }
     }
+}
+
+fn install_shell_integration() -> anyhow::Result<()> {
+    let config_dir = dirs::config_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("amux")
+        .join("shell");
+    std::fs::create_dir_all(&config_dir)?;
+
+    let zsh_script = include_str!("../../../resources/shell-integration/amux-zsh-integration.zsh");
+    let bash_script =
+        include_str!("../../../resources/shell-integration/amux-bash-integration.bash");
+
+    let zsh_path = config_dir.join("amux-zsh-integration.zsh");
+    let bash_path = config_dir.join("amux-bash-integration.bash");
+
+    std::fs::write(&zsh_path, zsh_script)?;
+    std::fs::write(&bash_path, bash_script)?;
+
+    println!("Shell integration scripts installed to:");
+    println!("  {}", zsh_path.display());
+    println!("  {}", bash_path.display());
+    println!();
+    println!("Add one of the following to your shell config:");
+    println!();
+    println!("  # For zsh (~/.zshrc):");
+    println!(
+        "  [[ -n \"$AMUX_SOCKET_PATH\" ]] && source \"{}\"",
+        zsh_path.display()
+    );
+    println!();
+    println!("  # For bash (~/.bashrc):");
+    println!(
+        "  [[ -n \"$AMUX_SOCKET_PATH\" ]] && source \"{}\"",
+        bash_path.display()
+    );
+
+    Ok(())
 }

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -102,7 +102,8 @@ pub struct StatusSetParams {
 #[derive(Debug, Deserialize)]
 pub struct SetCwdParams {
     pub surface_id: String,
-    pub cwd: String,
+    #[serde(default)]
+    pub cwd: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -15,6 +15,9 @@ pub const METHODS: &[&str] = &[
     "surface.send_text",
     "surface.read_text",
     "surface.list",
+    "surface.set_cwd",
+    "surface.set_git",
+    "surface.set_pr",
     "pane.split",
     "pane.close",
     "pane.focus",
@@ -90,6 +93,36 @@ pub struct StatusSetParams {
     pub state: String,
     #[serde(default)]
     pub label: Option<String>,
+    #[serde(default)]
+    pub task: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetCwdParams {
+    pub surface_id: String,
+    pub cwd: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetGitParams {
+    pub surface_id: String,
+    #[serde(default)]
+    pub branch: Option<String>,
+    #[serde(default)]
+    pub dirty: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetPrParams {
+    pub surface_id: String,
+    #[serde(default)]
+    pub number: Option<u32>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub state: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -349,9 +349,18 @@ impl NotificationStore {
         message: Option<String>,
     ) {
         let existing = self.workspace_statuses.get(&workspace_id);
-        // Preserve task/message if not explicitly provided in this call
-        let task = task.or_else(|| existing.and_then(|s| s.task.clone()));
-        let message = message.or_else(|| existing.and_then(|s| s.message.clone()));
+        // Normalize empty strings to None, then preserve existing if not provided.
+        // Some("") means "clear", None means "keep previous".
+        let task = match task {
+            Some(s) if s.is_empty() => None,
+            Some(s) => Some(s),
+            None => existing.and_then(|s| s.task.clone()),
+        };
+        let message = match message {
+            Some(s) if s.is_empty() => None,
+            Some(s) => Some(s),
+            None => existing.and_then(|s| s.message.clone()),
+        };
         self.workspace_statuses.insert(
             workspace_id,
             WorkspaceStatus {

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -336,7 +336,7 @@ impl NotificationStore {
         self.notifications
             .iter()
             .rev()
-            .find(|n| n.workspace_id == workspace_id)
+            .find(|n| n.workspace_id == workspace_id && !n.read)
     }
 
     /// Set workspace agent status. Clears any existing progress bar.

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -48,6 +48,10 @@ pub struct WorkspaceStatus {
     pub updated_at: Instant,
     /// Optional progress value (0.0–1.0) for progress bar display.
     pub progress: Option<f32>,
+    /// Agent's current task description (shown as title line in sidebar).
+    pub task: Option<String>,
+    /// Agent's latest message (shown as subtitle in sidebar).
+    pub message: Option<String>,
 }
 
 /// A single notification entry.
@@ -336,7 +340,18 @@ impl NotificationStore {
     }
 
     /// Set workspace agent status. Clears any existing progress bar.
-    pub fn set_status(&mut self, workspace_id: u64, state: AgentState, label: Option<String>) {
+    pub fn set_status(
+        &mut self,
+        workspace_id: u64,
+        state: AgentState,
+        label: Option<String>,
+        task: Option<String>,
+        message: Option<String>,
+    ) {
+        let existing = self.workspace_statuses.get(&workspace_id);
+        // Preserve task/message if not explicitly provided in this call
+        let task = task.or_else(|| existing.and_then(|s| s.task.clone()));
+        let message = message.or_else(|| existing.and_then(|s| s.message.clone()));
         self.workspace_statuses.insert(
             workspace_id,
             WorkspaceStatus {
@@ -344,6 +359,8 @@ impl NotificationStore {
                 label,
                 updated_at: Instant::now(),
                 progress: None,
+                task,
+                message,
             },
         );
     }
@@ -559,12 +576,18 @@ mod tests {
     #[test]
     fn workspace_status_roundtrip() {
         let mut store = NotificationStore::new();
-        store.set_status(1, AgentState::Active, Some("Running tests".into()));
+        store.set_status(
+            1,
+            AgentState::Active,
+            Some("Running tests".into()),
+            None,
+            None,
+        );
         let status = store.workspace_status(1).unwrap();
         assert_eq!(status.state, AgentState::Active);
         assert_eq!(status.label.as_deref(), Some("Running tests"));
 
-        store.set_status(1, AgentState::Idle, None);
+        store.set_status(1, AgentState::Idle, None, None, None);
         let status = store.workspace_status(1).unwrap();
         assert_eq!(status.state, AgentState::Idle);
         assert!(status.label.is_none());
@@ -656,7 +679,7 @@ mod tests {
     fn progress_lifecycle() {
         let mut store = NotificationStore::new();
         // set_status creates entry with no progress
-        store.set_status(1, AgentState::Active, Some("Building".into()));
+        store.set_status(1, AgentState::Active, Some("Building".into()), None, None);
         assert!(store.workspace_status(1).unwrap().progress.is_none());
 
         // set_progress adds progress
@@ -664,7 +687,7 @@ mod tests {
         assert_eq!(store.workspace_status(1).unwrap().progress, Some(0.5));
 
         // set_status clears progress
-        store.set_status(1, AgentState::Idle, None);
+        store.set_status(1, AgentState::Idle, None, None, None);
         assert!(store.workspace_status(1).unwrap().progress.is_none());
     }
 }

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -87,6 +87,10 @@ pub struct SavedWorkspaceStatus {
     pub state: String,
     #[serde(default)]
     pub label: Option<String>,
+    #[serde(default)]
+    pub task: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
 }
 
 // --- File Operations ---

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -52,6 +52,16 @@ pub struct SavedSurface {
     pub scrollback: String,
     pub cols: u16,
     pub rows: u16,
+    #[serde(default)]
+    pub git_branch: Option<String>,
+    #[serde(default)]
+    pub git_dirty: bool,
+    #[serde(default)]
+    pub pr_number: Option<u32>,
+    #[serde(default)]
+    pub pr_title: Option<String>,
+    #[serde(default)]
+    pub pr_state: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -170,6 +180,11 @@ mod tests {
                     scrollback: "$ echo hello\nhello\n".to_string(),
                     cols: 80,
                     rows: 24,
+                    git_branch: None,
+                    git_dirty: false,
+                    pr_number: None,
+                    pr_title: None,
+                    pr_state: None,
                 }],
                 active_surface_idx: 0,
             },

--- a/resources/bin/claude
+++ b/resources/bin/claude
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# amux claude wrapper — injects hooks via --settings so agent status flows
+# back into amux without touching ~/.claude/settings.json.
+#
+# When running inside an amux terminal (AMUX_SURFACE_ID is set), this wrapper
+# intercepts `claude` invocations to inject --settings with hook definitions.
+# Outside amux (or when the socket is down), it passes through unchanged.
+
+# Find the real claude binary, skipping our own directory.
+find_real_claude() {
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local IFS=:
+    for d in $PATH; do
+        [[ "$d" == "$self_dir" ]] && continue
+        [[ -x "$d/claude" ]] && printf '%s' "$d/claude" && return 0
+    done
+    return 1
+}
+
+# Return 0 only when AMUX_SOCKET_PATH points to a live amux socket.
+amux_socket_available() {
+    local socket="${AMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+
+    local amux_bin="${AMUX_BIN:-amux}"
+    [[ -x "$amux_bin" ]] || amux_bin="$(command -v amux 2>/dev/null || true)"
+    [[ -n "$amux_bin" ]] || return 1
+
+    # Bounded check so claude startup doesn't block behind a hung socket.
+    "$amux_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
+# Pass through if not in an amux terminal or the socket is unavailable.
+IN_AMUX=0
+if [[ -n "${AMUX_SURFACE_ID:-}" ]]; then
+    IN_AMUX=1
+fi
+
+if [[ "$IN_AMUX" == "0" ]] || ! amux_socket_available; then
+    REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
+    exec "$REAL_CLAUDE" "$@"
+fi
+
+# Find real claude.
+REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
+
+# Pass through subcommands that don't support session/hook flags.
+case "${1:-}" in
+    mcp|config|api-key|rc|remote-control) exec "$REAL_CLAUDE" "$@" ;;
+esac
+
+# Unset CLAUDECODE to avoid "nested session" detection — amux terminals are
+# independent sessions even when the parent shell was launched from Claude Code.
+unset CLAUDECODE
+
+# Check if the user already specified a session/resume flag.
+SKIP_SESSION_ID=false
+for arg in "$@"; do
+    case "$arg" in
+        --resume|--resume=*|--session-id|--session-id=*|--continue|-c)
+            SKIP_SESSION_ID=true
+            break
+            ;;
+    esac
+done
+
+# Export the wrapper's PID. Because we exec claude below, this PID becomes
+# the actual claude process PID.
+export AMUX_CLAUDE_PID=$$
+
+# Resolve the amux CLI binary for hook commands.
+AMUX_CMD="${AMUX_BIN:-amux}"
+
+# Build hooks settings JSON.
+# Claude Code merges --settings additively with the user's own settings.json.
+HOOKS_JSON="{\"hooks\":{\"UserPromptSubmit\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"\\\"${AMUX_CMD}\\\" claude-hook UserPromptSubmit\",\"timeout\":5}]}],\"PreToolUse\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"\\\"${AMUX_CMD}\\\" claude-hook PreToolUse\",\"timeout\":5}]}],\"Notification\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"\\\"${AMUX_CMD}\\\" claude-hook Notification\",\"timeout\":5}]}],\"Stop\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"\\\"${AMUX_CMD}\\\" claude-hook Stop\",\"timeout\":5}]}],\"SubagentStart\":[{\"matcher\":\"\",\"hooks\":[{\"type\":\"command\",\"command\":\"\\\"${AMUX_CMD}\\\" claude-hook SubagentStart\",\"timeout\":5}]}]}}"
+
+if [[ "$SKIP_SESSION_ID" == true ]]; then
+    exec "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
+else
+    SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    exec "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
+fi

--- a/resources/shell-integration/amux-bash-integration.bash
+++ b/resources/shell-integration/amux-bash-integration.bash
@@ -56,10 +56,18 @@ _amux_report_pr() {
         return 0
     }
 
+    # Use timeout/gtimeout if available, otherwise run gh directly
+    local timeout_cmd=""
+    if command -v timeout >/dev/null 2>&1; then
+        timeout_cmd="timeout 10"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        timeout_cmd="gtimeout 10"
+    fi
+
     local gh_output=""
     gh_output="$(
         cd "$repo_path" 2>/dev/null \
-            && timeout 10 gh pr view "$branch" \
+            && $timeout_cmd gh pr view "$branch" \
                 --json number,title,state \
                 --jq '[.number, .title, .state] | @tsv' \
                 2>/dev/null

--- a/resources/shell-integration/amux-bash-integration.bash
+++ b/resources/shell-integration/amux-bash-integration.bash
@@ -1,0 +1,201 @@
+# amux shell integration for bash
+# Source this from .bashrc: [[ -n "$AMUX_SOCKET_PATH" ]] && source ~/.config/amux/shell/amux-bash-integration.bash
+
+# Guard: only activate inside amux
+[[ -n "$AMUX_SOCKET_PATH" ]] || return 0
+
+# ---------------------------------------------------------------------------
+# Throttle state
+# ---------------------------------------------------------------------------
+_AMUX_PWD_LAST=""
+_AMUX_GIT_LAST_PWD=""
+_AMUX_GIT_LAST_RUN=0
+_AMUX_GIT_FORCE=0
+_AMUX_PR_POLL_PID=""
+_AMUX_PR_POLL_PWD=""
+_AMUX_PR_POLL_INTERVAL=45
+_AMUX_PR_FORCE=0
+
+# ---------------------------------------------------------------------------
+# Git branch + dirty detection
+# ---------------------------------------------------------------------------
+_amux_report_git() {
+    local repo_path="$1"
+    [[ -n "$repo_path" ]] || return 0
+
+    git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1 || {
+        amux set-git --clear >/dev/null 2>&1
+        return 0
+    }
+
+    local branch dirty_flag=""
+    branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
+    if [[ -n "$branch" ]]; then
+        local first
+        first="$(git -C "$repo_path" status --porcelain -uno 2>/dev/null | head -1)"
+        [[ -n "$first" ]] && dirty_flag="--dirty"
+        amux set-git --branch "$branch" $dirty_flag >/dev/null 2>&1
+    else
+        amux set-git --clear >/dev/null 2>&1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# PR polling
+# ---------------------------------------------------------------------------
+_amux_report_pr() {
+    local repo_path="$1"
+    [[ -n "$repo_path" ]] || return 0
+    [[ -d "$repo_path" ]] || return 0
+    command -v gh >/dev/null 2>&1 || return 0
+
+    local branch
+    branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
+    [[ -n "$branch" ]] || {
+        amux set-pr --clear >/dev/null 2>&1
+        return 0
+    }
+
+    local gh_output=""
+    gh_output="$(
+        cd "$repo_path" 2>/dev/null \
+            && timeout 10 gh pr view "$branch" \
+                --json number,title,state \
+                --jq '[.number, .title, .state] | @tsv' \
+                2>/dev/null
+    )" || true
+
+    if [[ -z "$gh_output" ]]; then
+        amux set-pr --clear >/dev/null 2>&1
+        return 0
+    fi
+
+    local IFS=$'\t'
+    local number title state
+    read -r number title state <<< "$gh_output"
+    [[ -n "$number" ]] || return 0
+
+    local state_lower="${state,,}"
+    amux set-pr --number "$number" --title "$title" --state "$state_lower" >/dev/null 2>&1
+}
+
+_amux_stop_pr_poll() {
+    if [[ -n "$_AMUX_PR_POLL_PID" ]]; then
+        kill "$_AMUX_PR_POLL_PID" >/dev/null 2>&1 || true
+        wait "$_AMUX_PR_POLL_PID" >/dev/null 2>&1 || true
+        _AMUX_PR_POLL_PID=""
+    fi
+}
+
+_amux_start_pr_poll() {
+    local watch_pwd="${1:-$PWD}"
+    local force="${2:-0}"
+
+    if [[ "$force" != "1" && "$watch_pwd" == "$_AMUX_PR_POLL_PWD" && -n "$_AMUX_PR_POLL_PID" ]] \
+        && kill -0 "$_AMUX_PR_POLL_PID" 2>/dev/null; then
+        return 0
+    fi
+
+    _amux_stop_pr_poll
+    _AMUX_PR_POLL_PWD="$watch_pwd"
+
+    local interval="${_AMUX_PR_POLL_INTERVAL:-45}"
+    local shell_pid="$$"
+    (
+        while true; do
+            kill -0 "$shell_pid" >/dev/null 2>&1 || break
+            _amux_report_pr "$watch_pwd" || true
+            sleep "$interval"
+        done
+    ) &
+    _AMUX_PR_POLL_PID=$!
+    disown "$_AMUX_PR_POLL_PID" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# PROMPT_COMMAND hook
+# ---------------------------------------------------------------------------
+_amux_prompt_command() {
+    local now
+    now="$(date +%s)"
+    local pwd="$PWD"
+
+    # CWD: report on change
+    if [[ "$pwd" != "$_AMUX_PWD_LAST" ]]; then
+        _AMUX_PWD_LAST="$pwd"
+        amux set-cwd "$pwd" >/dev/null 2>&1 &
+        disown $! 2>/dev/null || true
+    fi
+
+    # Git branch: refresh on directory change, force flag, or every ~3s
+    local should_git=0
+    if [[ "$pwd" != "$_AMUX_GIT_LAST_PWD" ]]; then
+        should_git=1
+    elif (( _AMUX_GIT_FORCE )); then
+        should_git=1
+    elif (( now - _AMUX_GIT_LAST_RUN >= 3 )); then
+        should_git=1
+    fi
+
+    if (( should_git )); then
+        _AMUX_GIT_FORCE=0
+        _AMUX_GIT_LAST_PWD="$pwd"
+        _AMUX_GIT_LAST_RUN=$now
+        _amux_report_git "$pwd" &
+        disown $! 2>/dev/null || true
+    fi
+
+    # PR polling
+    local should_restart_pr=0
+    if [[ "$pwd" != "$_AMUX_PR_POLL_PWD" ]]; then
+        should_restart_pr=1
+    elif (( _AMUX_PR_FORCE )); then
+        should_restart_pr=1
+    elif [[ -z "$_AMUX_PR_POLL_PID" ]] || ! kill -0 "$_AMUX_PR_POLL_PID" 2>/dev/null; then
+        should_restart_pr=1
+    fi
+
+    if (( should_restart_pr )); then
+        _AMUX_PR_FORCE=0
+        if [[ -n "$_AMUX_PR_POLL_PWD" && "$pwd" != "$_AMUX_PR_POLL_PWD" ]]; then
+            amux set-pr --clear >/dev/null 2>&1 &
+            disown $! 2>/dev/null || true
+        fi
+        _amux_start_pr_poll "$pwd" 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# DEBUG trap for preexec equivalent
+# ---------------------------------------------------------------------------
+_amux_preexec_trap() {
+    # Only trigger for interactive commands, not PROMPT_COMMAND itself
+    [[ "$BASH_COMMAND" == "_amux_prompt_command" ]] && return
+    [[ "$BASH_COMMAND" == "$PROMPT_COMMAND" ]] && return
+
+    local cmd="$BASH_COMMAND"
+    case "$cmd" in
+        git\ *|git|gh\ *|lazygit|lazygit\ *|tig|tig\ *|gitui|gitui\ *|stg\ *|jj\ *)
+            _AMUX_GIT_FORCE=1
+            _AMUX_PR_FORCE=1 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+_amux_cleanup() {
+    _amux_stop_pr_poll
+}
+
+# ---------------------------------------------------------------------------
+# Register hooks
+# ---------------------------------------------------------------------------
+if [[ -z "$PROMPT_COMMAND" ]]; then
+    PROMPT_COMMAND="_amux_prompt_command"
+elif [[ "$PROMPT_COMMAND" != *"_amux_prompt_command"* ]]; then
+    PROMPT_COMMAND="_amux_prompt_command;$PROMPT_COMMAND"
+fi
+
+trap '_amux_preexec_trap' DEBUG
+trap '_amux_cleanup' EXIT

--- a/resources/shell-integration/amux-bash-integration.bash
+++ b/resources/shell-integration/amux-bash-integration.bash
@@ -47,7 +47,10 @@ _amux_report_pr() {
     local repo_path="$1"
     [[ -n "$repo_path" ]] || return 0
     [[ -d "$repo_path" ]] || return 0
-    command -v gh >/dev/null 2>&1 || return 0
+    command -v gh >/dev/null 2>&1 || {
+        amux set-pr --clear >/dev/null 2>&1
+        return 0
+    }
 
     local branch
     branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"

--- a/resources/shell-integration/amux-bash-integration.bash
+++ b/resources/shell-integration/amux-bash-integration.bash
@@ -203,12 +203,31 @@ _amux_cleanup() {
 }
 
 # ---------------------------------------------------------------------------
+# PATH fix: re-prepend amux bin dir after path_helper clobbers it
+# ---------------------------------------------------------------------------
+_amux_fix_path_done=0
+_amux_fix_path() {
+    [[ "$_amux_fix_path_done" == "1" ]] && return
+    _amux_fix_path_done=1
+    if [[ -n "${AMUX_SHELL_INTEGRATION_DIR:-}" ]]; then
+        local bin_dir="${AMUX_SHELL_INTEGRATION_DIR%/shell}/bin"
+        if [[ -d "$bin_dir" ]]; then
+            local new_path=":${PATH}:"
+            new_path="${new_path//:${bin_dir}:/:}"
+            new_path="${new_path#:}"
+            new_path="${new_path%:}"
+            PATH="${bin_dir}:${new_path}"
+        fi
+    fi
+}
+
+# ---------------------------------------------------------------------------
 # Register hooks
 # ---------------------------------------------------------------------------
 if [[ -z "$PROMPT_COMMAND" ]]; then
-    PROMPT_COMMAND="_amux_prompt_command"
+    PROMPT_COMMAND="_amux_fix_path;_amux_prompt_command"
 elif [[ "$PROMPT_COMMAND" != *"_amux_prompt_command"* ]]; then
-    PROMPT_COMMAND="_amux_prompt_command;$PROMPT_COMMAND"
+    PROMPT_COMMAND="_amux_fix_path;_amux_prompt_command;$PROMPT_COMMAND"
 fi
 
 trap '_amux_preexec_trap' DEBUG

--- a/resources/shell-integration/amux-bash-integration.bash
+++ b/resources/shell-integration/amux-bash-integration.bash
@@ -4,6 +4,9 @@
 # Guard: only activate inside amux
 [[ -n "$AMUX_SOCKET_PATH" ]] || return 0
 
+# Resolve amux binary (AMUX_BIN set by amux-app, fallback to PATH)
+_AMUX_CMD="${AMUX_BIN:-amux}"
+
 # ---------------------------------------------------------------------------
 # Throttle state
 # ---------------------------------------------------------------------------
@@ -24,7 +27,7 @@ _amux_report_git() {
     [[ -n "$repo_path" ]] || return 0
 
     git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1 || {
-        amux set-git --clear >/dev/null 2>&1
+        "$_AMUX_CMD" set-git --clear >/dev/null 2>&1
         return 0
     }
 
@@ -34,9 +37,9 @@ _amux_report_git() {
         local first
         first="$(git -C "$repo_path" status --porcelain -uno 2>/dev/null | head -1)"
         [[ -n "$first" ]] && dirty_flag="--dirty"
-        amux set-git --branch "$branch" $dirty_flag >/dev/null 2>&1
+        "$_AMUX_CMD" set-git --branch "$branch" $dirty_flag >/dev/null 2>&1
     else
-        amux set-git --clear >/dev/null 2>&1
+        "$_AMUX_CMD" set-git --clear >/dev/null 2>&1
     fi
 }
 
@@ -48,14 +51,14 @@ _amux_report_pr() {
     [[ -n "$repo_path" ]] || return 0
     [[ -d "$repo_path" ]] || return 0
     command -v gh >/dev/null 2>&1 || {
-        amux set-pr --clear >/dev/null 2>&1
+        "$_AMUX_CMD" set-pr --clear >/dev/null 2>&1
         return 0
     }
 
     local branch
     branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
     [[ -n "$branch" ]] || {
-        amux set-pr --clear >/dev/null 2>&1
+        "$_AMUX_CMD" set-pr --clear >/dev/null 2>&1
         return 0
     }
 
@@ -77,7 +80,7 @@ _amux_report_pr() {
     )" || true
 
     if [[ -z "$gh_output" ]]; then
-        amux set-pr --clear >/dev/null 2>&1
+        "$_AMUX_CMD" set-pr --clear >/dev/null 2>&1
         return 0
     fi
 
@@ -87,7 +90,7 @@ _amux_report_pr() {
     [[ -n "$number" ]] || return 0
 
     local state_lower="${state,,}"
-    amux set-pr --number "$number" --title "$title" --state "$state_lower" >/dev/null 2>&1
+    "$_AMUX_CMD" set-pr --number "$number" --title "$title" --state "$state_lower" >/dev/null 2>&1
 }
 
 _amux_stop_pr_poll() {
@@ -134,7 +137,7 @@ _amux_prompt_command() {
     # CWD: report on change
     if [[ "$pwd" != "$_AMUX_PWD_LAST" ]]; then
         _AMUX_PWD_LAST="$pwd"
-        amux set-cwd "$pwd" >/dev/null 2>&1 &
+        "$_AMUX_CMD" set-cwd "$pwd" >/dev/null 2>&1 &
         disown $! 2>/dev/null || true
     fi
 
@@ -169,7 +172,7 @@ _amux_prompt_command() {
     if (( should_restart_pr )); then
         _AMUX_PR_FORCE=0
         if [[ -n "$_AMUX_PR_POLL_PWD" && "$pwd" != "$_AMUX_PR_POLL_PWD" ]]; then
-            amux set-pr --clear >/dev/null 2>&1 &
+            "$_AMUX_CMD" set-pr --clear >/dev/null 2>&1 &
             disown $! 2>/dev/null || true
         fi
         _amux_start_pr_poll "$pwd" 1

--- a/resources/shell-integration/amux-zsh-integration.zsh
+++ b/resources/shell-integration/amux-zsh-integration.zsh
@@ -315,9 +315,27 @@ _amux_zshexit() {
 }
 
 # ---------------------------------------------------------------------------
+# PATH fix: re-prepend amux bin dir after path_helper clobbers it
+# ---------------------------------------------------------------------------
+_amux_fix_path() {
+    if [[ -n "${AMUX_SHELL_INTEGRATION_DIR:-}" ]]; then
+        # bin dir is sibling of shell dir: ~/.config/amux/bin
+        local bin_dir="${AMUX_SHELL_INTEGRATION_DIR%/shell}/bin"
+        if [[ -d "$bin_dir" ]]; then
+            # Remove existing entry and re-prepend
+            local -a parts=("${(@s/:/)PATH}")
+            parts=("${(@)parts:#$bin_dir}")
+            PATH="${bin_dir}:${(j/:/)parts}"
+        fi
+    fi
+    add-zsh-hook -d precmd _amux_fix_path
+}
+
+# ---------------------------------------------------------------------------
 # Register hooks
 # ---------------------------------------------------------------------------
 autoload -Uz add-zsh-hook
 add-zsh-hook preexec _amux_preexec
 add-zsh-hook precmd _amux_precmd
 add-zsh-hook zshexit _amux_zshexit
+add-zsh-hook precmd _amux_fix_path

--- a/resources/shell-integration/amux-zsh-integration.zsh
+++ b/resources/shell-integration/amux-zsh-integration.zsh
@@ -4,6 +4,9 @@
 # Guard: only activate inside amux
 [[ -n "$AMUX_SOCKET_PATH" ]] || return 0
 
+# Resolve amux binary (AMUX_BIN set by amux-app, fallback to PATH)
+typeset -g _AMUX_CMD="${AMUX_BIN:-amux}"
+
 # ---------------------------------------------------------------------------
 # Throttle state
 # ---------------------------------------------------------------------------
@@ -69,7 +72,7 @@ _amux_report_git() {
 
     # Not in a git repo? Clear.
     git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1 || {
-        amux set-git --clear >/dev/null 2>&1
+        "$_AMUX_CMD" set-git --clear >/dev/null 2>&1
         return 0
     }
 
@@ -79,9 +82,9 @@ _amux_report_git() {
         local first
         first="$(git -C "$repo_path" status --porcelain -uno 2>/dev/null | head -1)"
         [[ -n "$first" ]] && dirty_flag="--dirty"
-        amux set-git --branch "$branch" $dirty_flag >/dev/null 2>&1
+        "$_AMUX_CMD" set-git --branch "$branch" $dirty_flag >/dev/null 2>&1
     else
-        amux set-git --clear >/dev/null 2>&1
+        "$_AMUX_CMD" set-git --clear >/dev/null 2>&1
     fi
 }
 
@@ -94,14 +97,14 @@ _amux_report_pr() {
     [[ -d "$repo_path" ]] || return 0
 
     command -v gh >/dev/null 2>&1 || {
-        amux set-pr --clear >/dev/null 2>&1
+        "$_AMUX_CMD" set-pr --clear >/dev/null 2>&1
         return 0
     }
 
     local branch
     branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
     [[ -n "$branch" ]] || {
-        amux set-pr --clear >/dev/null 2>&1
+        "$_AMUX_CMD" set-pr --clear >/dev/null 2>&1
         return 0
     }
 
@@ -123,7 +126,7 @@ _amux_report_pr() {
     )" || true
 
     if [[ -z "$gh_output" ]]; then
-        amux set-pr --clear >/dev/null 2>&1
+        "$_AMUX_CMD" set-pr --clear >/dev/null 2>&1
         return 0
     fi
 
@@ -133,7 +136,7 @@ _amux_report_pr() {
     [[ -n "$number" ]] || return 0
 
     local state_lower="${state:l}"
-    amux set-pr --number "$number" --title "$title" --state "$state_lower" >/dev/null 2>&1
+    "$_AMUX_CMD" set-pr --number "$number" --title "$title" --state "$state_lower" >/dev/null 2>&1
 }
 
 _amux_stop_pr_poll() {
@@ -234,7 +237,7 @@ _amux_precmd() {
     # CWD: report on change
     if [[ "$pwd" != "$_AMUX_PWD_LAST" ]]; then
         _AMUX_PWD_LAST="$pwd"
-        { amux set-cwd "$pwd" >/dev/null 2>&1 } &!
+        { "$_AMUX_CMD" set-cwd "$pwd" >/dev/null 2>&1 } &!
     fi
 
     # Git branch: refresh on directory change, force flag, or every ~3s
@@ -297,7 +300,7 @@ _amux_precmd() {
     if (( should_restart_pr )); then
         _AMUX_PR_FORCE=0
         if (( pr_context_changed )); then
-            { amux set-pr --clear >/dev/null 2>&1 } &!
+            { "$_AMUX_CMD" set-pr --clear >/dev/null 2>&1 } &!
         fi
         _amux_start_pr_poll "$pwd" 1
     fi

--- a/resources/shell-integration/amux-zsh-integration.zsh
+++ b/resources/shell-integration/amux-zsh-integration.zsh
@@ -92,7 +92,11 @@ _amux_report_pr() {
     local repo_path="$1"
     [[ -n "$repo_path" ]] || return 0
     [[ -d "$repo_path" ]] || return 0
-    command -v gh >/dev/null 2>&1 || return 0
+
+    command -v gh >/dev/null 2>&1 || {
+        amux set-pr --clear >/dev/null 2>&1
+        return 0
+    }
 
     local branch
     branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"

--- a/resources/shell-integration/amux-zsh-integration.zsh
+++ b/resources/shell-integration/amux-zsh-integration.zsh
@@ -1,0 +1,308 @@
+# amux shell integration for zsh
+# Source this from .zshrc: [[ -n "$AMUX_SOCKET_PATH" ]] && source ~/.config/amux/shell/amux-zsh-integration.zsh
+
+# Guard: only activate inside amux
+[[ -n "$AMUX_SOCKET_PATH" ]] || return 0
+
+# ---------------------------------------------------------------------------
+# Throttle state
+# ---------------------------------------------------------------------------
+typeset -g _AMUX_PWD_LAST=""
+typeset -g _AMUX_GIT_LAST_PWD=""
+typeset -g _AMUX_GIT_LAST_RUN=0
+typeset -g _AMUX_GIT_FORCE=0
+typeset -g _AMUX_GIT_HEAD_LAST_PWD=""
+typeset -g _AMUX_GIT_HEAD_PATH=""
+typeset -g _AMUX_GIT_HEAD_SIGNATURE=""
+typeset -g _AMUX_GIT_HEAD_WATCH_PID=""
+typeset -g _AMUX_PR_POLL_PID=""
+typeset -g _AMUX_PR_POLL_PWD=""
+typeset -g _AMUX_PR_POLL_INTERVAL=45
+typeset -g _AMUX_PR_FORCE=0
+
+# ---------------------------------------------------------------------------
+# Git HEAD resolution (no git subprocess — fast)
+# ---------------------------------------------------------------------------
+_amux_git_resolve_head_path() {
+    local dir="$PWD"
+    while true; do
+        if [[ -d "$dir/.git" ]]; then
+            print -r -- "$dir/.git/HEAD"
+            return 0
+        fi
+        if [[ -f "$dir/.git" ]]; then
+            local line gitdir
+            line="$(<"$dir/.git")"
+            if [[ "$line" == gitdir:* ]]; then
+                gitdir="${line#gitdir:}"
+                gitdir="${gitdir## }"
+                gitdir="${gitdir%% }"
+                [[ -n "$gitdir" ]] || return 1
+                [[ "$gitdir" != /* ]] && gitdir="$dir/$gitdir"
+                print -r -- "$gitdir/HEAD"
+                return 0
+            fi
+        fi
+        [[ "$dir" == "/" || -z "$dir" ]] && break
+        dir="${dir:h}"
+    done
+    return 1
+}
+
+_amux_git_head_signature() {
+    local head_path="$1"
+    [[ -n "$head_path" && -r "$head_path" ]] || return 1
+    local line=""
+    if IFS= read -r line < "$head_path"; then
+        print -r -- "$line"
+        return 0
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Git branch + dirty detection
+# ---------------------------------------------------------------------------
+_amux_report_git() {
+    local repo_path="$1"
+    [[ -n "$repo_path" ]] || return 0
+
+    # Not in a git repo? Clear.
+    git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1 || {
+        amux set-git --clear >/dev/null 2>&1
+        return 0
+    }
+
+    local branch dirty_flag=""
+    branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
+    if [[ -n "$branch" ]]; then
+        local first
+        first="$(git -C "$repo_path" status --porcelain -uno 2>/dev/null | head -1)"
+        [[ -n "$first" ]] && dirty_flag="--dirty"
+        amux set-git --branch "$branch" $dirty_flag >/dev/null 2>&1
+    else
+        amux set-git --clear >/dev/null 2>&1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# PR polling
+# ---------------------------------------------------------------------------
+_amux_report_pr() {
+    local repo_path="$1"
+    [[ -n "$repo_path" ]] || return 0
+    [[ -d "$repo_path" ]] || return 0
+    command -v gh >/dev/null 2>&1 || return 0
+
+    local branch
+    branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
+    [[ -n "$branch" ]] || {
+        amux set-pr --clear >/dev/null 2>&1
+        return 0
+    }
+
+    local gh_output=""
+    gh_output="$(
+        builtin cd "$repo_path" 2>/dev/null \
+            && timeout 10 gh pr view "$branch" \
+                --json number,title,state \
+                --jq '[.number, .title, .state] | @tsv' \
+                2>/dev/null
+    )" || true
+
+    if [[ -z "$gh_output" ]]; then
+        amux set-pr --clear >/dev/null 2>&1
+        return 0
+    fi
+
+    local IFS=$'\t'
+    local number title state
+    read -r number title state <<< "$gh_output"
+    [[ -n "$number" ]] || return 0
+
+    local state_lower="${state:l}"
+    amux set-pr --number "$number" --title "$title" --state "$state_lower" >/dev/null 2>&1
+}
+
+_amux_stop_pr_poll() {
+    if [[ -n "$_AMUX_PR_POLL_PID" ]]; then
+        kill "$_AMUX_PR_POLL_PID" >/dev/null 2>&1 || true
+        _AMUX_PR_POLL_PID=""
+    fi
+}
+
+_amux_start_pr_poll() {
+    local watch_pwd="${1:-$PWD}"
+    local force="${2:-0}"
+
+    if [[ "$force" != "1" && "$watch_pwd" == "$_AMUX_PR_POLL_PWD" && -n "$_AMUX_PR_POLL_PID" ]] \
+        && kill -0 "$_AMUX_PR_POLL_PID" 2>/dev/null; then
+        return 0
+    fi
+
+    _amux_stop_pr_poll
+    _AMUX_PR_POLL_PWD="$watch_pwd"
+
+    local interval="${_AMUX_PR_POLL_INTERVAL:-45}"
+    local shell_pid="$$"
+    {
+        while true; do
+            kill -0 "$shell_pid" >/dev/null 2>&1 || break
+            _amux_report_pr "$watch_pwd" || true
+            sleep "$interval"
+        done
+    } >/dev/null 2>&1 &!
+    _AMUX_PR_POLL_PID=$!
+}
+
+# ---------------------------------------------------------------------------
+# HEAD file watcher (detects branch changes during long commands)
+# ---------------------------------------------------------------------------
+_amux_stop_head_watch() {
+    if [[ -n "$_AMUX_GIT_HEAD_WATCH_PID" ]]; then
+        kill "$_AMUX_GIT_HEAD_WATCH_PID" >/dev/null 2>&1 || true
+        _AMUX_GIT_HEAD_WATCH_PID=""
+    fi
+}
+
+_amux_start_head_watch() {
+    local watch_pwd="$PWD"
+    local watch_head_path
+    watch_head_path="$(_amux_git_resolve_head_path 2>/dev/null || true)"
+    [[ -n "$watch_head_path" ]] || return 0
+
+    local watch_head_sig
+    watch_head_sig="$(_amux_git_head_signature "$watch_head_path" 2>/dev/null || true)"
+
+    _AMUX_GIT_HEAD_LAST_PWD="$watch_pwd"
+    _AMUX_GIT_HEAD_PATH="$watch_head_path"
+    _AMUX_GIT_HEAD_SIGNATURE="$watch_head_sig"
+
+    _amux_stop_head_watch
+    {
+        local last_sig="$watch_head_sig"
+        while true; do
+            sleep 1
+            local sig
+            sig="$(_amux_git_head_signature "$watch_head_path" 2>/dev/null || true)"
+            if [[ -n "$sig" && "$sig" != "$last_sig" ]]; then
+                last_sig="$sig"
+                _amux_report_git "$watch_pwd"
+            fi
+        done
+    } >/dev/null 2>&1 &!
+    _AMUX_GIT_HEAD_WATCH_PID=$!
+}
+
+# ---------------------------------------------------------------------------
+# Hook: preexec (before command runs)
+# ---------------------------------------------------------------------------
+_amux_preexec() {
+    # Force git refresh after git-related commands
+    local cmd="${1## }"
+    case "$cmd" in
+        git\ *|git|gh\ *|lazygit|lazygit\ *|tig|tig\ *|gitui|gitui\ *|stg\ *|jj\ *)
+            _AMUX_GIT_FORCE=1
+            _AMUX_PR_FORCE=1 ;;
+    esac
+
+    _amux_stop_pr_poll
+    _amux_start_head_watch
+}
+
+# ---------------------------------------------------------------------------
+# Hook: precmd (before prompt)
+# ---------------------------------------------------------------------------
+_amux_precmd() {
+    _amux_stop_head_watch
+
+    local now=$EPOCHSECONDS
+    local pwd="$PWD"
+
+    # CWD: report on change
+    if [[ "$pwd" != "$_AMUX_PWD_LAST" ]]; then
+        _AMUX_PWD_LAST="$pwd"
+        { amux set-cwd "$pwd" >/dev/null 2>&1 } &!
+    fi
+
+    # Git branch: refresh on directory change, force flag, or every ~3s
+    local should_git=0
+    local git_head_changed=0
+
+    # Detect HEAD changes (branch switch via alias, tool, etc.)
+    if [[ "$pwd" != "$_AMUX_GIT_HEAD_LAST_PWD" ]]; then
+        _AMUX_GIT_HEAD_LAST_PWD="$pwd"
+        _AMUX_GIT_HEAD_PATH="$(_amux_git_resolve_head_path 2>/dev/null || true)"
+        _AMUX_GIT_HEAD_SIGNATURE=""
+    fi
+    if [[ -n "$_AMUX_GIT_HEAD_PATH" ]]; then
+        local head_sig
+        head_sig="$(_amux_git_head_signature "$_AMUX_GIT_HEAD_PATH" 2>/dev/null || true)"
+        if [[ -n "$head_sig" ]]; then
+            if [[ -z "$_AMUX_GIT_HEAD_SIGNATURE" ]]; then
+                _AMUX_GIT_HEAD_SIGNATURE="$head_sig"
+            elif [[ "$head_sig" != "$_AMUX_GIT_HEAD_SIGNATURE" ]]; then
+                _AMUX_GIT_HEAD_SIGNATURE="$head_sig"
+                git_head_changed=1
+                _AMUX_GIT_FORCE=1
+                _AMUX_PR_FORCE=1
+                should_git=1
+            fi
+        fi
+    fi
+
+    if [[ "$pwd" != "$_AMUX_GIT_LAST_PWD" ]]; then
+        should_git=1
+    elif (( _AMUX_GIT_FORCE )); then
+        should_git=1
+    elif (( now - _AMUX_GIT_LAST_RUN >= 3 )); then
+        should_git=1
+    fi
+
+    if (( should_git )); then
+        _AMUX_GIT_FORCE=0
+        _AMUX_GIT_LAST_PWD="$pwd"
+        _AMUX_GIT_LAST_RUN=$now
+        { _amux_report_git "$pwd" } >/dev/null 2>&1 &!
+    fi
+
+    # PR polling: restart on directory/branch change
+    local should_restart_pr=0
+    local pr_context_changed=0
+    if [[ -n "$_AMUX_PR_POLL_PWD" && "$pwd" != "$_AMUX_PR_POLL_PWD" ]]; then
+        pr_context_changed=1
+    elif (( git_head_changed )); then
+        pr_context_changed=1
+    fi
+    if [[ "$pwd" != "$_AMUX_PR_POLL_PWD" ]]; then
+        should_restart_pr=1
+    elif (( _AMUX_PR_FORCE )); then
+        should_restart_pr=1
+    elif [[ -z "$_AMUX_PR_POLL_PID" ]] || ! kill -0 "$_AMUX_PR_POLL_PID" 2>/dev/null; then
+        should_restart_pr=1
+    fi
+
+    if (( should_restart_pr )); then
+        _AMUX_PR_FORCE=0
+        if (( pr_context_changed )); then
+            { amux set-pr --clear >/dev/null 2>&1 } &!
+        fi
+        _amux_start_pr_poll "$pwd" 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup on shell exit
+# ---------------------------------------------------------------------------
+_amux_zshexit() {
+    _amux_stop_head_watch
+    _amux_stop_pr_poll
+}
+
+# ---------------------------------------------------------------------------
+# Register hooks
+# ---------------------------------------------------------------------------
+autoload -Uz add-zsh-hook
+add-zsh-hook preexec _amux_preexec
+add-zsh-hook precmd _amux_precmd
+add-zsh-hook zshexit _amux_zshexit

--- a/resources/shell-integration/amux-zsh-integration.zsh
+++ b/resources/shell-integration/amux-zsh-integration.zsh
@@ -101,10 +101,18 @@ _amux_report_pr() {
         return 0
     }
 
+    # Use timeout/gtimeout if available, otherwise run gh directly
+    local timeout_cmd=""
+    if command -v timeout >/dev/null 2>&1; then
+        timeout_cmd="timeout 10"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        timeout_cmd="gtimeout 10"
+    fi
+
     local gh_output=""
     gh_output="$(
         builtin cd "$repo_path" 2>/dev/null \
-            && timeout 10 gh pr view "$branch" \
+            && ${=timeout_cmd} gh pr view "$branch" \
                 --json number,title,state \
                 --jq '[.number, .title, .state] | @tsv' \
                 2>/dev/null

--- a/resources/shell-integration/zsh/.zlogin
+++ b/resources/shell-integration/zsh/.zlogin
@@ -1,0 +1,12 @@
+# amux compatibility shim: restores ZDOTDIR and sources user's .zlogin.
+
+if [[ -n "${AMUX_ZSH_ZDOTDIR+X}" ]]; then
+    builtin export ZDOTDIR="$AMUX_ZSH_ZDOTDIR"
+    builtin unset AMUX_ZSH_ZDOTDIR
+else
+    builtin unset ZDOTDIR
+fi
+
+builtin typeset _amux_file="${ZDOTDIR-$HOME}/.zlogin"
+[[ ! -r "$_amux_file" ]] || builtin source -- "$_amux_file"
+builtin unset _amux_file

--- a/resources/shell-integration/zsh/.zprofile
+++ b/resources/shell-integration/zsh/.zprofile
@@ -1,0 +1,12 @@
+# amux compatibility shim: restores ZDOTDIR and sources user's .zprofile.
+
+if [[ -n "${AMUX_ZSH_ZDOTDIR+X}" ]]; then
+    builtin export ZDOTDIR="$AMUX_ZSH_ZDOTDIR"
+    builtin unset AMUX_ZSH_ZDOTDIR
+else
+    builtin unset ZDOTDIR
+fi
+
+builtin typeset _amux_file="${ZDOTDIR-$HOME}/.zprofile"
+[[ ! -r "$_amux_file" ]] || builtin source -- "$_amux_file"
+builtin unset _amux_file

--- a/resources/shell-integration/zsh/.zshenv
+++ b/resources/shell-integration/zsh/.zshenv
@@ -1,0 +1,29 @@
+# amux ZDOTDIR bootstrap for zsh.
+#
+# amux sets ZDOTDIR to this directory so that shell integration is loaded
+# automatically. We restore the user's real ZDOTDIR immediately so that:
+# - /etc/zshrc sets HISTFILE relative to the real ZDOTDIR/HOME (shared history)
+# - zsh loads the user's real .zprofile/.zshrc normally (no wrapper recursion)
+
+if [[ -n "${AMUX_ZSH_ZDOTDIR+X}" ]]; then
+    builtin export ZDOTDIR="$AMUX_ZSH_ZDOTDIR"
+    builtin unset AMUX_ZSH_ZDOTDIR
+else
+    builtin unset ZDOTDIR
+fi
+
+{
+    # zsh treats unset ZDOTDIR as if it were HOME. We do the same.
+    builtin typeset _amux_file="${ZDOTDIR-$HOME}/.zshenv"
+    [[ ! -r "$_amux_file" ]] || builtin source -- "$_amux_file"
+} always {
+    if [[ -o interactive ]]; then
+        # Load amux integration (unless disabled)
+        if [[ "${AMUX_SHELL_INTEGRATION:-1}" != "0" && -n "${AMUX_SHELL_INTEGRATION_DIR:-}" ]]; then
+            builtin typeset _amux_integ="$AMUX_SHELL_INTEGRATION_DIR/amux-zsh-integration.zsh"
+            [[ -r "$_amux_integ" ]] && builtin source -- "$_amux_integ"
+        fi
+    fi
+
+    builtin unset _amux_file _amux_integ
+}

--- a/resources/shell-integration/zsh/.zshrc
+++ b/resources/shell-integration/zsh/.zshrc
@@ -1,0 +1,12 @@
+# amux compatibility shim: restores ZDOTDIR and sources user's .zshrc.
+
+if [[ -n "${AMUX_ZSH_ZDOTDIR+X}" ]]; then
+    builtin export ZDOTDIR="$AMUX_ZSH_ZDOTDIR"
+    builtin unset AMUX_ZSH_ZDOTDIR
+else
+    builtin unset ZDOTDIR
+fi
+
+builtin typeset _amux_file="${ZDOTDIR-$HOME}/.zshrc"
+[[ ! -r "$_amux_file" ]] || builtin source -- "$_amux_file"
+builtin unset _amux_file


### PR DESCRIPTION
## Summary

- **Per-surface metadata model** (`SurfaceMetadata` struct) with CWD, git branch/dirty, PR number/title/state
- **OSC 7 wiring**: existing `WorkingDirectoryChanged` event now stores CWD in surface metadata
- **3 new IPC methods**: `surface.set_cwd`, `surface.set_git`, `surface.set_pr` for shell integration
- **Extended `status.set`** with optional `task` and `message` fields for agent hooks
- **3 new CLI commands**: `amux set-cwd`, `amux set-git`, `amux set-pr` with `--clear` support
- **Shell integration scripts** for zsh and bash (modeled on cmux): prompt hooks report CWD/git, background PR polling via `gh` every 45s, HEAD file watching during long commands
- **`amux install-shell-integration`** command to install scripts to `~/.config/amux/shell/`
- **Sidebar rendering** of all metadata: agent task as title, agent message as subtitle, git branch + CWD line, PR state badge with color coding
- **Session persistence** of all metadata fields

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo build --no-default-features` (soft renderer) builds
- [ ] Launch amux, `cd` to a git repo, verify CWD updates in sidebar via OSC 7
- [ ] Run `amux set-status --state active --task "Fix bug" --message "Editing auth.rs"` and verify sidebar
- [ ] Run `amux set-git --branch main --dirty` and verify sidebar shows `main*`
- [ ] Run `amux set-pr --number 10 --title "Add feature" --state merged` and verify purple badge
- [ ] Source zsh integration, verify automatic CWD/git/PR reporting on `cd`
- [ ] `amux install-shell-integration` installs scripts and prints instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell integrations (Bash/Zsh) and installer to auto-report CWD, git branch/dirty state, and PR info; CLI: `set-cwd`, `set-git`, `set-pr`, enhanced `set-status` (optional task/message), hooks/claude support
  * Sidebar driven by surface metadata: shows task (✱), agent message, git branch + dirty marker, shortened CWD, and PR lines

* **Bug Fixes / Improvements**
  * Session restore now restores per-surface metadata (cwd, git, PR) but skips unread notifications and does not reinstate persisted workspace agent statuses
  * Notifications: task/message normalization and sidebar suppresses previews when agent messages exist
<!-- end of auto-generated comment: release notes by coderabbit.ai -->