### PR TITLE
Phase 12: Terminal rendering audit

### DIFF
--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -12,6 +12,45 @@ use crate::pipeline::{
 };
 use crate::snapshot::TerminalSnapshot;
 
+#[allow(clippy::too_many_arguments)]
+/// Emit procedural rectangle quads for a custom glyph (box-drawing, block, shade).
+/// Returns `true` if the character was handled, `false` if it should fall through
+/// to normal font shaping.
+fn emit_custom_glyph(
+    ch: char,
+    col: usize,
+    row: usize,
+    fg_color: [f32; 4],
+    phys_x: f32,
+    phys_y: f32,
+    cell_width: f32,
+    cell_height: f32,
+    bg_instances: &mut Vec<CellBgInstance>,
+) -> bool {
+    if let Some(rects) = crate::custom_glyphs::custom_glyph_rects(ch) {
+        let cell_px = phys_x + col as f32 * cell_width;
+        let cell_py = phys_y + row as f32 * cell_height;
+        for r in rects {
+            // Round both edges and derive size from the difference so adjacent
+            // cells meet exactly without gaps or overlaps at fractional DPI.
+            let x0 = (cell_px + r.x * cell_width).round();
+            let y0 = (cell_py + r.y * cell_height).round();
+            let x1 = (cell_px + (r.x + r.w) * cell_width).round();
+            let y1 = (cell_py + (r.y + r.h) * cell_height).round();
+            let pw = (x1 - x0).max(1.0);
+            let ph = (y1 - y0).max(1.0);
+            bg_instances.push(CellBgInstance {
+                pos: [x0, y0],
+                size: [pw, ph],
+                color: fg_color,
+            });
+        }
+        true
+    } else {
+        false
+    }
+}
+
 /// Compute a simple hash of highlight ranges for dirty tracking.
 fn hash_highlight_ranges(ranges: &[(usize, usize, usize)]) -> u64 {
     use std::hash::{Hash, Hasher};
@@ -434,27 +473,16 @@ impl CallbackTrait for TerminalPaintCallback {
                 }
 
                 // Check for procedurally-rendered box-drawing / block characters.
-                // These are emitted as solid-color bg quads using the cell's fg color,
-                // bypassing font shaping entirely for pixel-perfect line connections.
                 if cell.text.len() <= 4 {
-                    let mut chars = cell.text.chars();
-                    if let Some(ch) = chars.next() {
-                        if chars.next().is_none() {
-                            if let Some(rects) = crate::custom_glyphs::custom_glyph_rects(ch) {
-                                let fg_color = maybe_linearize(cell.fg, linearize);
-                                let cell_px = self.phys_rect.x + cell.col as f32 * self.cell_width;
-                                let cell_py = self.phys_rect.y + cell.row as f32 * self.cell_height;
-                                for r in rects {
-                                    let px = (cell_px + r.x * self.cell_width).round();
-                                    let py = (cell_py + r.y * self.cell_height).round();
-                                    let pw = (r.w * self.cell_width).round().max(1.0);
-                                    let ph = (r.h * self.cell_height).round().max(1.0);
-                                    bg_instances.push(CellBgInstance {
-                                        pos: [px, py],
-                                        size: [pw, ph],
-                                        color: fg_color,
-                                    });
-                                }
+                    if let Some(ch) = cell.text.chars().next() {
+                        if cell.text.chars().nth(1).is_none() {
+                            let fg_color = maybe_linearize(cell.fg, linearize);
+                            if emit_custom_glyph(
+                                ch, cell.col, cell.row, fg_color,
+                                self.phys_rect.x, self.phys_rect.y,
+                                self.cell_width, self.cell_height,
+                                &mut bg_instances,
+                            ) {
                                 continue;
                             }
                         }
@@ -512,24 +540,15 @@ impl CallbackTrait for TerminalPaintCallback {
                 }
                 // Re-emit custom glyph rects (they live in bg_instances, not cached glyphs).
                 if cell.text.len() <= 4 {
-                    let mut chars = cell.text.chars();
-                    if let Some(ch) = chars.next() {
-                        if chars.next().is_none() {
-                            if let Some(rects) = crate::custom_glyphs::custom_glyph_rects(ch) {
-                                let fg_color = maybe_linearize(cell.fg, linearize);
-                                let cell_px = self.phys_rect.x + cell.col as f32 * self.cell_width;
-                                let cell_py = self.phys_rect.y + cell.row as f32 * self.cell_height;
-                                for r in rects {
-                                    let px = (cell_px + r.x * self.cell_width).round();
-                                    let py = (cell_py + r.y * self.cell_height).round();
-                                    let pw = (r.w * self.cell_width).round().max(1.0);
-                                    let ph = (r.h * self.cell_height).round().max(1.0);
-                                    bg_instances.push(CellBgInstance {
-                                        pos: [px, py],
-                                        size: [pw, ph],
-                                        color: fg_color,
-                                    });
-                                }
+                    if let Some(ch) = cell.text.chars().next() {
+                        if cell.text.chars().nth(1).is_none() {
+                            let fg_color = maybe_linearize(cell.fg, linearize);
+                            if emit_custom_glyph(
+                                ch, cell.col, cell.row, fg_color,
+                                self.phys_rect.x, self.phys_rect.y,
+                                self.cell_width, self.cell_height,
+                                &mut bg_instances,
+                            ) {
                                 continue;
                             }
                         }

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -478,9 +478,14 @@ impl CallbackTrait for TerminalPaintCallback {
                         if cell.text.chars().nth(1).is_none() {
                             let fg_color = maybe_linearize(cell.fg, linearize);
                             if emit_custom_glyph(
-                                ch, cell.col, cell.row, fg_color,
-                                self.phys_rect.x, self.phys_rect.y,
-                                self.cell_width, self.cell_height,
+                                ch,
+                                cell.col,
+                                cell.row,
+                                fg_color,
+                                self.phys_rect.x,
+                                self.phys_rect.y,
+                                self.cell_width,
+                                self.cell_height,
                                 &mut bg_instances,
                             ) {
                                 continue;
@@ -544,9 +549,14 @@ impl CallbackTrait for TerminalPaintCallback {
                         if cell.text.chars().nth(1).is_none() {
                             let fg_color = maybe_linearize(cell.fg, linearize);
                             if emit_custom_glyph(
-                                ch, cell.col, cell.row, fg_color,
-                                self.phys_rect.x, self.phys_rect.y,
-                                self.cell_width, self.cell_height,
+                                ch,
+                                cell.col,
+                                cell.row,
+                                fg_color,
+                                self.phys_rect.x,
+                                self.phys_rect.y,
+                                self.cell_width,
+                                self.cell_height,
                                 &mut bg_instances,
                             ) {
                                 continue;

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -321,8 +321,8 @@ impl CallbackTrait for TerminalPaintCallback {
         let snap = &self.snapshot;
         let linearize = resources.target_is_srgb;
 
-        // --- Background instances (always rebuilt — cheap) ---
-        let mut bg_instances = Vec::with_capacity(snap.cells.len() + 1);
+        // --- Background instances (span-based to avoid hairline gaps) ---
+        let mut bg_instances = Vec::with_capacity(snap.cells.len() / 4 + 1);
 
         // Full-rect background quad (absolute physical pixel positions)
         let default_bg = maybe_linearize(snap.default_bg, linearize);
@@ -332,17 +332,92 @@ impl CallbackTrait for TerminalPaintCallback {
             color: default_bg,
         });
 
-        for cell in &snap.cells {
-            if cell.bg == snap.default_bg {
-                continue;
+        // Batch consecutive cells on the same row with the same bg into spans.
+        // This eliminates sub-pixel gaps between adjacent cell backgrounds.
+        {
+            let mut span_row: Option<usize> = None;
+            let mut span_col_start: usize = 0;
+            let mut span_col_end: usize = 0;
+            let mut span_bg: [f32; 4] = [0.0; 4];
+
+            let flush_span = |instances: &mut Vec<CellBgInstance>,
+                              row: usize,
+                              col_start: usize,
+                              col_end: usize,
+                              color: [f32; 4],
+                              phys_rect: &PhysRect,
+                              cell_w: f32,
+                              cell_h: f32| {
+                let px = phys_rect.x + col_start as f32 * cell_w;
+                let py = phys_rect.y + row as f32 * cell_h;
+                let w = (col_end - col_start) as f32 * cell_w;
+                instances.push(CellBgInstance {
+                    pos: [px, py],
+                    size: [w, cell_h],
+                    color,
+                });
+            };
+
+            for cell in &snap.cells {
+                if cell.bg == snap.default_bg {
+                    // Flush pending span
+                    if let Some(r) = span_row {
+                        flush_span(
+                            &mut bg_instances,
+                            r,
+                            span_col_start,
+                            span_col_end,
+                            span_bg,
+                            &self.phys_rect,
+                            self.cell_width,
+                            self.cell_height,
+                        );
+                        span_row = None;
+                    }
+                    continue;
+                }
+
+                let bg = maybe_linearize(cell.bg, linearize);
+
+                // Try to extend current span
+                if let Some(r) = span_row {
+                    if cell.row == r && cell.col == span_col_end && bg == span_bg {
+                        span_col_end = cell.col + 1;
+                        continue;
+                    }
+                    // Flush previous span
+                    flush_span(
+                        &mut bg_instances,
+                        r,
+                        span_col_start,
+                        span_col_end,
+                        span_bg,
+                        &self.phys_rect,
+                        self.cell_width,
+                        self.cell_height,
+                    );
+                }
+
+                // Start new span
+                span_row = Some(cell.row);
+                span_col_start = cell.col;
+                span_col_end = cell.col + 1;
+                span_bg = bg;
             }
-            let px = self.phys_rect.x + cell.col as f32 * self.cell_width;
-            let py = self.phys_rect.y + cell.row as f32 * self.cell_height;
-            bg_instances.push(CellBgInstance {
-                pos: [px, py],
-                size: [self.cell_width, self.cell_height],
-                color: maybe_linearize(cell.bg, linearize),
-            });
+
+            // Flush last span
+            if let Some(r) = span_row {
+                flush_span(
+                    &mut bg_instances,
+                    r,
+                    span_col_start,
+                    span_col_end,
+                    span_bg,
+                    &self.phys_rect,
+                    self.cell_width,
+                    self.cell_height,
+                );
+            }
         }
 
         // --- Foreground instances (glyphs) ---
@@ -356,6 +431,34 @@ impl CallbackTrait for TerminalPaintCallback {
             for cell in &snap.cells {
                 if cell.text.is_empty() || cell.text == " " {
                     continue;
+                }
+
+                // Check for procedurally-rendered box-drawing / block characters.
+                // These are emitted as solid-color bg quads using the cell's fg color,
+                // bypassing font shaping entirely for pixel-perfect line connections.
+                if cell.text.len() <= 4 {
+                    let mut chars = cell.text.chars();
+                    if let Some(ch) = chars.next() {
+                        if chars.next().is_none() {
+                            if let Some(rects) = crate::custom_glyphs::custom_glyph_rects(ch) {
+                                let fg_color = maybe_linearize(cell.fg, linearize);
+                                let cell_px = self.phys_rect.x + cell.col as f32 * self.cell_width;
+                                let cell_py = self.phys_rect.y + cell.row as f32 * self.cell_height;
+                                for r in rects {
+                                    let px = (cell_px + r.x * self.cell_width).round();
+                                    let py = (cell_py + r.y * self.cell_height).round();
+                                    let pw = (r.w * self.cell_width).round().max(1.0);
+                                    let ph = (r.h * self.cell_height).round().max(1.0);
+                                    bg_instances.push(CellBgInstance {
+                                        pos: [px, py],
+                                        size: [pw, ph],
+                                        color: fg_color,
+                                    });
+                                }
+                                continue;
+                            }
+                        }
+                    }
                 }
 
                 let color = maybe_linearize(cell.fg, linearize);
@@ -406,6 +509,31 @@ impl CallbackTrait for TerminalPaintCallback {
             for cell in &snap.cells {
                 if cell.text.is_empty() || cell.text == " " {
                     continue;
+                }
+                // Re-emit custom glyph rects (they live in bg_instances, not cached glyphs).
+                if cell.text.len() <= 4 {
+                    let mut chars = cell.text.chars();
+                    if let Some(ch) = chars.next() {
+                        if chars.next().is_none() {
+                            if let Some(rects) = crate::custom_glyphs::custom_glyph_rects(ch) {
+                                let fg_color = maybe_linearize(cell.fg, linearize);
+                                let cell_px = self.phys_rect.x + cell.col as f32 * self.cell_width;
+                                let cell_py = self.phys_rect.y + cell.row as f32 * self.cell_height;
+                                for r in rects {
+                                    let px = (cell_px + r.x * self.cell_width).round();
+                                    let py = (cell_py + r.y * self.cell_height).round();
+                                    let pw = (r.w * self.cell_width).round().max(1.0);
+                                    let ph = (r.h * self.cell_height).round().max(1.0);
+                                    bg_instances.push(CellBgInstance {
+                                        pos: [px, py],
+                                        size: [pw, ph],
+                                        color: fg_color,
+                                    });
+                                }
+                                continue;
+                            }
+                        }
+                    }
                 }
                 color_map.insert((cell.col, cell.row), maybe_linearize(cell.fg, linearize));
             }

--- a/crates/amux-render-gpu/src/custom_glyphs.rs
+++ b/crates/amux-render-gpu/src/custom_glyphs.rs
@@ -1,0 +1,607 @@
+//! Procedural rendering of box-drawing, block-element, and shade characters.
+//!
+//! Instead of relying on font glyphs (which have side bearings and don't fill
+//! the cell edge-to-edge), we define each character as a set of filled
+//! rectangles in normalized cell coordinates (0.0–1.0). The GPU callback
+//! emits these as foreground-colored background quads, producing pixel-perfect
+//! lines that connect seamlessly across adjacent cells.
+//!
+//! This matches the approach used by wezterm and Ghostty, both of which render
+//! these characters procedurally rather than from fonts.
+
+/// A filled rectangle in normalized cell coordinates.
+/// (0.0, 0.0) is the top-left corner; (1.0, 1.0) is the bottom-right.
+#[derive(Debug, Clone, Copy)]
+pub struct CustomRect {
+    pub x: f32,
+    pub y: f32,
+    pub w: f32,
+    pub h: f32,
+}
+
+/// Line thickness as a fraction of cell height.
+/// Light ≈ 1/16, Heavy ≈ 3/16. Clamped to at least 1 physical pixel at render time.
+const LIGHT: f32 = 1.0 / 16.0;
+const HEAVY: f32 = 3.0 / 16.0;
+
+/// Half-thicknesses for centering lines.
+const HL: f32 = LIGHT / 2.0;
+const HH: f32 = HEAVY / 2.0;
+
+// ---------------------------------------------------------------------------
+// Helpers for building rectangle arrays
+// ---------------------------------------------------------------------------
+
+/// Horizontal line spanning the full cell width at the vertical center.
+const fn hline_full(half_t: f32) -> CustomRect {
+    CustomRect {
+        x: 0.0,
+        y: 0.5 - half_t,
+        w: 1.0,
+        h: half_t * 2.0,
+    }
+}
+
+/// Vertical line spanning the full cell height at the horizontal center.
+const fn vline_full(half_t: f32) -> CustomRect {
+    CustomRect {
+        x: 0.5 - half_t,
+        y: 0.0,
+        w: half_t * 2.0,
+        h: 1.0,
+    }
+}
+
+/// Horizontal line from x0 to x1 at vertical center.
+const fn hline(x0: f32, x1: f32, half_t: f32) -> CustomRect {
+    CustomRect {
+        x: x0,
+        y: 0.5 - half_t,
+        w: x1 - x0,
+        h: half_t * 2.0,
+    }
+}
+
+/// Vertical line from y0 to y1 at horizontal center.
+const fn vline(y0: f32, y1: f32, half_t: f32) -> CustomRect {
+    CustomRect {
+        x: 0.5 - half_t,
+        y: y0,
+        w: half_t * 2.0,
+        h: y1 - y0,
+    }
+}
+
+/// A filled block covering a fraction of the cell.
+const fn block(x: f32, y: f32, w: f32, h: f32) -> CustomRect {
+    CustomRect { x, y, w, h }
+}
+
+// ---------------------------------------------------------------------------
+// Character lookup
+// ---------------------------------------------------------------------------
+
+/// Helper macro to create `&'static [CustomRect]` from const-fn expressions.
+/// Each invocation creates a `const` item so the array lives in static memory.
+macro_rules! rects {
+    ($($rect:expr),+ $(,)?) => {{
+        const R: &[CustomRect] = &[$($rect),+];
+        Some(R)
+    }};
+}
+
+/// Returns the set of rectangles for a procedurally-rendered character,
+/// or `None` if the character should use the normal font glyph path.
+pub fn custom_glyph_rects(ch: char) -> Option<&'static [CustomRect]> {
+    match ch as u32 {
+        // =================================================================
+        // BOX DRAWING — Light lines
+        // =================================================================
+
+        // ─ Light horizontal
+        0x2500 => rects![hline_full(HL)],
+        // │ Light vertical
+        0x2502 => rects![vline_full(HL)],
+
+        // ┌ Light down and right
+        0x250C => rects![hline(0.5, 1.0, HL), vline(0.5, 1.0, HL)],
+        // ┐ Light down and left
+        0x2510 => rects![hline(0.0, 0.5 + HL, HL), vline(0.5, 1.0, HL)],
+        // └ Light up and right
+        0x2514 => rects![hline(0.5, 1.0, HL), vline(0.0, 0.5 + HL, HL)],
+        // ┘ Light up and left
+        0x2518 => rects![hline(0.0, 0.5 + HL, HL), vline(0.0, 0.5 + HL, HL)],
+
+        // ├ Light vertical and right
+        0x251C => rects![vline_full(HL), hline(0.5, 1.0, HL)],
+        // ┤ Light vertical and left
+        0x2524 => rects![vline_full(HL), hline(0.0, 0.5 + HL, HL)],
+        // ┬ Light down and horizontal
+        0x252C => rects![hline_full(HL), vline(0.5, 1.0, HL)],
+        // ┴ Light up and horizontal
+        0x2534 => rects![hline_full(HL), vline(0.0, 0.5 + HL, HL)],
+        // ┼ Light vertical and horizontal
+        0x253C => rects![hline_full(HL), vline_full(HL)],
+
+        // =================================================================
+        // BOX DRAWING — Heavy lines
+        // =================================================================
+
+        // ━ Heavy horizontal
+        0x2501 => rects![hline_full(HH)],
+        // ┃ Heavy vertical
+        0x2503 => rects![vline_full(HH)],
+
+        // ┏ Heavy down and right
+        0x250F => rects![hline(0.5, 1.0, HH), vline(0.5, 1.0, HH)],
+        // ┓ Heavy down and left
+        0x2513 => rects![hline(0.0, 0.5 + HH, HH), vline(0.5, 1.0, HH)],
+        // ┗ Heavy up and right
+        0x2517 => rects![hline(0.5, 1.0, HH), vline(0.0, 0.5 + HH, HH)],
+        // ┛ Heavy up and left
+        0x251B => rects![hline(0.0, 0.5 + HH, HH), vline(0.0, 0.5 + HH, HH)],
+
+        // ┣ Heavy vertical and right
+        0x2523 => rects![vline_full(HH), hline(0.5, 1.0, HH)],
+        // ┫ Heavy vertical and left
+        0x252B => rects![vline_full(HH), hline(0.0, 0.5 + HH, HH)],
+        // ┳ Heavy down and horizontal
+        0x2533 => rects![hline_full(HH), vline(0.5, 1.0, HH)],
+        // ┻ Heavy up and horizontal
+        0x253B => rects![hline_full(HH), vline(0.0, 0.5 + HH, HH)],
+        // ╋ Heavy vertical and horizontal
+        0x254B => rects![hline_full(HH), vline_full(HH)],
+
+        // =================================================================
+        // BOX DRAWING — Dashed lines (light)
+        // =================================================================
+
+        // ┄ Light triple dash horizontal
+        0x2504 => rects![
+            hline(0.0 / 6.0, 1.0 / 6.0, HL),
+            hline(2.0 / 6.0, 3.5 / 6.0, HL),
+            hline(4.5 / 6.0, 1.0, HL),
+        ],
+        // ┆ Light triple dash vertical
+        0x2506 => rects![
+            vline(0.0 / 6.0, 1.0 / 6.0, HL),
+            vline(2.0 / 6.0, 3.5 / 6.0, HL),
+            vline(4.5 / 6.0, 1.0, HL),
+        ],
+        // ┈ Light quadruple dash horizontal
+        0x2508 => rects![
+            hline(0.0 / 8.0, 1.0 / 8.0, HL),
+            hline(2.0 / 8.0, 3.0 / 8.0, HL),
+            hline(4.5 / 8.0, 5.5 / 8.0, HL),
+            hline(6.5 / 8.0, 1.0, HL),
+        ],
+        // ┊ Light quadruple dash vertical
+        0x250A => rects![
+            vline(0.0 / 8.0, 1.0 / 8.0, HL),
+            vline(2.0 / 8.0, 3.0 / 8.0, HL),
+            vline(4.5 / 8.0, 5.5 / 8.0, HL),
+            vline(6.5 / 8.0, 1.0, HL),
+        ],
+
+        // ┅ Heavy triple dash horizontal
+        0x2505 => rects![
+            hline(0.0 / 6.0, 1.0 / 6.0, HH),
+            hline(2.0 / 6.0, 3.5 / 6.0, HH),
+            hline(4.5 / 6.0, 1.0, HH),
+        ],
+        // ┇ Heavy triple dash vertical
+        0x2507 => rects![
+            vline(0.0 / 6.0, 1.0 / 6.0, HH),
+            vline(2.0 / 6.0, 3.5 / 6.0, HH),
+            vline(4.5 / 6.0, 1.0, HH),
+        ],
+        // ┉ Heavy quadruple dash horizontal
+        0x2509 => rects![
+            hline(0.0 / 8.0, 1.0 / 8.0, HH),
+            hline(2.0 / 8.0, 3.0 / 8.0, HH),
+            hline(4.5 / 8.0, 5.5 / 8.0, HH),
+            hline(6.5 / 8.0, 1.0, HH),
+        ],
+        // ┋ Heavy quadruple dash vertical
+        0x250B => rects![
+            vline(0.0 / 8.0, 1.0 / 8.0, HH),
+            vline(2.0 / 8.0, 3.0 / 8.0, HH),
+            vline(4.5 / 8.0, 5.5 / 8.0, HH),
+            vline(6.5 / 8.0, 1.0, HH),
+        ],
+
+        // =================================================================
+        // BOX DRAWING — Mixed light/heavy (most common combinations)
+        // =================================================================
+
+        // ┍ Down light and right heavy
+        0x250D => rects![hline(0.5, 1.0, HH), vline(0.5, 1.0, HL)],
+        // ┎ Down heavy and right light
+        0x250E => rects![hline(0.5, 1.0, HL), vline(0.5, 1.0, HH)],
+        // ┑ Down light and left heavy
+        0x2511 => rects![hline(0.0, 0.5 + HL, HH), vline(0.5, 1.0, HL)],
+        // ┒ Down heavy and left light
+        0x2512 => rects![hline(0.0, 0.5 + HH, HL), vline(0.5, 1.0, HH)],
+        // ┕ Up light and right heavy
+        0x2515 => rects![hline(0.5, 1.0, HH), vline(0.0, 0.5 + HL, HL)],
+        // ┖ Up heavy and right light
+        0x2516 => rects![hline(0.5, 1.0, HL), vline(0.0, 0.5 + HH, HH)],
+        // ┙ Up light and left heavy
+        0x2519 => rects![hline(0.0, 0.5 + HL, HH), vline(0.0, 0.5 + HL, HL)],
+        // ┚ Up heavy and left light
+        0x251A => rects![hline(0.0, 0.5 + HH, HL), vline(0.0, 0.5 + HH, HH)],
+
+        // ┝ Vertical light and right heavy
+        0x251D => rects![vline_full(HL), hline(0.5, 1.0, HH)],
+        // ┞ Up heavy and right down light — simplified to vertical + right stub
+        0x251E => rects![
+            vline(0.0, 0.5, HH),
+            vline(0.5, 1.0, HL),
+            hline(0.5, 1.0, HL)
+        ],
+        // ┠ Down heavy and right up light — simplified
+        0x2520 => rects![
+            vline(0.0, 0.5, HL),
+            vline(0.5, 1.0, HH),
+            hline(0.5, 1.0, HL)
+        ],
+        // ┡ Down light and right up heavy
+        0x2521 => rects![vline_full(HH), hline(0.5, 1.0, HL)],
+        // ┢ Down heavy and right up light (variant)
+        0x2522 => rects![vline_full(HL), hline(0.5, 1.0, HH)],
+
+        // ┥ Vertical light and left heavy
+        0x2525 => rects![vline_full(HL), hline(0.0, 0.5 + HL, HH)],
+        // ┩ Down light and left up heavy
+        0x2529 => rects![vline_full(HH), hline(0.0, 0.5 + HH, HL)],
+
+        // ┭ Left heavy and right down light
+        0x252D => rects![
+            hline(0.0, 0.5, HH),
+            hline(0.5, 1.0, HL),
+            vline(0.5, 1.0, HL)
+        ],
+        // ┮ Left light and right down heavy (variant)
+        0x252E => rects![hline_full(HL), vline(0.5, 1.0, HH)],
+        // ┯ Down light and horizontal heavy
+        0x252F => rects![hline_full(HH), vline(0.5, 1.0, HL)],
+        // ┰ Down heavy and horizontal light
+        0x2530 => rects![hline_full(HL), vline(0.5, 1.0, HH)],
+
+        // ┵ Left heavy and right up light
+        0x2535 => rects![
+            hline(0.0, 0.5, HH),
+            hline(0.5, 1.0, HL),
+            vline(0.0, 0.5 + HL, HL)
+        ],
+        // ┷ Up light and horizontal heavy
+        0x2537 => rects![hline_full(HH), vline(0.0, 0.5 + HL, HL)],
+        // ┸ Up heavy and horizontal light
+        0x2538 => rects![hline_full(HL), vline(0.0, 0.5 + HH, HH)],
+
+        // ┽ Left heavy and right vertical light
+        0x253D => rects![vline_full(HL), hline(0.0, 0.5, HH), hline(0.5, 1.0, HL)],
+        // ┾ Left light and right vertical heavy (variant)
+        0x253E => rects![vline_full(HL), hline(0.0, 0.5, HL), hline(0.5, 1.0, HH)],
+        // ┿ Vertical light and horizontal heavy
+        0x253F => rects![hline_full(HH), vline_full(HL)],
+        // ╀ Up heavy, down horizontal light
+        0x2540 => rects![hline_full(HL), vline(0.0, 0.5, HH), vline(0.5, 1.0, HL)],
+        // ╁ Down heavy, up horizontal light
+        0x2541 => rects![hline_full(HL), vline(0.0, 0.5, HL), vline(0.5, 1.0, HH)],
+        // ╂ Vertical heavy and horizontal light
+        0x2542 => rects![hline_full(HL), vline_full(HH)],
+
+        // =================================================================
+        // BOX DRAWING — Double lines
+        // =================================================================
+
+        // ═ Double horizontal
+        0x2550 => rects![
+            hline_full(HL),
+            CustomRect {
+                x: 0.0,
+                y: 0.5 + HL * 2.0,
+                w: 1.0,
+                h: LIGHT,
+            },
+        ],
+        // ║ Double vertical
+        0x2551 => rects![
+            vline_full(HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.0,
+                w: LIGHT,
+                h: 1.0,
+            },
+        ],
+
+        // ╔ Double down and right
+        0x2554 => rects![
+            hline(0.5 - HL, 1.0, HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.5 + HL * 2.0,
+                w: 0.5 - HL * 2.0,
+                h: LIGHT,
+            },
+            vline(0.5 - HL, 1.0, HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.5 + HL * 2.0,
+                w: LIGHT,
+                h: 0.5 - HL * 2.0,
+            },
+        ],
+        // ╗ Double down and left
+        0x2557 => rects![
+            hline(0.0, 0.5 + HL, HL),
+            CustomRect {
+                x: 0.0,
+                y: 0.5 + HL * 2.0,
+                w: 0.5 - HL * 2.0 + LIGHT,
+                h: LIGHT,
+            },
+            vline(0.5 - HL, 1.0, HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.5 + HL * 2.0,
+                w: LIGHT,
+                h: 0.5 - HL * 2.0,
+            },
+        ],
+        // ╚ Double up and right
+        0x255A => rects![
+            hline(0.5 - HL, 1.0, HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.0,
+                w: 0.5 - HL * 2.0,
+                h: LIGHT,
+            },
+            vline(0.0, 0.5 + HL, HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.0,
+                w: LIGHT,
+                h: 0.5 - HL * 2.0 + LIGHT,
+            },
+        ],
+        // ╝ Double up and left
+        0x255D => rects![
+            hline(0.0, 0.5 + HL, HL),
+            CustomRect {
+                x: 0.0,
+                y: 0.5 - HL - LIGHT,
+                w: 0.5 - HL * 2.0 + LIGHT,
+                h: LIGHT,
+            },
+            vline(0.0, 0.5 + HL, HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.0,
+                w: LIGHT,
+                h: 0.5 - HL * 2.0 + LIGHT,
+            },
+        ],
+
+        // ╠ Double vertical and right
+        0x2560 => rects![
+            vline_full(HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.0,
+                w: LIGHT,
+                h: 0.5 - HL - LIGHT,
+            },
+            hline(0.5 + HL * 2.0, 1.0, HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.5 + HL + LIGHT,
+                w: LIGHT,
+                h: 0.5 - HL - LIGHT,
+            },
+        ],
+        // ╣ Double vertical and left
+        0x2563 => rects![
+            vline_full(HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.0,
+                w: LIGHT,
+                h: 0.5 - HL - LIGHT,
+            },
+            hline(0.0, 0.5 - HL * 2.0 + LIGHT, HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.5 + HL + LIGHT,
+                w: LIGHT,
+                h: 0.5 - HL - LIGHT,
+            },
+        ],
+        // ╦ Double horizontal and down
+        0x2566 => rects![
+            hline_full(HL),
+            CustomRect {
+                x: 0.5 - HL,
+                y: 0.5 + HL * 2.0,
+                w: LIGHT,
+                h: 0.5 - HL * 2.0,
+            },
+            CustomRect {
+                x: 0.0,
+                y: 0.5 + HL * 2.0,
+                w: 1.0,
+                h: LIGHT,
+            },
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.5 + HL * 2.0,
+                w: LIGHT,
+                h: 0.5 - HL * 2.0,
+            },
+        ],
+        // ╩ Double horizontal and up
+        0x2569 => rects![
+            hline_full(HL),
+            CustomRect {
+                x: 0.5 - HL,
+                y: 0.0,
+                w: LIGHT,
+                h: 0.5 - HL * 2.0 + LIGHT,
+            },
+            CustomRect {
+                x: 0.0,
+                y: 0.5 - HL - LIGHT,
+                w: 1.0,
+                h: LIGHT,
+            },
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.0,
+                w: LIGHT,
+                h: 0.5 - HL * 2.0 + LIGHT,
+            },
+        ],
+        // ╬ Double vertical and horizontal
+        0x256C => rects![
+            vline(0.0, 0.5 - HL - LIGHT, HL),
+            vline(0.5 + HL + LIGHT, 1.0, HL),
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.0,
+                w: LIGHT,
+                h: 0.5 - HL - LIGHT,
+            },
+            CustomRect {
+                x: 0.5 + HL * 2.0,
+                y: 0.5 + HL + LIGHT,
+                w: LIGHT,
+                h: 0.5 - HL - LIGHT,
+            },
+            hline(0.0, 0.5 - HL - LIGHT, HL),
+            hline(0.5 + HL + LIGHT, 1.0, HL),
+            CustomRect {
+                x: 0.0,
+                y: 0.5 + HL * 2.0,
+                w: 0.5 - HL - LIGHT,
+                h: LIGHT,
+            },
+            CustomRect {
+                x: 0.5 + HL + LIGHT,
+                y: 0.5 + HL * 2.0,
+                w: 0.5 - HL - LIGHT,
+                h: LIGHT,
+            },
+        ],
+
+        // =================================================================
+        // BOX DRAWING — Rounded corners (approximated as right angles)
+        // =================================================================
+
+        // ╭ Arc down and right
+        0x256D => rects![hline(0.5, 1.0, HL), vline(0.5, 1.0, HL)],
+        // ╮ Arc down and left
+        0x256E => rects![hline(0.0, 0.5 + HL, HL), vline(0.5, 1.0, HL)],
+        // ╯ Arc up and left
+        0x256F => rects![hline(0.0, 0.5 + HL, HL), vline(0.0, 0.5 + HL, HL)],
+        // ╰ Arc up and right
+        0x2570 => rects![hline(0.5, 1.0, HL), vline(0.0, 0.5 + HL, HL)],
+
+        // =================================================================
+        // BLOCK ELEMENTS
+        // =================================================================
+
+        // ▀ Upper half block
+        0x2580 => rects![block(0.0, 0.0, 1.0, 0.5)],
+        // ▁ Lower one eighth block
+        0x2581 => rects![block(0.0, 7.0 / 8.0, 1.0, 1.0 / 8.0)],
+        // ▂ Lower one quarter block
+        0x2582 => rects![block(0.0, 6.0 / 8.0, 1.0, 2.0 / 8.0)],
+        // ▃ Lower three eighths block
+        0x2583 => rects![block(0.0, 5.0 / 8.0, 1.0, 3.0 / 8.0)],
+        // ▄ Lower half block
+        0x2584 => rects![block(0.0, 0.5, 1.0, 0.5)],
+        // ▅ Lower five eighths block
+        0x2585 => rects![block(0.0, 3.0 / 8.0, 1.0, 5.0 / 8.0)],
+        // ▆ Lower three quarters block
+        0x2586 => rects![block(0.0, 2.0 / 8.0, 1.0, 6.0 / 8.0)],
+        // ▇ Lower seven eighths block
+        0x2587 => rects![block(0.0, 1.0 / 8.0, 1.0, 7.0 / 8.0)],
+        // █ Full block
+        0x2588 => rects![block(0.0, 0.0, 1.0, 1.0)],
+        // ▉ Left seven eighths block
+        0x2589 => rects![block(0.0, 0.0, 7.0 / 8.0, 1.0)],
+        // ▊ Left three quarters block
+        0x258A => rects![block(0.0, 0.0, 6.0 / 8.0, 1.0)],
+        // ▋ Left five eighths block
+        0x258B => rects![block(0.0, 0.0, 5.0 / 8.0, 1.0)],
+        // ▌ Left half block
+        0x258C => rects![block(0.0, 0.0, 0.5, 1.0)],
+        // ▍ Left three eighths block
+        0x258D => rects![block(0.0, 0.0, 3.0 / 8.0, 1.0)],
+        // ▎ Left one quarter block
+        0x258E => rects![block(0.0, 0.0, 2.0 / 8.0, 1.0)],
+        // ▏ Left one eighth block
+        0x258F => rects![block(0.0, 0.0, 1.0 / 8.0, 1.0)],
+        // ▐ Right half block
+        0x2590 => rects![block(0.5, 0.0, 0.5, 1.0)],
+
+        // ▔ Upper one eighth block
+        0x2594 => rects![block(0.0, 0.0, 1.0, 1.0 / 8.0)],
+        // ▕ Right one eighth block
+        0x2595 => rects![block(7.0 / 8.0, 0.0, 1.0 / 8.0, 1.0)],
+
+        // Quadrant blocks
+        // ▖ Quadrant lower left
+        0x2596 => rects![block(0.0, 0.5, 0.5, 0.5)],
+        // ▗ Quadrant lower right
+        0x2597 => rects![block(0.5, 0.5, 0.5, 0.5)],
+        // ▘ Quadrant upper left
+        0x2598 => rects![block(0.0, 0.0, 0.5, 0.5)],
+        // ▙ Quadrant upper left and lower left and lower right
+        0x2599 => rects![block(0.0, 0.0, 0.5, 0.5), block(0.0, 0.5, 1.0, 0.5),],
+        // ▚ Quadrant upper left and lower right
+        0x259A => rects![block(0.0, 0.0, 0.5, 0.5), block(0.5, 0.5, 0.5, 0.5)],
+        // ▛ Quadrant upper left and upper right and lower left
+        0x259B => rects![block(0.0, 0.0, 1.0, 0.5), block(0.0, 0.5, 0.5, 0.5),],
+        // ▜ Quadrant upper left and upper right and lower right
+        0x259C => rects![block(0.0, 0.0, 1.0, 0.5), block(0.5, 0.5, 0.5, 0.5),],
+        // ▝ Quadrant upper right
+        0x259D => rects![block(0.5, 0.0, 0.5, 0.5)],
+        // ▞ Quadrant upper right and lower left
+        0x259E => rects![block(0.5, 0.0, 0.5, 0.5), block(0.0, 0.5, 0.5, 0.5)],
+        // ▟ Quadrant upper right and lower left and lower right
+        0x259F => rects![block(0.5, 0.0, 0.5, 0.5), block(0.0, 0.5, 1.0, 0.5),],
+
+        // =================================================================
+        // SHADE CHARACTERS
+        // =================================================================
+        // ░ ▒ ▓ — rendered as full-cell blocks with reduced alpha.
+        // We approximate by using partial coverage patterns, but since our
+        // rendering path uses opaque rectangles, we use a checkerboard-like
+        // approximation: horizontal stripes.
+        // For now, render as full blocks (the alpha will be handled by the
+        // caller if needed, or we can revisit with a proper dithering approach).
+
+        // ░ Light shade (25%)
+        0x2591 => rects![
+            block(0.0, 0.0 / 4.0, 1.0, 0.5 / 4.0),
+            block(0.0, 1.0 / 4.0, 1.0, 0.5 / 4.0),
+            block(0.0, 2.0 / 4.0, 1.0, 0.5 / 4.0),
+            block(0.0, 3.0 / 4.0, 1.0, 0.5 / 4.0),
+        ],
+        // ▒ Medium shade (50%)
+        0x2592 => rects![
+            block(0.0, 0.0, 1.0, 1.0 / 8.0),
+            block(0.0, 2.0 / 8.0, 1.0, 1.0 / 8.0),
+            block(0.0, 4.0 / 8.0, 1.0, 1.0 / 8.0),
+            block(0.0, 6.0 / 8.0, 1.0, 1.0 / 8.0),
+        ],
+        // ▓ Dark shade (75%)
+        0x2593 => rects![block(0.0, 0.0, 1.0, 1.0)],
+
+        _ => None,
+    }
+}

--- a/crates/amux-render-gpu/src/custom_glyphs.rs
+++ b/crates/amux-render-gpu/src/custom_glyphs.rs
@@ -578,29 +578,33 @@ pub fn custom_glyph_rects(ch: char) -> Option<&'static [CustomRect]> {
         // =================================================================
         // SHADE CHARACTERS
         // =================================================================
-        // ░ ▒ ▓ — rendered as full-cell blocks with reduced alpha.
-        // We approximate by using partial coverage patterns, but since our
-        // rendering path uses opaque rectangles, we use a checkerboard-like
-        // approximation: horizontal stripes.
-        // For now, render as full blocks (the alpha will be handled by the
-        // caller if needed, or we can revisit with a proper dithering approach).
+        // ░ ▒ ▓ — shade characters approximated with horizontal stripes.
+        // True shade rendering needs alpha blending (shader support); we
+        // approximate coverage by distributing opaque stripe area across
+        // the cell. This is a known limitation — results are banded rather
+        // than uniformly dithered.
 
-        // ░ Light shade (25%)
+        // ░ Light shade (~25% coverage: 4 thin stripes)
         0x2591 => rects![
-            block(0.0, 0.0 / 4.0, 1.0, 0.5 / 4.0),
-            block(0.0, 1.0 / 4.0, 1.0, 0.5 / 4.0),
-            block(0.0, 2.0 / 4.0, 1.0, 0.5 / 4.0),
-            block(0.0, 3.0 / 4.0, 1.0, 0.5 / 4.0),
+            block(0.0, 0.0 / 4.0, 1.0, 1.0 / 16.0),
+            block(0.0, 1.0 / 4.0, 1.0, 1.0 / 16.0),
+            block(0.0, 2.0 / 4.0, 1.0, 1.0 / 16.0),
+            block(0.0, 3.0 / 4.0, 1.0, 1.0 / 16.0),
         ],
-        // ▒ Medium shade (50%)
+        // ▒ Medium shade (~50% coverage: 4 medium stripes)
         0x2592 => rects![
-            block(0.0, 0.0, 1.0, 1.0 / 8.0),
-            block(0.0, 2.0 / 8.0, 1.0, 1.0 / 8.0),
-            block(0.0, 4.0 / 8.0, 1.0, 1.0 / 8.0),
-            block(0.0, 6.0 / 8.0, 1.0, 1.0 / 8.0),
+            block(0.0, 0.0 / 4.0, 1.0, 1.0 / 8.0),
+            block(0.0, 1.0 / 4.0, 1.0, 1.0 / 8.0),
+            block(0.0, 2.0 / 4.0, 1.0, 1.0 / 8.0),
+            block(0.0, 3.0 / 4.0, 1.0, 1.0 / 8.0),
         ],
-        // ▓ Dark shade (75%)
-        0x2593 => rects![block(0.0, 0.0, 1.0, 1.0)],
+        // ▓ Dark shade (~75% coverage: full cell minus thin gaps)
+        0x2593 => rects![
+            block(0.0, 0.0, 1.0, 3.0 / 16.0),
+            block(0.0, 1.0 / 4.0, 1.0, 3.0 / 16.0),
+            block(0.0, 2.0 / 4.0, 1.0, 3.0 / 16.0),
+            block(0.0, 3.0 / 4.0, 1.0, 3.0 / 16.0),
+        ],
 
         _ => None,
     }

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -1,5 +1,6 @@
 mod atlas;
 mod callback;
+mod custom_glyphs;
 mod pipeline;
 pub mod snapshot;
 
@@ -56,7 +57,9 @@ impl GpuRenderer {
         // Measure cell dimensions via cosmic-text (same approach as amux-render-soft).
         let line_height = (font_size * 1.3).ceil();
         let metrics = Metrics::new(font_size, line_height);
-        let cell_width = measure_cell_width(&mut font_system, metrics);
+        // Ceil cell width to an integer pixel to prevent hairline gaps between
+        // adjacent cells caused by fractional coordinates accumulating rounding errors.
+        let cell_width = measure_cell_width(&mut font_system, metrics).ceil();
         let cell_height = line_height;
 
         // Register resources in egui's callback_resources.

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -142,7 +142,7 @@ impl GpuRenderer {
             .callback_resources
             .get_mut::<TerminalGpuResources>()
         {
-            let cell_width = measure_cell_width(&mut r.font_system, metrics);
+            let cell_width = measure_cell_width(&mut r.font_system, metrics).ceil();
             r.metrics = metrics;
             // Clear all pane render states to force full rebuild with new metrics.
             r.pane_states.clear();

--- a/crates/amux-render-soft/src/lib.rs
+++ b/crates/amux-render-soft/src/lib.rs
@@ -44,7 +44,7 @@ impl SoftRenderer {
         let line_height = (font_size * 1.3).ceil();
         let metrics = Metrics::new(font_size, line_height);
 
-        let cell_width = measure_cell_width(&mut font_system, metrics);
+        let cell_width = measure_cell_width(&mut font_system, metrics).ceil();
         let cell_height = line_height;
 
         Self {

--- a/crates/amux-term/src/config.rs
+++ b/crates/amux-term/src/config.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use wezterm_term::color::ColorPalette;
+use wezterm_term::color::{ColorPalette, RgbColor, SrgbaTuple};
 use wezterm_term::config::{BidiMode, NewlineCanon};
 use wezterm_term::TerminalConfiguration;
 
@@ -17,11 +17,52 @@ pub struct AmuxTermConfig {
     pub enable_kitty_keyboard: bool,
 }
 
+/// Build a color palette using standard xterm ANSI colors (0-15).
+/// wezterm-term's default palette uses softer, more pastel colors that make
+/// reds look pinkish. This overrides with the widely-expected xterm defaults.
+fn default_palette() -> ColorPalette {
+    let mut palette = ColorPalette::default();
+
+    // Standard xterm ANSI colors (same as iTerm2, Terminal.app, Ghostty defaults)
+    let xterm_ansi: [(u8, u8, u8); 16] = [
+        (0x00, 0x00, 0x00), // 0  Black
+        (0xcd, 0x00, 0x00), // 1  Red
+        (0x00, 0xcd, 0x00), // 2  Green
+        (0xcd, 0xcd, 0x00), // 3  Yellow
+        (0x00, 0x00, 0xee), // 4  Blue
+        (0xcd, 0x00, 0xcd), // 5  Magenta
+        (0x00, 0xcd, 0xcd), // 6  Cyan
+        (0xe5, 0xe5, 0xe5), // 7  White
+        (0x7f, 0x7f, 0x7f), // 8  Bright Black (Grey)
+        (0xff, 0x00, 0x00), // 9  Bright Red
+        (0x00, 0xff, 0x00), // 10 Bright Green
+        (0xff, 0xff, 0x00), // 11 Bright Yellow
+        (0x5c, 0x5c, 0xff), // 12 Bright Blue
+        (0xff, 0x00, 0xff), // 13 Bright Magenta
+        (0x00, 0xff, 0xff), // 14 Bright Cyan
+        (0xff, 0xff, 0xff), // 15 Bright White
+    ];
+
+    for (i, (r, g, b)) in xterm_ansi.iter().enumerate() {
+        palette.colors.0[i] = RgbColor::new_8bpc(*r, *g, *b).into();
+    }
+
+    // Use a lighter default foreground (standard xterm white-ish grey)
+    palette.foreground = SrgbaTuple(
+        0xe5 as f32 / 255.0,
+        0xe5 as f32 / 255.0,
+        0xe5 as f32 / 255.0,
+        1.0,
+    );
+
+    palette
+}
+
 impl Default for AmuxTermConfig {
     fn default() -> Self {
         Self {
             scrollback_lines: 10_000,
-            color_palette: ColorPalette::default(),
+            color_palette: default_palette(),
             enable_kitty_keyboard: true,
         }
     }


### PR DESCRIPTION
## Summary
- Override wezterm's pastel ANSI palette with standard xterm colors (fixes reds appearing too pink)
- Ceil cell width to integer pixels to prevent fractional coordinate gaps between adjacent cells
- Batch consecutive same-color background cells into spans, eliminating hairline gaps between cell backgrounds
- Add procedural rendering for ~100 box-drawing (U+2500–U+256C), block-element (U+2580–U+259F), and shade characters as pixel-aligned rectangles, bypassing font glyphs entirely for seamless line connections

## Test plan
- [ ] Verify ANSI colors match xterm defaults (red should be `#cd0000`, not pinkish)
- [ ] Confirm no visible gaps between adjacent cells with same background color
- [ ] Test box-drawing characters render seamlessly: `┌──┬──┐`, `╔══╦══╗`, `╭──╮`
- [ ] Test block elements render edge-to-edge: `▀▄█▌▐`
- [ ] Verify `cargo build --no-default-features` (soft renderer fallback) still builds
- [ ] Run `cargo clippy --workspace -- -D warnings` and `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Procedural rendering for box-drawing, block and shade characters using optimized rectangle shapes for crisper, consistent glyphs.

* **Improvements**
  * Adjacent cell backgrounds merged into wider row spans to reduce rendering work.
  * Custom-rendered glyphs are honored in both full and appearance-only updates, skipping normal font shaping when used.
  * Cell width rounding tightened for more consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->