### PR TITLE
Tab/workspace renaming, visual tab improvements, and terminal polish

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -64,6 +64,12 @@ fn get_cwd_from_pid(pid: u32) -> Option<String> {
 const DEFAULT_FONT_SIZE: f32 = 14.0;
 const DEFAULT_SIDEBAR_WIDTH: f32 = 200.0;
 const TAB_BAR_HEIGHT: f32 = 24.0;
+/// Visual padding below the terminal grid (does not reduce PTY rows).
+/// Painted with TERMINAL_BG so it blends with the terminal background.
+const TERMINAL_BOTTOM_PAD: f32 = 4.0;
+/// Default terminal background color, used for padding strips and unfilled areas.
+/// Will be replaced by palette-based color when color scheme config is added.
+const TERMINAL_BG: egui::Color32 = egui::Color32::from_gray(0);
 
 // ---------------------------------------------------------------------------
 // App config (loaded from ~/.config/amux/config.toml)
@@ -1359,7 +1365,7 @@ impl eframe::App for AmuxApp {
                     // Zoomed mode: render single pane fullscreen
                     let content_rect = egui::Rect::from_min_max(
                         egui::pos2(panel_rect.min.x, panel_rect.min.y + TAB_BAR_HEIGHT),
-                        panel_rect.max,
+                        egui::pos2(panel_rect.max.x, panel_rect.max.y - TERMINAL_BOTTOM_PAD),
                     );
                     let sel_changed = self.handle_selection_mouse(ui, zoomed_id, content_rect);
                     if sel_changed {
@@ -1395,7 +1401,7 @@ impl eframe::App for AmuxApp {
                         if id == focused {
                             let content_rect = egui::Rect::from_min_max(
                                 egui::pos2(rect.min.x, rect.min.y + TAB_BAR_HEIGHT),
-                                rect.max,
+                                egui::pos2(rect.max.x, rect.max.y - TERMINAL_BOTTOM_PAD),
                             );
                             let sel_changed = self.handle_selection_mouse(ui, id, content_rect);
                             if sel_changed {
@@ -1511,7 +1517,16 @@ impl AmuxApp {
             egui::Rect::from_min_size(rect.min, egui::vec2(rect.width(), TAB_BAR_HEIGHT));
         let content_rect = egui::Rect::from_min_max(
             egui::pos2(rect.min.x, rect.min.y + TAB_BAR_HEIGHT),
-            rect.max,
+            egui::pos2(rect.max.x, rect.max.y - TERMINAL_BOTTOM_PAD),
+        );
+        // Paint bottom padding strip with terminal background color.
+        ui.painter().rect_filled(
+            egui::Rect::from_min_max(
+                egui::pos2(rect.min.x, rect.max.y - TERMINAL_BOTTOM_PAD),
+                rect.max,
+            ),
+            0.0,
+            TERMINAL_BG,
         );
 
         {
@@ -1958,9 +1973,8 @@ impl AmuxApp {
     fn resize_pane_if_needed(&mut self, id: PaneId, rect: egui::Rect, ui: &egui::Ui) {
         let (cell_width, cell_height) = self.cell_dimensions(ui);
 
-        // Account for tab bar height (always shown) and a 1-row bottom margin
-        // that acts as visual padding below terminal content.
-        let content_height = rect.height() - TAB_BAR_HEIGHT - cell_height;
+        // Account for tab bar height (always shown) and visual bottom padding.
+        let content_height = rect.height() - TAB_BAR_HEIGHT - TERMINAL_BOTTOM_PAD;
 
         let cols = (rect.width() / cell_width).floor() as usize;
         let rows = (content_height / cell_height).floor() as usize;
@@ -2740,8 +2754,7 @@ impl AmuxApp {
             let cols = dim_cols.max(1) as f32;
             let rows = dim_rows.max(1) as f32;
             let cell_w = pane_rect.width() / cols;
-            // Use content area minus 1-row bottom margin, matching resize_pane_if_needed.
-            let cell_h = (pane_rect.height() - TAB_BAR_HEIGHT) / (rows + 1.0);
+            let cell_h = (pane_rect.height() - TAB_BAR_HEIGHT - TERMINAL_BOTTOM_PAD) / rows;
             let x = pane_rect.min.x + cursor.x as f32 * cell_w;
             let y = pane_rect.min.y + TAB_BAR_HEIGHT + cursor.y as f32 * cell_h;
             ctx.send_viewport_cmd(egui::ViewportCommand::IMERect(egui::Rect::from_min_size(
@@ -2779,8 +2792,7 @@ impl AmuxApp {
             let cols = dim_cols.max(1) as f32;
             let rows = dim_rows.max(1) as f32;
             let cell_w = pane_rect.width() / cols;
-            // Use content area minus 1-row bottom margin, matching resize_pane_if_needed.
-            let cell_h = (pane_rect.height() - TAB_BAR_HEIGHT) / (rows + 1.0);
+            let cell_h = (pane_rect.height() - TAB_BAR_HEIGHT - TERMINAL_BOTTOM_PAD) / rows;
             let x = pane_rect.min.x + cursor.x as f32 * cell_w;
             let y = pane_rect.min.y + TAB_BAR_HEIGHT + cursor.y as f32 * cell_h;
 

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -957,9 +957,11 @@ struct AmuxApp {
 }
 
 /// What is being renamed — workspace or tab (surface).
+/// Uses stable IDs rather than indices so background reorder/close can't
+/// cause the modal to rename the wrong item.
 enum RenameTarget {
-    Workspace(usize),
-    Tab { pane_id: PaneId, surface_idx: usize },
+    Workspace(u64),
+    Tab { pane_id: PaneId, surface_id: u64 },
 }
 
 struct RenameModal {
@@ -1296,8 +1298,9 @@ impl eframe::App for AmuxApp {
                     }
                     sidebar::SidebarAction::StartRenameWorkspace(idx) => {
                         if idx < self.workspaces.len() {
+                            let ws_id = self.workspaces[idx].id;
                             self.rename_modal = Some(RenameModal {
-                                target: RenameTarget::Workspace(idx),
+                                target: RenameTarget::Workspace(ws_id),
                                 buf: self.workspaces[idx].title.clone(),
                                 just_opened: true,
                             });
@@ -1768,7 +1771,9 @@ impl AmuxApp {
                 }
                 let managed = self.panes.get_mut(&pane_id).unwrap();
                 managed.surfaces.remove(idx);
-                if managed.active_surface_idx >= managed.surfaces.len() {
+                if idx < managed.active_surface_idx {
+                    managed.active_surface_idx -= 1;
+                } else if managed.active_surface_idx >= managed.surfaces.len() {
                     managed.active_surface_idx = managed.surfaces.len() - 1;
                 }
             } else if let Some(idx) = switch_to {
@@ -1788,7 +1793,7 @@ impl AmuxApp {
                         self.rename_modal = Some(RenameModal {
                             target: RenameTarget::Tab {
                                 pane_id,
-                                surface_idx: idx,
+                                surface_id: surface.id,
                             },
                             buf: current_title,
                             just_opened: true,
@@ -2124,6 +2129,11 @@ impl AmuxApp {
     // --- Shortcuts ---
 
     fn handle_shortcuts(&mut self, ctx: &egui::Context) -> bool {
+        // Skip terminal shortcuts when a modal text field has focus — let egui
+        // handle Cmd+V, Cmd+C, etc. for the text widget instead.
+        if self.rename_modal.is_some() || self.find_state.is_some() {
+            return false;
+        }
         let events = ctx.input(|i| i.events.clone());
 
         for event in &events {
@@ -2730,7 +2740,8 @@ impl AmuxApp {
             let cols = dim_cols.max(1) as f32;
             let rows = dim_rows.max(1) as f32;
             let cell_w = pane_rect.width() / cols;
-            let cell_h = (pane_rect.height() - TAB_BAR_HEIGHT) / rows;
+            // Use content area minus 1-row bottom margin, matching resize_pane_if_needed.
+            let cell_h = (pane_rect.height() - TAB_BAR_HEIGHT) / (rows + 1.0);
             let x = pane_rect.min.x + cursor.x as f32 * cell_w;
             let y = pane_rect.min.y + TAB_BAR_HEIGHT + cursor.y as f32 * cell_h;
             ctx.send_viewport_cmd(egui::ViewportCommand::IMERect(egui::Rect::from_min_size(
@@ -2768,7 +2779,8 @@ impl AmuxApp {
             let cols = dim_cols.max(1) as f32;
             let rows = dim_rows.max(1) as f32;
             let cell_w = pane_rect.width() / cols;
-            let cell_h = (pane_rect.height() - TAB_BAR_HEIGHT) / rows;
+            // Use content area minus 1-row bottom margin, matching resize_pane_if_needed.
+            let cell_h = (pane_rect.height() - TAB_BAR_HEIGHT) / (rows + 1.0);
             let x = pane_rect.min.x + cursor.x as f32 * cell_w;
             let y = pane_rect.min.y + TAB_BAR_HEIGHT + cursor.y as f32 * cell_h;
 
@@ -3154,21 +3166,23 @@ impl AmuxApp {
         if let Some(new_name) = apply {
             if !new_name.is_empty() {
                 match &self.rename_modal.as_ref().unwrap().target {
-                    RenameTarget::Workspace(idx) => {
-                        let idx = *idx;
-                        if idx < self.workspaces.len() {
-                            self.workspaces[idx].title = new_name;
+                    RenameTarget::Workspace(ws_id) => {
+                        let ws_id = *ws_id;
+                        if let Some(ws) = self.workspaces.iter_mut().find(|w| w.id == ws_id) {
+                            ws.title = new_name;
                         }
                     }
                     RenameTarget::Tab {
                         pane_id,
-                        surface_idx,
+                        surface_id,
                     } => {
                         let pane_id = *pane_id;
-                        let surface_idx = *surface_idx;
+                        let surface_id = *surface_id;
                         if let Some(managed) = self.panes.get_mut(&pane_id) {
-                            if surface_idx < managed.surfaces.len() {
-                                managed.surfaces[surface_idx].user_title = Some(new_name);
+                            if let Some(surface) =
+                                managed.surfaces.iter_mut().find(|s| s.id == surface_id)
+                            {
+                                surface.user_title = Some(new_name);
                             }
                         }
                     }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -61,7 +61,7 @@ fn get_cwd_from_pid(pid: u32) -> Option<String> {
     None
 }
 
-const DEFAULT_FONT_SIZE: f32 = 12.0;
+const DEFAULT_FONT_SIZE: f32 = 14.0;
 const DEFAULT_SIDEBAR_WIDTH: f32 = 200.0;
 const TAB_BAR_HEIGHT: f32 = 24.0;
 
@@ -273,6 +273,7 @@ fn main() -> anyhow::Result<()> {
                 ime_preedit: None,
                 selection_changed: false,
                 tab_drag: None,
+                rename_modal: None,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
             }))
@@ -334,9 +335,6 @@ fn fresh_startup(
         sidebar: SidebarState {
             visible: true,
             width: DEFAULT_SIDEBAR_WIDTH,
-            renaming: None,
-            rename_buf: String::new(),
-            rename_just_opened: false,
             drag: None,
         },
         notifications: NotificationStore::new(),
@@ -380,6 +378,7 @@ fn restore_session(
                         surface.metadata.pr_number = saved_sf.pr_number;
                         surface.metadata.pr_title = saved_sf.pr_title.clone();
                         surface.metadata.pr_state = saved_sf.pr_state.clone();
+                        surface.user_title = saved_sf.user_title.clone();
                         surfaces.push(surface);
                     }
                     Err(e) => {
@@ -459,9 +458,6 @@ fn restore_session(
     let sidebar = SidebarState {
         visible: session.sidebar.visible,
         width: session.sidebar.width,
-        renaming: None,
-        rename_buf: String::new(),
-        rename_just_opened: false,
         drag: None,
     };
 
@@ -682,6 +678,8 @@ struct PaneSurface {
     scroll_offset: usize,
     scroll_accum: f32,
     metadata: SurfaceMetadata,
+    /// User-set title override. When set, takes precedence over OSC 0/2 title.
+    user_title: Option<String>,
 }
 
 /// A leaf in the split tree. Each pane has its own tab bar with surfaces.
@@ -717,12 +715,6 @@ pub(crate) struct Workspace {
 pub(crate) struct SidebarState {
     pub(crate) visible: bool,
     pub(crate) width: f32,
-    /// When set, the workspace at this index is being renamed in-place.
-    pub(crate) renaming: Option<usize>,
-    /// Buffer for the in-progress rename text.
-    pub(crate) rename_buf: String,
-    /// True on the first frame after rename starts (to skip focus-loss exit).
-    pub(crate) rename_just_opened: bool,
     /// Drag reorder state.
     pub(crate) drag: Option<SidebarDragState>,
 }
@@ -925,6 +917,7 @@ fn spawn_surface(
         scroll_offset: 0,
         scroll_accum: 0.0,
         metadata,
+        user_title: None,
     })
 }
 
@@ -957,8 +950,22 @@ struct AmuxApp {
     selection_changed: bool,
     /// Drag state for tab reordering within a pane.
     tab_drag: Option<TabDragState>,
+    /// Rename modal state for workspaces and tabs.
+    rename_modal: Option<RenameModal>,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
+}
+
+/// What is being renamed — workspace or tab (surface).
+enum RenameTarget {
+    Workspace(usize),
+    Tab { pane_id: PaneId, surface_idx: usize },
+}
+
+struct RenameModal {
+    target: RenameTarget,
+    buf: String,
+    just_opened: bool,
 }
 
 struct TabDragState {
@@ -1074,6 +1081,7 @@ impl AmuxApp {
                                 pr_number: sf.metadata.pr_number,
                                 pr_title: sf.metadata.pr_title.clone(),
                                 pr_state: sf.metadata.pr_state.clone(),
+                                user_title: sf.user_title.clone(),
                             }
                         })
                         .collect();
@@ -1246,7 +1254,11 @@ impl eframe::App for AmuxApp {
         // Handle keyboard/paste input -> focused pane's active surface only
         // (blocked during copy mode — all keys go through handle_copy_mode_key)
         let mut sent_input = false;
-        if !shortcut_consumed && self.copy_mode.is_none() {
+        if !shortcut_consumed
+            && self.copy_mode.is_none()
+            && self.rename_modal.is_none()
+            && self.find_state.is_none()
+        {
             sent_input = self.handle_input(ctx);
         }
 
@@ -1282,9 +1294,13 @@ impl eframe::App for AmuxApp {
                     sidebar::SidebarAction::CloseWorkspace(idx) => {
                         self.close_workspace_at(idx);
                     }
-                    sidebar::SidebarAction::RenameWorkspace(idx, new_name) => {
+                    sidebar::SidebarAction::StartRenameWorkspace(idx) => {
                         if idx < self.workspaces.len() {
-                            self.workspaces[idx].title = new_name;
+                            self.rename_modal = Some(RenameModal {
+                                target: RenameTarget::Workspace(idx),
+                                buf: self.workspaces[idx].title.clone(),
+                                just_opened: true,
+                            });
                         }
                     }
                     sidebar::SidebarAction::MarkWorkspaceRead(idx) => {
@@ -1402,7 +1418,7 @@ impl eframe::App for AmuxApp {
                     }
                 }
 
-                ui.allocate_rect(panel_rect, egui::Sense::click_and_drag());
+                ui.allocate_rect(panel_rect, egui::Sense::hover());
             });
 
         // Notification panel overlay
@@ -1413,6 +1429,11 @@ impl eframe::App for AmuxApp {
         // Find bar overlay
         if self.find_state.is_some() {
             self.render_find_bar(ctx);
+        }
+
+        // Rename modal
+        if self.rename_modal.is_some() {
+            self.render_rename_modal(ctx);
         }
 
         // Hyperlink hover detection + Cmd+click handling
@@ -1501,19 +1522,25 @@ impl AmuxApp {
             // Get pointer state for hover detection and drag
             let hover_pos = ui.input(|i| i.pointer.hover_pos());
             let primary_pressed = ui.input(|i| i.pointer.primary_pressed());
+
             let any_released = ui.input(|i| i.pointer.any_released());
             let primary_down = ui.input(|i| i.pointer.primary_down());
             let interact_pos = ui.input(|i| i.pointer.interact_pos());
 
             // Track actions to apply after rendering
             let mut switch_to: Option<usize> = None;
+
             let mut close_tab: Option<usize> = None;
             let mut tab_rects: Vec<egui::Rect> = Vec::new();
             let mut drag_start: Option<usize> = None;
+            let mut start_rename_tab: Option<usize> = None;
 
             for (idx, surface) in managed.surfaces.iter().enumerate() {
                 let is_active = idx == active_idx;
-                let raw_title = surface.pane.title();
+                let raw_title = surface
+                    .user_title
+                    .as_deref()
+                    .unwrap_or_else(|| surface.pane.title());
                 let label = if raw_title.is_empty() {
                     format!("tab {}", surface.id)
                 } else if raw_title.chars().count() > 20 {
@@ -1526,7 +1553,7 @@ impl AmuxApp {
                 let text_galley =
                     painter.layout_no_wrap(label.clone(), tab_font.clone(), egui::Color32::WHITE);
                 let text_width = text_galley.size().x;
-                let tab_w = text_width + 24.0;
+                let tab_w = (text_width + 24.0).max(120.0);
 
                 let this_tab = egui::Rect::from_min_size(
                     egui::pos2(x, tab_rect.min.y),
@@ -1536,15 +1563,24 @@ impl AmuxApp {
 
                 let tab_hovered = hover_pos.is_some_and(|p| this_tab.contains(p));
 
-                // Tab background
+                // Tab background + border
+                let border_color = egui::Color32::from_gray(55);
                 if is_active {
                     painter.rect_filled(this_tab, 0.0, egui::Color32::from_gray(50));
-                    let underline = egui::Rect::from_min_size(
-                        egui::pos2(x, tab_rect.max.y - 2.0),
+                    // Active highlight at the top
+                    let topline = egui::Rect::from_min_size(
+                        egui::pos2(x, tab_rect.min.y),
                         egui::vec2(tab_w, 2.0),
                     );
-                    painter.rect_filled(underline, 0.0, egui::Color32::from_rgb(80, 140, 220));
+                    painter.rect_filled(topline, 0.0, egui::Color32::from_rgb(80, 140, 220));
                 }
+                // 1px border around each tab
+                painter.rect_stroke(
+                    this_tab,
+                    0.0,
+                    egui::Stroke::new(1.0, border_color),
+                    egui::StrokeKind::Outside,
+                );
 
                 let text_color = if is_active {
                     egui::Color32::WHITE
@@ -1571,6 +1607,20 @@ impl AmuxApp {
                     };
                     sidebar::paint_close_x(painter, close_center, 3.5, close_color);
                 }
+
+                // Right-click context menu
+                let tab_id = ui.id().with("tab_ctx").with(pane_id).with(idx);
+                let tab_response = ui.interact(this_tab, tab_id, egui::Sense::click());
+                tab_response.context_menu(|ui| {
+                    if ui.button("Rename Tab").clicked() {
+                        start_rename_tab = Some(idx);
+                        ui.close_menu();
+                    }
+                    if ui.button("Close Tab").clicked() {
+                        close_tab = Some(idx);
+                        ui.close_menu();
+                    }
+                });
 
                 // Hit testing (primary button only)
                 if primary_pressed {
@@ -1724,6 +1774,27 @@ impl AmuxApp {
             } else if let Some(idx) = switch_to {
                 let managed = self.panes.get_mut(&pane_id).unwrap();
                 managed.active_surface_idx = idx;
+            }
+
+            // Open rename modal for tab
+            if let Some(idx) = start_rename_tab {
+                if let Some(managed) = self.panes.get(&pane_id) {
+                    if idx < managed.surfaces.len() {
+                        let surface = &managed.surfaces[idx];
+                        let current_title = surface
+                            .user_title
+                            .clone()
+                            .unwrap_or_else(|| surface.pane.title().to_string());
+                        self.rename_modal = Some(RenameModal {
+                            target: RenameTarget::Tab {
+                                pane_id,
+                                surface_idx: idx,
+                            },
+                            buf: current_title,
+                            just_opened: true,
+                        });
+                    }
+                }
             }
         }
 
@@ -1882,8 +1953,9 @@ impl AmuxApp {
     fn resize_pane_if_needed(&mut self, id: PaneId, rect: egui::Rect, ui: &egui::Ui) {
         let (cell_width, cell_height) = self.cell_dimensions(ui);
 
-        // Account for tab bar height (always shown)
-        let content_height = rect.height() - TAB_BAR_HEIGHT;
+        // Account for tab bar height (always shown) and a 1-row bottom margin
+        // that acts as visual padding below terminal content.
+        let content_height = rect.height() - TAB_BAR_HEIGHT - cell_height;
 
         let cols = (rect.width() / cell_width).floor() as usize;
         let rows = (content_height / cell_height).floor() as usize;
@@ -3032,6 +3104,80 @@ impl AmuxApp {
         // Trim trailing whitespace per line
         let trimmed: Vec<&str> = result.lines().map(|l| l.trim_end()).collect();
         Some(trimmed.join("\n"))
+    }
+
+    fn render_rename_modal(&mut self, ctx: &egui::Context) {
+        let mut apply: Option<String> = None;
+        let mut cancel = false;
+
+        let title = match &self.rename_modal.as_ref().unwrap().target {
+            RenameTarget::Workspace(_) => "Rename Workspace",
+            RenameTarget::Tab { .. } => "Rename Tab",
+        };
+
+        let modal = self.rename_modal.as_mut().unwrap();
+        let just_opened = modal.just_opened;
+
+        egui::Window::new(title)
+            .collapsible(false)
+            .resizable(false)
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .fixed_size([280.0, 0.0])
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Name:");
+                    let response = ui.text_edit_singleline(&mut modal.buf);
+                    if just_opened {
+                        response.request_focus();
+                        modal.just_opened = false;
+                    }
+                    if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                        apply = Some(modal.buf.trim().to_string());
+                    }
+                });
+                ui.add_space(4.0);
+                ui.horizontal(|ui| {
+                    if ui.button("OK").clicked() {
+                        apply = Some(modal.buf.trim().to_string());
+                    }
+                    if ui.button("Cancel").clicked() {
+                        cancel = true;
+                    }
+                });
+            });
+
+        // Also close on Escape
+        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+            cancel = true;
+        }
+
+        if let Some(new_name) = apply {
+            if !new_name.is_empty() {
+                match &self.rename_modal.as_ref().unwrap().target {
+                    RenameTarget::Workspace(idx) => {
+                        let idx = *idx;
+                        if idx < self.workspaces.len() {
+                            self.workspaces[idx].title = new_name;
+                        }
+                    }
+                    RenameTarget::Tab {
+                        pane_id,
+                        surface_idx,
+                    } => {
+                        let pane_id = *pane_id;
+                        let surface_idx = *surface_idx;
+                        if let Some(managed) = self.panes.get_mut(&pane_id) {
+                            if surface_idx < managed.surfaces.len() {
+                                managed.surfaces[surface_idx].user_title = Some(new_name);
+                            }
+                        }
+                    }
+                }
+            }
+            self.rename_modal = None;
+        } else if cancel {
+            self.rename_modal = None;
+        }
     }
 
     fn render_find_bar(&mut self, ctx: &egui::Context) {

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -68,7 +68,7 @@ pub(crate) enum SidebarAction {
     SwitchWorkspace(usize),
     CreateWorkspace,
     CloseWorkspace(usize),
-    RenameWorkspace(usize, String),
+    StartRenameWorkspace(usize),
     MarkWorkspaceRead(usize),
     ReorderWorkspace(usize, usize),
     SetWorkspaceColor(usize, Option<[u8; 4]>),
@@ -303,7 +303,6 @@ fn render_workspace_row(
     let has_agent_message = status.as_ref().and_then(|s| s.message.as_ref()).is_some();
     let latest_notif = notifications.latest_for_workspace(ws.id);
     let has_notif_text = !has_agent_message && latest_notif.is_some_and(|n| !n.body.is_empty());
-    let is_renaming = state.renaming == Some(idx);
     let has_color = ws.color.is_some();
     let has_git_or_cwd = metadata.is_some_and(|m| m.git_branch.is_some() || m.cwd.is_some());
     let has_pr = metadata.is_some_and(|m| m.pr_number.is_some());
@@ -344,7 +343,7 @@ fn render_workspace_row(
     let hovered = response.hovered();
 
     // --- Drag initiation ---
-    if response.drag_started() && state.drag.is_none() && !is_renaming {
+    if response.drag_started() && state.drag.is_none() {
         state.drag = Some(SidebarDragState {
             source_idx: idx,
             current_y: rect.center().y,
@@ -362,9 +361,7 @@ fn render_workspace_row(
     // --- Context menu ---
     response.context_menu(|ui| {
         if ui.button("Rename Workspace").clicked() {
-            state.renaming = Some(idx);
-            state.rename_buf = ws.title.clone();
-            state.rename_just_opened = true;
+            actions.push(SidebarAction::StartRenameWorkspace(idx));
             ui.close_menu();
         }
         if ui.button("Close Workspace").clicked() {
@@ -434,50 +431,14 @@ fn render_workspace_row(
 
     let close_btn_reserve = CLOSE_BTN_SIZE + 4.0;
     let badge_reserve = BADGE_RADIUS * 2.0 + 4.0;
-    let right_reserve = if hovered && !is_renaming {
+    let right_reserve = if hovered {
         close_btn_reserve
     } else {
         badge_reserve
     };
     let max_title_w = avail_w - content_left - ROW_H_PAD - right_reserve;
 
-    if is_renaming {
-        let title_rect = egui::Rect::from_min_size(
-            rect.min + egui::vec2(content_left, ROW_V_PAD),
-            egui::vec2(max_title_w, title_line_h),
-        );
-        let rename_id = ui.id().with("rename").with(idx);
-        let mut text_edit = egui::TextEdit::singleline(&mut state.rename_buf)
-            .id(rename_id)
-            .font(egui::FontId::proportional(TITLE_FONT_SIZE))
-            .text_color(title_color)
-            .desired_width(max_title_w)
-            .frame(false);
-        text_edit = text_edit.background_color(Color32::from_rgba_premultiplied(0, 0, 0, 180));
-
-        let te_response = ui.put(title_rect, text_edit);
-        if !te_response.has_focus() {
-            te_response.request_focus();
-        }
-
-        let confirmed = ui.input(|i| i.key_pressed(egui::Key::Enter));
-        let cancelled = ui.input(|i| i.key_pressed(egui::Key::Escape));
-
-        let lost_focus = !te_response.has_focus() && !state.rename_just_opened;
-        state.rename_just_opened = false;
-
-        if confirmed || (lost_focus && !cancelled) {
-            let new_name = state.rename_buf.trim().to_string();
-            if !new_name.is_empty() && new_name != ws.title {
-                actions.push(SidebarAction::RenameWorkspace(idx, new_name));
-            }
-            state.renaming = None;
-            state.rename_buf.clear();
-        } else if cancelled {
-            state.renaming = None;
-            state.rename_buf.clear();
-        }
-    } else {
+    {
         let title_pos = rect.min + egui::vec2(content_left, ROW_V_PAD);
         let title_font = egui::FontId::proportional(TITLE_FONT_SIZE);
         // Show agent task as title if available, with star prefix like cmux.
@@ -502,7 +463,7 @@ fn render_workspace_row(
     // --- Close button on hover (replaces badge) or badge/count ---
     let badge_center_y = rect.min.y + ROW_V_PAD + title_line_h / 2.0;
 
-    if hovered && !is_renaming {
+    if hovered {
         let btn_center = egui::pos2(
             rect.right() - ROW_H_PAD - CLOSE_BTN_SIZE / 2.0,
             badge_center_y,
@@ -706,7 +667,7 @@ fn render_workspace_row(
     }
 
     // --- Click to switch workspace or mark read ---
-    if response.clicked() && !is_renaming {
+    if response.clicked() {
         if is_active {
             actions.push(SidebarAction::MarkWorkspaceRead(idx));
         } else {

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -283,6 +283,18 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_without_user_title_defaults_to_none() {
+        // Simulate an older session file that predates the user_title field.
+        let json = r#"{
+            "id": 0, "title": "zsh", "working_dir": "/tmp", "scrollback": "",
+            "cols": 80, "rows": 24, "git_branch": null, "git_dirty": false,
+            "pr_number": null, "pr_title": null, "pr_state": null
+        }"#;
+        let surface: SavedSurface = serde_json::from_str(json).unwrap();
+        assert!(surface.user_title.is_none());
+    }
+
+    #[test]
     fn load_rejects_empty_workspaces() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("session.json");

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -62,6 +62,8 @@ pub struct SavedSurface {
     pub pr_title: Option<String>,
     #[serde(default)]
     pub pr_state: Option<String>,
+    #[serde(default)]
+    pub user_title: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -189,6 +191,7 @@ mod tests {
                     pr_number: None,
                     pr_title: None,
                     pr_state: None,
+                    user_title: None,
                 }],
                 active_surface_idx: 0,
             },


### PR DESCRIPTION
## Summary
- Right-click context menu on tabs (Rename Tab, Close Tab) using egui's native `context_menu()`
- Modal rename dialog for both workspaces and tabs, with keyboard focus isolation (typing in modal no longer leaks to terminal)
- User-set tab titles persist via `user_title` field on `SavedSurface` with serde default
- Bump default font size from 12pt to 14pt
- Add 1-row clean buffer at bottom of terminal
- Minimum tab width of 120pt to match cmux
- 1px tab borders with `from_gray(55)` for visual distinction
- Active tab highlight moved from bottom to top of tab

## Test plan
- [ ] Right-click on a tab → context menu appears with Rename Tab / Close Tab
- [ ] Rename Tab → modal opens, typing stays in modal, Enter applies, Escape cancels
- [ ] Right-click workspace in sidebar → Rename Workspace → modal works the same way
- [ ] Renamed tabs persist across session save/restore
- [ ] Terminal bottom has 1 row of clean padding
- [ ] Tabs have visible 1px borders and minimum 120pt width
- [ ] Active tab has blue highlight at top edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)