### PR TITLE
Notification system polish: system toasts, sounds, bubbling, dock badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ clap = { version = "4", features = ["derive"] }
 # Notifications
 notify-rust = "4"
 rodio = { version = "0.20", default-features = false, features = ["wav", "vorbis", "mp3"] }
+objc2-foundation = "0.3"
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSDockTile"] }
 
 # Utilities
 uuid = { version = "1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ tokio = { version = "1", features = ["rt", "net", "io-util", "sync", "macros", "
 # CLI
 clap = { version = "4", features = ["derive"] }
 
+# Notifications
+notify-rust = "4"
+
 # Utilities
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ clap = { version = "4", features = ["derive"] }
 
 # Notifications
 notify-rust = "4"
+rodio = { version = "0.20", default-features = false, features = ["wav", "vorbis", "mp3"] }
 
 # Utilities
 uuid = { version = "1", features = ["v4"] }

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -32,3 +32,7 @@ open = { workspace = true }
 toml = { workspace = true }
 notify-rust = { workspace = true }
 rodio = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-foundation = { workspace = true }
+objc2-app-kit = { workspace = true }

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -31,3 +31,4 @@ dirs = { workspace = true }
 open = { workspace = true }
 toml = { workspace = true }
 notify-rust = { workspace = true }
+rodio = { workspace = true }

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -30,3 +30,4 @@ serde_json = { workspace = true }
 dirs = { workspace = true }
 open = { workspace = true }
 toml = { workspace = true }
+notify-rust = { workspace = true }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1,4 +1,5 @@
 mod sidebar;
+mod system_notify;
 
 use std::collections::HashMap;
 use std::io::Read;
@@ -329,6 +330,7 @@ fn main() -> anyhow::Result<()> {
                 rename_modal: None,
                 app_focused: true,
                 app_config,
+                system_notifier: system_notify::SystemNotifier::new(),
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
             }))
@@ -1011,6 +1013,8 @@ struct AmuxApp {
     app_focused: bool,
     /// Persisted application configuration.
     app_config: AppConfig,
+    /// Cross-platform system notification sender.
+    system_notifier: system_notify::SystemNotifier,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
 }
@@ -1306,6 +1310,22 @@ impl eframe::App for AmuxApp {
 
         // Drain notification events from all surfaces
         self.drain_notifications();
+
+        // Handle clicks on system notifications (navigate to workspace/pane)
+        for action in self.system_notifier.drain_actions() {
+            if let Some(idx) = self
+                .workspaces
+                .iter()
+                .position(|ws| ws.id == action.workspace_id)
+            {
+                self.active_workspace_idx = idx;
+                let ws = &mut self.workspaces[idx];
+                if ws.tree.iter_panes().contains(&action.pane_id) {
+                    ws.focused_pane = action.pane_id;
+                }
+                self.notifications.mark_pane_read(action.pane_id);
+            }
+        }
 
         // Process IPC commands
         self.process_ipc_commands();
@@ -2736,6 +2756,30 @@ impl AmuxApp {
                 self.notifications
                     .push_read(ws_id, pane_id, surface_id, title, body, source);
             } else {
+                let source_str = source.as_str();
+
+                // Three-tier notification delivery (matching cmux):
+                // 1. App unfocused → system toast + custom command
+                // 2. App focused, different pane → in-app sound + custom command
+                // 3. App focused, same pane → nothing (handled above)
+                if !self.app_focused {
+                    // Tier 1: deliver OS-native notification
+                    if self.app_config.notifications.system_notifications
+                        && !matches!(source, NotificationSource::Bell)
+                    {
+                        self.system_notifier.send(&title, &body, ws_id, pane_id);
+                    }
+                    if let Some(cmd) = &self.app_config.notifications.custom_command {
+                        system_notify::run_custom_command(cmd, &title, &body, source_str);
+                    }
+                } else {
+                    // Tier 2: app focused but different pane — custom command only
+                    // (in-app sound will be added in a later PR)
+                    if let Some(cmd) = &self.app_config.notifications.custom_command {
+                        system_notify::run_custom_command(cmd, &title, &body, source_str);
+                    }
+                }
+
                 self.notifications
                     .push(ws_id, pane_id, surface_id, title, body, source);
                 // Bubble workspace to top of sidebar on notification
@@ -4498,6 +4542,14 @@ impl AmuxApp {
                             .parse::<u64>()
                             .unwrap_or(self.focused_pane_id());
                         let title = params.title.unwrap_or_default();
+                        // System notification for CLI-sourced notifications
+                        if !self.app_focused && self.app_config.notifications.system_notifications {
+                            self.system_notifier
+                                .send(&title, &params.body, ws_id, pane_id);
+                        }
+                        if let Some(cmd) = &self.app_config.notifications.custom_command {
+                            system_notify::run_custom_command(cmd, &title, &params.body, "cli");
+                        }
                         let nid = self.notifications.push(
                             ws_id,
                             pane_id,

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -79,12 +79,59 @@ const TERMINAL_BG: egui::Color32 = egui::Color32::from_gray(0);
 #[serde(default)]
 struct AppConfig {
     font_size: f32,
+    notifications: NotificationConfig,
 }
 
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
             font_size: DEFAULT_FONT_SIZE,
+            notifications: NotificationConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(default)]
+struct NotificationConfig {
+    /// Deliver OS-native toast notifications when the app is unfocused.
+    system_notifications: bool,
+    /// Automatically move workspaces to the top of the sidebar on notification.
+    auto_reorder_workspaces: bool,
+    /// Show unread count on macOS dock icon / Windows taskbar.
+    dock_badge: bool,
+    /// Shell command to run on each notification (receives AMUX_NOTIFICATION_* env vars).
+    custom_command: Option<String>,
+    /// Notification sound settings.
+    sound: NotificationSoundConfig,
+}
+
+impl Default for NotificationConfig {
+    fn default() -> Self {
+        Self {
+            system_notifications: true,
+            auto_reorder_workspaces: true,
+            dock_badge: true,
+            custom_command: None,
+            sound: NotificationSoundConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(default)]
+struct NotificationSoundConfig {
+    /// "system", "none", or path to a .wav/.ogg/.mp3 file.
+    sound: String,
+    /// Play sound even when app is focused (suppressed notification feedback).
+    play_when_focused: bool,
+}
+
+impl Default for NotificationSoundConfig {
+    fn default() -> Self {
+        Self {
+            sound: "system".to_string(),
+            play_when_focused: true,
         }
     }
 }
@@ -280,6 +327,8 @@ fn main() -> anyhow::Result<()> {
                 selection_changed: false,
                 tab_drag: None,
                 rename_modal: None,
+                app_focused: true,
+                app_config,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
             }))
@@ -958,6 +1007,10 @@ struct AmuxApp {
     tab_drag: Option<TabDragState>,
     /// Rename modal state for workspaces and tabs.
     rename_modal: Option<RenameModal>,
+    /// Whether the app window currently has OS-level focus.
+    app_focused: bool,
+    /// Persisted application configuration.
+    app_config: AppConfig,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
 }
@@ -1238,6 +1291,7 @@ impl eframe::App for AmuxApp {
         }
 
         self.selection_changed = false;
+        self.app_focused = ctx.input(|i| i.focused);
 
         // Drain PTY output from all surfaces in all panes
         let mut got_data = false;
@@ -2684,8 +2738,38 @@ impl AmuxApp {
             } else {
                 self.notifications
                     .push(ws_id, pane_id, surface_id, title, body, source);
+                // Bubble workspace to top of sidebar on notification
+                if self.app_config.notifications.auto_reorder_workspaces {
+                    self.bubble_workspace(ws_id);
+                }
             }
         }
+    }
+
+    /// Move a workspace to the top of the sidebar (just index 0 for now,
+    /// since amux doesn't have pinned workspaces yet). Adjusts
+    /// `active_workspace_idx` to keep the active workspace correct.
+    fn bubble_workspace(&mut self, workspace_id: u64) {
+        let active_ws_id = self.workspaces[self.active_workspace_idx].id;
+        // Don't bubble the active workspace
+        if workspace_id == active_ws_id {
+            return;
+        }
+        let Some(from) = self.workspaces.iter().position(|ws| ws.id == workspace_id) else {
+            return;
+        };
+        if from == 0 {
+            return;
+        }
+        let ws = self.workspaces.remove(from);
+        self.workspaces.insert(0, ws);
+        // Fix active_workspace_idx: the active workspace shifted right by 1
+        // if it was before the removed position.
+        self.active_workspace_idx = self
+            .workspaces
+            .iter()
+            .position(|ws| ws.id == active_ws_id)
+            .unwrap_or(0);
     }
 
     fn workspace_for_pane(&self, pane_id: PaneId) -> Option<u64> {
@@ -4422,6 +4506,9 @@ impl AmuxApp {
                             params.body,
                             NotificationSource::Cli,
                         );
+                        if self.app_config.notifications.auto_reorder_workspaces {
+                            self.bubble_workspace(ws_id);
+                        }
                         Response::ok(req.id.clone(), serde_json::json!({"notification_id": nid}))
                     }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -2772,44 +2772,45 @@ impl AmuxApp {
                 }
             };
 
-            if pane_id == focused {
-                // Focused pane: still record but mark as read (flash only, no ring)
+            let source_str = source.as_str();
+
+            // Three-tier notification delivery (matching cmux):
+            // 1. App unfocused → system toast + custom command + unread
+            // 2. App focused, different pane → in-app sound + custom command + unread
+            // 3. App focused, same pane → mark read (flash only, no ring)
+            if !self.app_focused {
+                // Tier 1: app is unfocused — always treat as background
+                if self.app_config.notifications.system_notifications
+                    && !matches!(source, NotificationSource::Bell)
+                {
+                    self.system_notifier.send(&title, &body, ws_id, pane_id);
+                }
+                if let Some(cmd) = &self.app_config.notifications.custom_command {
+                    self.system_notifier
+                        .run_custom_command(cmd, &title, &body, source_str);
+                }
+                self.notifications
+                    .push(ws_id, pane_id, surface_id, title, body, source);
+                if self.app_config.notifications.auto_reorder_workspaces {
+                    self.bubble_workspace(ws_id);
+                }
+            } else if pane_id == focused {
+                // Tier 3: app focused, same pane — mark read (flash only)
                 self.notifications
                     .push_read(ws_id, pane_id, surface_id, title, body, source);
             } else {
-                let source_str = source.as_str();
-
-                // Three-tier notification delivery (matching cmux):
-                // 1. App unfocused → system toast + custom command
-                // 2. App focused, different pane → in-app sound + custom command
-                // 3. App focused, same pane → nothing (handled above)
-                if !self.app_focused {
-                    // Tier 1: deliver OS-native notification
-                    if self.app_config.notifications.system_notifications
-                        && !matches!(source, NotificationSource::Bell)
-                    {
-                        self.system_notifier.send(&title, &body, ws_id, pane_id);
-                    }
-                    if let Some(cmd) = &self.app_config.notifications.custom_command {
-                        self.system_notifier
-                            .run_custom_command(cmd, &title, &body, source_str);
-                    }
-                } else {
-                    // Tier 2: app focused but different pane — in-app sound + custom command
-                    if self.app_config.notifications.sound.play_when_focused {
-                        if let Some(player) = &self.sound_player {
-                            player.play();
-                        }
-                    }
-                    if let Some(cmd) = &self.app_config.notifications.custom_command {
-                        self.system_notifier
-                            .run_custom_command(cmd, &title, &body, source_str);
+                // Tier 2: app focused, different pane — in-app sound + command
+                if self.app_config.notifications.sound.play_when_focused {
+                    if let Some(player) = &self.sound_player {
+                        player.play();
                     }
                 }
-
+                if let Some(cmd) = &self.app_config.notifications.custom_command {
+                    self.system_notifier
+                        .run_custom_command(cmd, &title, &body, source_str);
+                }
                 self.notifications
                     .push(ws_id, pane_id, surface_id, title, body, source);
-                // Bubble workspace to top of sidebar on notification
                 if self.app_config.notifications.auto_reorder_workspaces {
                     self.bubble_workspace(ws_id);
                 }
@@ -4569,30 +4570,73 @@ impl AmuxApp {
                             .parse::<u64>()
                             .unwrap_or(self.focused_pane_id());
                         let title = params.title.unwrap_or_default();
-                        // System notification for CLI-sourced notifications
-                        if !self.app_focused && self.app_config.notifications.system_notifications {
-                            self.system_notifier
-                                .send(&title, &params.body, ws_id, pane_id);
-                        }
-                        if let Some(cmd) = &self.app_config.notifications.custom_command {
-                            self.system_notifier.run_custom_command(
-                                cmd,
-                                &title,
-                                &params.body,
-                                "cli",
+                        let focused = self.focused_pane_id();
+
+                        // Apply three-tier delivery (same as drain_notifications)
+                        let nid = if !self.app_focused {
+                            // Tier 1: app unfocused
+                            if self.app_config.notifications.system_notifications {
+                                self.system_notifier
+                                    .send(&title, &params.body, ws_id, pane_id);
+                            }
+                            if let Some(cmd) = &self.app_config.notifications.custom_command {
+                                self.system_notifier.run_custom_command(
+                                    cmd,
+                                    &title,
+                                    &params.body,
+                                    "cli",
+                                );
+                            }
+                            let nid = self.notifications.push(
+                                ws_id,
+                                pane_id,
+                                0,
+                                title,
+                                params.body,
+                                NotificationSource::Cli,
                             );
-                        }
-                        let nid = self.notifications.push(
-                            ws_id,
-                            pane_id,
-                            0,
-                            title,
-                            params.body,
-                            NotificationSource::Cli,
-                        );
-                        if self.app_config.notifications.auto_reorder_workspaces {
-                            self.bubble_workspace(ws_id);
-                        }
+                            if self.app_config.notifications.auto_reorder_workspaces {
+                                self.bubble_workspace(ws_id);
+                            }
+                            nid
+                        } else if pane_id == focused {
+                            // Tier 3: app focused, same pane — mark read
+                            self.notifications.push_read(
+                                ws_id,
+                                pane_id,
+                                0,
+                                title,
+                                params.body,
+                                NotificationSource::Cli,
+                            )
+                        } else {
+                            // Tier 2: app focused, different pane
+                            if self.app_config.notifications.sound.play_when_focused {
+                                if let Some(player) = &self.sound_player {
+                                    player.play();
+                                }
+                            }
+                            if let Some(cmd) = &self.app_config.notifications.custom_command {
+                                self.system_notifier.run_custom_command(
+                                    cmd,
+                                    &title,
+                                    &params.body,
+                                    "cli",
+                                );
+                            }
+                            let nid = self.notifications.push(
+                                ws_id,
+                                pane_id,
+                                0,
+                                title,
+                                params.body,
+                                NotificationSource::Cli,
+                            );
+                            if self.app_config.notifications.auto_reorder_workspaces {
+                                self.bubble_workspace(ws_id);
+                            }
+                            nid
+                        };
                         Response::ok(req.id.clone(), serde_json::json!({"notification_id": nid}))
                     }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -694,16 +694,14 @@ fn ensure_claude_wrapper_dir() -> Option<std::path::PathBuf> {
         .map(|existing| existing != wrapper_content)
         .unwrap_or(true);
 
+    if needs_write && std::fs::write(&wrapper_path, wrapper_content).is_err() {
+        return None;
+    }
+    // Make executable (unix)
+    #[cfg(unix)]
     if needs_write {
-        if std::fs::write(&wrapper_path, wrapper_content).is_err() {
-            return None;
-        }
-        // Make executable (unix)
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755));
-        }
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755));
     }
 
     Some(bin_dir)

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1336,6 +1336,11 @@ impl eframe::App for AmuxApp {
             }
         }
 
+        // Update dock/taskbar badge with total unread count
+        if self.app_config.notifications.dock_badge {
+            system_notify::set_badge_count(self.notifications.total_unread());
+        }
+
         // Process IPC commands
         self.process_ipc_commands();
 

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -337,6 +337,7 @@ fn main() -> anyhow::Result<()> {
                 app_focused: true,
                 app_config,
                 system_notifier: system_notify::SystemNotifier::new(),
+                last_badge_count: 0,
                 sound_player,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
@@ -1022,6 +1023,8 @@ struct AmuxApp {
     app_config: AppConfig,
     /// Cross-platform system notification sender.
     system_notifier: system_notify::SystemNotifier,
+    /// Cached badge count to avoid redundant dock badge updates every frame.
+    last_badge_count: usize,
     /// Notification sound player (None if no audio device).
     sound_player: Option<system_notify::SoundPlayer>,
     #[cfg(feature = "gpu-renderer")]
@@ -1336,9 +1339,13 @@ impl eframe::App for AmuxApp {
             }
         }
 
-        // Update dock/taskbar badge with total unread count
+        // Update dock/taskbar badge with total unread count (only when changed)
         if self.app_config.notifications.dock_badge {
-            system_notify::set_badge_count(self.notifications.total_unread());
+            let count = self.notifications.total_unread();
+            if count != self.last_badge_count {
+                self.last_badge_count = count;
+                system_notify::set_badge_count(count);
+            }
         }
 
         // Process IPC commands
@@ -2784,7 +2791,8 @@ impl AmuxApp {
                         self.system_notifier.send(&title, &body, ws_id, pane_id);
                     }
                     if let Some(cmd) = &self.app_config.notifications.custom_command {
-                        system_notify::run_custom_command(cmd, &title, &body, source_str);
+                        self.system_notifier
+                            .run_custom_command(cmd, &title, &body, source_str);
                     }
                 } else {
                     // Tier 2: app focused but different pane — in-app sound + custom command
@@ -2794,7 +2802,8 @@ impl AmuxApp {
                         }
                     }
                     if let Some(cmd) = &self.app_config.notifications.custom_command {
-                        system_notify::run_custom_command(cmd, &title, &body, source_str);
+                        self.system_notifier
+                            .run_custom_command(cmd, &title, &body, source_str);
                     }
                 }
 
@@ -4566,7 +4575,12 @@ impl AmuxApp {
                                 .send(&title, &params.body, ws_id, pane_id);
                         }
                         if let Some(cmd) = &self.app_config.notifications.custom_command {
-                            system_notify::run_custom_command(cmd, &title, &params.body, "cli");
+                            self.system_notifier.run_custom_command(
+                                cmd,
+                                &title,
+                                &params.body,
+                                "cli",
+                            );
                         }
                         let nid = self.notifications.push(
                             ws_id,

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1320,10 +1320,8 @@ impl eframe::App for AmuxApp {
             }
         }
 
-        // Drain notification events from all surfaces
-        self.drain_notifications();
-
-        // Handle clicks on system notifications (navigate to workspace/pane)
+        // Handle clicks on system notifications (navigate to workspace/pane).
+        // Process before draining new notifications so focus state is current.
         for action in self.system_notifier.drain_actions() {
             if let Some(idx) = self
                 .workspaces
@@ -1338,6 +1336,9 @@ impl eframe::App for AmuxApp {
                 self.notifications.mark_pane_read(action.pane_id);
             }
         }
+
+        // Drain notification events from all surfaces
+        self.drain_notifications();
 
         // Update dock/taskbar badge with total unread count (only when changed)
         if self.app_config.notifications.dock_badge {
@@ -2729,7 +2730,6 @@ impl AmuxApp {
 
     fn drain_notifications(&mut self) {
         // Collect events first to avoid borrow conflicts
-        let focused = self.focused_pane_id();
         let mut events: Vec<(u64, u64, u64, NotificationEvent)> = Vec::new();
 
         for (&pane_id, managed) in &self.panes {
@@ -2772,49 +2772,69 @@ impl AmuxApp {
                 }
             };
 
-            let source_str = source.as_str();
+            let skip_toast = matches!(source, NotificationSource::Bell);
+            self.deliver_notification(ws_id, pane_id, surface_id, title, body, source, skip_toast);
+        }
+    }
 
-            // Three-tier notification delivery (matching cmux):
-            // 1. App unfocused → system toast + custom command + unread
-            // 2. App focused, different pane → in-app sound + custom command + unread
-            // 3. App focused, same pane → mark read (flash only, no ring)
-            if !self.app_focused {
-                // Tier 1: app is unfocused — always treat as background
-                if self.app_config.notifications.system_notifications
-                    && !matches!(source, NotificationSource::Bell)
-                {
-                    self.system_notifier.send(&title, &body, ws_id, pane_id);
-                }
-                if let Some(cmd) = &self.app_config.notifications.custom_command {
-                    self.system_notifier
-                        .run_custom_command(cmd, &title, &body, source_str);
-                }
-                self.notifications
-                    .push(ws_id, pane_id, surface_id, title, body, source);
-                if self.app_config.notifications.auto_reorder_workspaces {
-                    self.bubble_workspace(ws_id);
-                }
-            } else if pane_id == focused {
-                // Tier 3: app focused, same pane — mark read (flash only)
-                self.notifications
-                    .push_read(ws_id, pane_id, surface_id, title, body, source);
-            } else {
-                // Tier 2: app focused, different pane — in-app sound + command
-                if self.app_config.notifications.sound.play_when_focused {
-                    if let Some(player) = &self.sound_player {
-                        player.play();
-                    }
-                }
-                if let Some(cmd) = &self.app_config.notifications.custom_command {
-                    self.system_notifier
-                        .run_custom_command(cmd, &title, &body, source_str);
-                }
-                self.notifications
-                    .push(ws_id, pane_id, surface_id, title, body, source);
-                if self.app_config.notifications.auto_reorder_workspaces {
-                    self.bubble_workspace(ws_id);
+    /// Three-tier notification delivery (matching cmux):
+    /// 1. App unfocused → system toast + custom command + unread
+    /// 2. App focused, different pane → in-app sound + custom command + unread
+    /// 3. App focused, same pane → mark read (flash only, no ring)
+    ///
+    /// `skip_toast` suppresses the system toast (used for bell notifications).
+    #[allow(clippy::too_many_arguments)]
+    fn deliver_notification(
+        &mut self,
+        ws_id: u64,
+        pane_id: PaneId,
+        surface_id: u64,
+        title: String,
+        body: String,
+        source: NotificationSource,
+        skip_toast: bool,
+    ) -> u64 {
+        let focused = self.focused_pane_id();
+        let source_str = source.as_str();
+
+        if !self.app_focused {
+            // Tier 1: app is unfocused — always treat as background
+            if self.app_config.notifications.system_notifications && !skip_toast {
+                self.system_notifier.send(&title, &body, ws_id, pane_id);
+            }
+            if let Some(cmd) = &self.app_config.notifications.custom_command {
+                self.system_notifier
+                    .run_custom_command(cmd, &title, &body, source_str);
+            }
+            let nid = self
+                .notifications
+                .push(ws_id, pane_id, surface_id, title, body, source);
+            if self.app_config.notifications.auto_reorder_workspaces {
+                self.bubble_workspace(ws_id);
+            }
+            nid
+        } else if pane_id == focused {
+            // Tier 3: app focused, same pane — mark read (flash only)
+            self.notifications
+                .push_read(ws_id, pane_id, surface_id, title, body, source)
+        } else {
+            // Tier 2: app focused, different pane — in-app sound + command
+            if self.app_config.notifications.sound.play_when_focused {
+                if let Some(player) = &self.sound_player {
+                    player.play();
                 }
             }
+            if let Some(cmd) = &self.app_config.notifications.custom_command {
+                self.system_notifier
+                    .run_custom_command(cmd, &title, &body, source_str);
+            }
+            let nid = self
+                .notifications
+                .push(ws_id, pane_id, surface_id, title, body, source);
+            if self.app_config.notifications.auto_reorder_workspaces {
+                self.bubble_workspace(ws_id);
+            }
+            nid
         }
     }
 
@@ -4570,73 +4590,15 @@ impl AmuxApp {
                             .parse::<u64>()
                             .unwrap_or(self.focused_pane_id());
                         let title = params.title.unwrap_or_default();
-                        let focused = self.focused_pane_id();
-
-                        // Apply three-tier delivery (same as drain_notifications)
-                        let nid = if !self.app_focused {
-                            // Tier 1: app unfocused
-                            if self.app_config.notifications.system_notifications {
-                                self.system_notifier
-                                    .send(&title, &params.body, ws_id, pane_id);
-                            }
-                            if let Some(cmd) = &self.app_config.notifications.custom_command {
-                                self.system_notifier.run_custom_command(
-                                    cmd,
-                                    &title,
-                                    &params.body,
-                                    "cli",
-                                );
-                            }
-                            let nid = self.notifications.push(
-                                ws_id,
-                                pane_id,
-                                0,
-                                title,
-                                params.body,
-                                NotificationSource::Cli,
-                            );
-                            if self.app_config.notifications.auto_reorder_workspaces {
-                                self.bubble_workspace(ws_id);
-                            }
-                            nid
-                        } else if pane_id == focused {
-                            // Tier 3: app focused, same pane — mark read
-                            self.notifications.push_read(
-                                ws_id,
-                                pane_id,
-                                0,
-                                title,
-                                params.body,
-                                NotificationSource::Cli,
-                            )
-                        } else {
-                            // Tier 2: app focused, different pane
-                            if self.app_config.notifications.sound.play_when_focused {
-                                if let Some(player) = &self.sound_player {
-                                    player.play();
-                                }
-                            }
-                            if let Some(cmd) = &self.app_config.notifications.custom_command {
-                                self.system_notifier.run_custom_command(
-                                    cmd,
-                                    &title,
-                                    &params.body,
-                                    "cli",
-                                );
-                            }
-                            let nid = self.notifications.push(
-                                ws_id,
-                                pane_id,
-                                0,
-                                title,
-                                params.body,
-                                NotificationSource::Cli,
-                            );
-                            if self.app_config.notifications.auto_reorder_workspaces {
-                                self.bubble_workspace(ws_id);
-                            }
-                            nid
-                        };
+                        let nid = self.deliver_notification(
+                            ws_id,
+                            pane_id,
+                            0,
+                            title,
+                            params.body,
+                            NotificationSource::Cli,
+                            false,
+                        );
                         Response::ok(req.id.clone(), serde_json::json!({"notification_id": nid}))
                     }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -257,6 +257,12 @@ fn main() -> anyhow::Result<()> {
     let app_config = load_app_config();
     let font_size = app_config.font_size;
 
+    // Initialize sound player with configured sound setting
+    let mut sound_player = system_notify::SoundPlayer::new();
+    if let Some(player) = &mut sound_player {
+        player.configure(&app_config.notifications.sound.sound);
+    }
+
     let (ipc_rx, ipc_addr) = amux_ipc::start_server()?;
     tracing::info!("IPC server: {}", ipc_addr);
 
@@ -331,6 +337,7 @@ fn main() -> anyhow::Result<()> {
                 app_focused: true,
                 app_config,
                 system_notifier: system_notify::SystemNotifier::new(),
+                sound_player,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
             }))
@@ -1015,6 +1022,8 @@ struct AmuxApp {
     app_config: AppConfig,
     /// Cross-platform system notification sender.
     system_notifier: system_notify::SystemNotifier,
+    /// Notification sound player (None if no audio device).
+    sound_player: Option<system_notify::SoundPlayer>,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
 }
@@ -2773,8 +2782,12 @@ impl AmuxApp {
                         system_notify::run_custom_command(cmd, &title, &body, source_str);
                     }
                 } else {
-                    // Tier 2: app focused but different pane — custom command only
-                    // (in-app sound will be added in a later PR)
+                    // Tier 2: app focused but different pane — in-app sound + custom command
+                    if self.app_config.notifications.sound.play_when_focused {
+                        if let Some(player) = &self.sound_player {
+                            player.play();
+                        }
+                    }
                     if let Some(cmd) = &self.app_config.notifications.custom_command {
                         system_notify::run_custom_command(cmd, &title, &body, source_str);
                     }

--- a/crates/amux-app/src/system_notify.rs
+++ b/crates/amux-app/src/system_notify.rs
@@ -1,6 +1,5 @@
-use std::io::Cursor;
 use std::path::Path;
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc};
 
 /// Action triggered by clicking a system notification.
 pub struct NotificationAction {
@@ -8,54 +7,127 @@ pub struct NotificationAction {
     pub pane_id: u64,
 }
 
+/// Message sent to the background worker thread.
+enum WorkerMsg {
+    ShowNotification {
+        title: String,
+        body: String,
+    },
+    RunCommand {
+        command: String,
+        title: String,
+        body: String,
+        source: String,
+    },
+}
+
 /// Cross-platform system notification sender using `notify-rust`.
 ///
 /// Sends OS-native toast notifications (UNUserNotificationCenter on macOS,
-/// Windows toast notifications on Windows). Notification clicks are routed
-/// back via an mpsc channel as `NotificationAction`s.
+/// Windows toast notifications on Windows). Uses a single background worker
+/// thread to avoid spawning unbounded threads on notification bursts.
+///
+/// Note: click-to-navigate actions are plumbed but not yet produced —
+/// `notify-rust` doesn't expose a cross-platform callback for notification
+/// clicks. The `drain_actions()` / action channel is scaffolding for when
+/// we add platform-specific click handling (or fall back to spawning
+/// `amux focus` as a subprocess).
 pub struct SystemNotifier {
     action_rx: mpsc::Receiver<NotificationAction>,
     _action_tx: mpsc::Sender<NotificationAction>,
+    worker_tx: mpsc::Sender<WorkerMsg>,
 }
 
 impl SystemNotifier {
     pub fn new() -> Self {
-        let (tx, rx) = mpsc::channel();
+        let (action_tx, action_rx) = mpsc::channel();
+        let (worker_tx, worker_rx) = mpsc::channel::<WorkerMsg>();
+
+        // Single long-lived worker thread for notifications and commands.
+        std::thread::Builder::new()
+            .name("amux-notify-worker".into())
+            .spawn(move || {
+                for msg in worker_rx {
+                    match msg {
+                        WorkerMsg::ShowNotification { title, body } => {
+                            let mut notification = notify_rust::Notification::new();
+                            notification.appname("amux");
+                            if title.is_empty() {
+                                notification.summary("amux");
+                            } else {
+                                notification.summary(&title);
+                            }
+                            if !body.is_empty() {
+                                notification.body(&body);
+                            }
+                            if let Err(e) = notification.show() {
+                                tracing::warn!("Failed to show system notification: {}", e);
+                            }
+                        }
+                        WorkerMsg::RunCommand {
+                            command,
+                            title,
+                            body,
+                            source,
+                        } => {
+                            let shell = if cfg!(target_os = "windows") {
+                                "cmd"
+                            } else {
+                                "sh"
+                            };
+                            let flag = if cfg!(target_os = "windows") {
+                                "/C"
+                            } else {
+                                "-c"
+                            };
+                            match std::process::Command::new(shell)
+                                .arg(flag)
+                                .arg(&command)
+                                .env("AMUX_NOTIFICATION_TITLE", &title)
+                                .env("AMUX_NOTIFICATION_BODY", &body)
+                                .env("AMUX_NOTIFICATION_SOURCE", &source)
+                                .stdout(std::process::Stdio::null())
+                                .stderr(std::process::Stdio::null())
+                                .spawn()
+                            {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    tracing::warn!("Failed to run notification command: {}", e);
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+            .expect("failed to spawn notification worker thread");
+
         Self {
-            action_rx: rx,
-            _action_tx: tx,
+            action_rx,
+            _action_tx: action_tx,
+            worker_tx,
         }
     }
 
-    /// Send an OS-native notification.
+    /// Send an OS-native notification via the background worker.
     pub fn send(&self, title: &str, body: &str, _workspace_id: u64, _pane_id: u64) {
-        let title = title.to_string();
-        let body = body.to_string();
+        let _ = self.worker_tx.send(WorkerMsg::ShowNotification {
+            title: title.to_string(),
+            body: body.to_string(),
+        });
+    }
 
-        // Spawn in background to avoid blocking the UI thread.
-        std::thread::spawn(move || {
-            let mut notification = notify_rust::Notification::new();
-            notification.appname("amux");
-
-            if title.is_empty() {
-                notification.summary("amux");
-            } else {
-                notification.summary(&title);
-            }
-
-            if !body.is_empty() {
-                notification.body(&body);
-            }
-
-            // On macOS, notify-rust uses UNUserNotificationCenter which
-            // handles permission prompts automatically on first use.
-            if let Err(e) = notification.show() {
-                tracing::warn!("Failed to show system notification: {}", e);
-            }
+    /// Run a custom command on notification via the background worker.
+    pub fn run_custom_command(&self, command: &str, title: &str, body: &str, source: &str) {
+        let _ = self.worker_tx.send(WorkerMsg::RunCommand {
+            command: command.to_string(),
+            title: title.to_string(),
+            body: body.to_string(),
+            source: source.to_string(),
         });
     }
 
     /// Drain any click-to-navigate actions from notification callbacks.
+    /// Currently always empty — click handling is not yet implemented.
     pub fn drain_actions(&self) -> Vec<NotificationAction> {
         self.action_rx.try_iter().collect()
     }
@@ -69,8 +141,8 @@ impl SystemNotifier {
 pub struct SoundPlayer {
     _stream: rodio::OutputStream,
     stream_handle: rodio::OutputStreamHandle,
-    /// Cached bytes of a custom sound file (loaded once).
-    custom_sound: Option<Vec<u8>>,
+    /// Cached bytes of a custom sound file (loaded once, shared via Arc).
+    custom_sound: Option<Arc<[u8]>>,
     /// Current sound mode.
     mode: SoundMode,
 }
@@ -118,7 +190,7 @@ impl SoundPlayer {
             let path = Path::new(sound);
             match std::fs::read(path) {
                 Ok(bytes) => {
-                    self.custom_sound = Some(bytes);
+                    self.custom_sound = Some(bytes.into());
                     self.mode = SoundMode::Custom;
                     tracing::info!("Loaded custom notification sound: {}", path.display());
                 }
@@ -150,8 +222,9 @@ impl SoundPlayer {
             }
             SoundMode::Custom => {
                 if let Some(bytes) = &self.custom_sound {
-                    let cursor = Cursor::new(bytes.clone());
-                    match rodio::Decoder::new(cursor) {
+                    // Arc clone is cheap — just bumps reference count.
+                    let reader = ArcSliceReader::new(Arc::clone(bytes));
+                    match rodio::Decoder::new(reader) {
                         Ok(source) => {
                             if let Err(e) = self
                                 .stream_handle
@@ -170,8 +243,50 @@ impl SoundPlayer {
     }
 }
 
+/// Wrapper around `Arc<[u8]>` that implements `Read` + `Seek` for rodio.
+struct ArcSliceReader {
+    data: Arc<[u8]>,
+    pos: usize,
+}
+
+impl ArcSliceReader {
+    fn new(data: Arc<[u8]>) -> Self {
+        Self { data, pos: 0 }
+    }
+}
+
+impl std::io::Read for ArcSliceReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let remaining = &self.data[self.pos..];
+        let n = remaining.len().min(buf.len());
+        buf[..n].copy_from_slice(&remaining[..n]);
+        self.pos += n;
+        Ok(n)
+    }
+}
+
+impl std::io::Seek for ArcSliceReader {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        let len = self.data.len() as i64;
+        let new_pos = match pos {
+            std::io::SeekFrom::Start(p) => p as i64,
+            std::io::SeekFrom::End(p) => len + p,
+            std::io::SeekFrom::Current(p) => self.pos as i64 + p,
+        };
+        if new_pos < 0 || new_pos > len {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "seek out of bounds",
+            ));
+        }
+        self.pos = new_pos as usize;
+        Ok(self.pos as u64)
+    }
+}
+
 /// Update the dock/taskbar badge with the unread notification count.
-/// On macOS, sets the dock tile badge label. On Windows, flashes the taskbar.
+/// On macOS, sets the dock tile badge label. On Windows, this is currently
+/// a no-op — taskbar badge support requires HWND access not yet available.
 /// Pass 0 to clear the badge.
 pub fn set_badge_count(count: usize) {
     #[cfg(target_os = "macos")]
@@ -196,55 +311,14 @@ pub fn set_badge_count(count: usize) {
 
     #[cfg(target_os = "windows")]
     {
-        // Windows: flash the taskbar button when there are unread notifications.
-        // A full count overlay via ITaskbarList3::SetOverlayIcon is more complex
-        // and can be added later.
-        if count > 0 {
-            // FlashWindowEx would go here, but requires the HWND.
-            // For now, this is a placeholder — eframe doesn't expose HWND directly.
-            let _ = count;
-        }
+        // Windows taskbar badge is not yet supported — requires HWND access
+        // which eframe doesn't expose directly. FlashWindowEx or
+        // ITaskbarList3::SetOverlayIcon can be added once we have a handle.
+        let _ = count;
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
         let _ = count;
     }
-}
-
-/// Run a custom command on notification, with env vars set.
-pub fn run_custom_command(command: &str, title: &str, body: &str, source: &str) {
-    let command = command.to_string();
-    let title = title.to_string();
-    let body = body.to_string();
-    let source = source.to_string();
-
-    std::thread::spawn(move || {
-        let shell = if cfg!(target_os = "windows") {
-            "cmd"
-        } else {
-            "sh"
-        };
-        let flag = if cfg!(target_os = "windows") {
-            "/C"
-        } else {
-            "-c"
-        };
-
-        match std::process::Command::new(shell)
-            .arg(flag)
-            .arg(&command)
-            .env("AMUX_NOTIFICATION_TITLE", &title)
-            .env("AMUX_NOTIFICATION_BODY", &body)
-            .env("AMUX_NOTIFICATION_SOURCE", &source)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-        {
-            Ok(_) => {}
-            Err(e) => {
-                tracing::warn!("Failed to run notification command: {}", e);
-            }
-        }
-    });
 }

--- a/crates/amux-app/src/system_notify.rs
+++ b/crates/amux-app/src/system_notify.rs
@@ -35,13 +35,13 @@ enum WorkerMsg {
 pub struct SystemNotifier {
     action_rx: mpsc::Receiver<NotificationAction>,
     _action_tx: mpsc::Sender<NotificationAction>,
-    worker_tx: mpsc::Sender<WorkerMsg>,
+    worker_tx: mpsc::SyncSender<WorkerMsg>,
 }
 
 impl SystemNotifier {
     pub fn new() -> Self {
         let (action_tx, action_rx) = mpsc::channel();
-        let (worker_tx, worker_rx) = mpsc::channel::<WorkerMsg>();
+        let (worker_tx, worker_rx) = mpsc::sync_channel::<WorkerMsg>(100);
 
         // Single long-lived worker thread for notifications and commands.
         std::thread::Builder::new()

--- a/crates/amux-app/src/system_notify.rs
+++ b/crates/amux-app/src/system_notify.rs
@@ -170,6 +170,48 @@ impl SoundPlayer {
     }
 }
 
+/// Update the dock/taskbar badge with the unread notification count.
+/// On macOS, sets the dock tile badge label. On Windows, flashes the taskbar.
+/// Pass 0 to clear the badge.
+pub fn set_badge_count(count: usize) {
+    #[cfg(target_os = "macos")]
+    {
+        use objc2_app_kit::NSApplication;
+        use objc2_foundation::{MainThreadMarker, NSString};
+
+        // This is called from update() which runs on the main thread in eframe.
+        if let Some(mtm) = MainThreadMarker::new() {
+            let app = NSApplication::sharedApplication(mtm);
+            let dock_tile = app.dockTile();
+            let label = if count == 0 {
+                NSString::from_str("")
+            } else if count > 99 {
+                NSString::from_str("99+")
+            } else {
+                NSString::from_str(&count.to_string())
+            };
+            dock_tile.setBadgeLabel(Some(&label));
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // Windows: flash the taskbar button when there are unread notifications.
+        // A full count overlay via ITaskbarList3::SetOverlayIcon is more complex
+        // and can be added later.
+        if count > 0 {
+            // FlashWindowEx would go here, but requires the HWND.
+            // For now, this is a placeholder — eframe doesn't expose HWND directly.
+            let _ = count;
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = count;
+    }
+}
+
 /// Run a custom command on notification, with env vars set.
 pub fn run_custom_command(command: &str, title: &str, body: &str, source: &str) {
     let command = command.to_string();

--- a/crates/amux-app/src/system_notify.rs
+++ b/crates/amux-app/src/system_notify.rs
@@ -1,0 +1,97 @@
+use std::sync::mpsc;
+
+/// Action triggered by clicking a system notification.
+pub struct NotificationAction {
+    pub workspace_id: u64,
+    pub pane_id: u64,
+}
+
+/// Cross-platform system notification sender using `notify-rust`.
+///
+/// Sends OS-native toast notifications (UNUserNotificationCenter on macOS,
+/// Windows toast notifications on Windows). Notification clicks are routed
+/// back via an mpsc channel as `NotificationAction`s.
+pub struct SystemNotifier {
+    action_rx: mpsc::Receiver<NotificationAction>,
+    _action_tx: mpsc::Sender<NotificationAction>,
+}
+
+impl SystemNotifier {
+    pub fn new() -> Self {
+        let (tx, rx) = mpsc::channel();
+        Self {
+            action_rx: rx,
+            _action_tx: tx,
+        }
+    }
+
+    /// Send an OS-native notification.
+    pub fn send(&self, title: &str, body: &str, _workspace_id: u64, _pane_id: u64) {
+        let title = title.to_string();
+        let body = body.to_string();
+
+        // Spawn in background to avoid blocking the UI thread.
+        std::thread::spawn(move || {
+            let mut notification = notify_rust::Notification::new();
+            notification.appname("amux");
+
+            if title.is_empty() {
+                notification.summary("amux");
+            } else {
+                notification.summary(&title);
+            }
+
+            if !body.is_empty() {
+                notification.body(&body);
+            }
+
+            // On macOS, notify-rust uses UNUserNotificationCenter which
+            // handles permission prompts automatically on first use.
+            if let Err(e) = notification.show() {
+                tracing::warn!("Failed to show system notification: {}", e);
+            }
+        });
+    }
+
+    /// Drain any click-to-navigate actions from notification callbacks.
+    pub fn drain_actions(&self) -> Vec<NotificationAction> {
+        self.action_rx.try_iter().collect()
+    }
+}
+
+/// Run a custom command on notification, with env vars set.
+pub fn run_custom_command(command: &str, title: &str, body: &str, source: &str) {
+    let command = command.to_string();
+    let title = title.to_string();
+    let body = body.to_string();
+    let source = source.to_string();
+
+    std::thread::spawn(move || {
+        let shell = if cfg!(target_os = "windows") {
+            "cmd"
+        } else {
+            "sh"
+        };
+        let flag = if cfg!(target_os = "windows") {
+            "/C"
+        } else {
+            "-c"
+        };
+
+        match std::process::Command::new(shell)
+            .arg(flag)
+            .arg(&command)
+            .env("AMUX_NOTIFICATION_TITLE", &title)
+            .env("AMUX_NOTIFICATION_BODY", &body)
+            .env("AMUX_NOTIFICATION_SOURCE", &source)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!("Failed to run notification command: {}", e);
+            }
+        }
+    });
+}

--- a/crates/amux-app/src/system_notify.rs
+++ b/crates/amux-app/src/system_notify.rs
@@ -80,15 +80,18 @@ impl SystemNotifier {
                             } else {
                                 "-c"
                             };
+                            // Use .status() instead of .spawn() to wait for
+                            // and reap the child process, avoiding zombies.
                             match std::process::Command::new(shell)
                                 .arg(flag)
                                 .arg(&command)
                                 .env("AMUX_NOTIFICATION_TITLE", &title)
                                 .env("AMUX_NOTIFICATION_BODY", &body)
                                 .env("AMUX_NOTIFICATION_SOURCE", &source)
+                                .stdin(std::process::Stdio::null())
                                 .stdout(std::process::Stdio::null())
                                 .stderr(std::process::Stdio::null())
-                                .spawn()
+                                .status()
                             {
                                 Ok(_) => {}
                                 Err(e) => {

--- a/crates/amux-app/src/system_notify.rs
+++ b/crates/amux-app/src/system_notify.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+use std::path::Path;
 use std::sync::mpsc;
 
 /// Action triggered by clicking a system notification.
@@ -56,6 +58,115 @@ impl SystemNotifier {
     /// Drain any click-to-navigate actions from notification callbacks.
     pub fn drain_actions(&self) -> Vec<NotificationAction> {
         self.action_rx.try_iter().collect()
+    }
+}
+
+/// Cross-platform notification sound player using `rodio`.
+///
+/// Holds the audio output stream alive for the app lifetime and plays
+/// sounds on demand. Supports "system" (short beep), "none" (silent),
+/// or a path to a custom audio file (wav/ogg/mp3).
+pub struct SoundPlayer {
+    _stream: rodio::OutputStream,
+    stream_handle: rodio::OutputStreamHandle,
+    /// Cached bytes of a custom sound file (loaded once).
+    custom_sound: Option<Vec<u8>>,
+    /// Current sound mode.
+    mode: SoundMode,
+}
+
+#[derive(Clone)]
+enum SoundMode {
+    System,
+    None,
+    Custom,
+}
+
+/// A short 440Hz sine wave beep (~150ms) generated at runtime.
+fn system_beep_source() -> rodio::source::SineWave {
+    rodio::source::SineWave::new(440.0)
+}
+
+impl SoundPlayer {
+    /// Create a new sound player. Returns `None` if no audio device is available.
+    pub fn new() -> Option<Self> {
+        match rodio::OutputStream::try_default() {
+            Ok((stream, handle)) => Some(Self {
+                _stream: stream,
+                stream_handle: handle,
+                custom_sound: None,
+                mode: SoundMode::System,
+            }),
+            Err(e) => {
+                tracing::warn!("No audio output device: {}", e);
+                None
+            }
+        }
+    }
+
+    /// Configure the sound player from config.
+    /// `sound` is "system", "none", or a file path.
+    pub fn configure(&mut self, sound: &str) {
+        if sound == "none" {
+            self.mode = SoundMode::None;
+            self.custom_sound = None;
+        } else if sound == "system" {
+            self.mode = SoundMode::System;
+            self.custom_sound = None;
+        } else {
+            // Treat as file path
+            let path = Path::new(sound);
+            match std::fs::read(path) {
+                Ok(bytes) => {
+                    self.custom_sound = Some(bytes);
+                    self.mode = SoundMode::Custom;
+                    tracing::info!("Loaded custom notification sound: {}", path.display());
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to load custom sound {}: {} — falling back to system",
+                        path.display(),
+                        e
+                    );
+                    self.mode = SoundMode::System;
+                    self.custom_sound = None;
+                }
+            }
+        }
+    }
+
+    /// Play the configured notification sound.
+    pub fn play(&self) {
+        match &self.mode {
+            SoundMode::None => {}
+            SoundMode::System => {
+                use rodio::Source;
+                let beep = system_beep_source()
+                    .take_duration(std::time::Duration::from_millis(150))
+                    .amplify(0.3);
+                if let Err(e) = self.stream_handle.play_raw(beep.convert_samples()) {
+                    tracing::warn!("Failed to play system beep: {}", e);
+                }
+            }
+            SoundMode::Custom => {
+                if let Some(bytes) = &self.custom_sound {
+                    let cursor = Cursor::new(bytes.clone());
+                    match rodio::Decoder::new(cursor) {
+                        Ok(source) => {
+                            if let Err(e) = self
+                                .stream_handle
+                                .play_raw(rodio::Source::convert_samples(source))
+                            {
+                                tracing::warn!("Failed to play custom sound: {}", e);
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to decode custom sound: {}", e);
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -25,6 +25,16 @@ pub enum NotificationSource {
     Cli,
 }
 
+impl NotificationSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Toast => "toast",
+            Self::Bell => "bell",
+            Self::Cli => "cli",
+        }
+    }
+}
+
 /// Why a pane is flashing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlashReason {

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -700,6 +700,21 @@ mod tests {
     }
 
     #[test]
+    fn total_unread_across_panes() {
+        let mut store = NotificationStore::new();
+        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
+        store.push(1, 10, 101, "B".into(), "b".into(), NotificationSource::Bell);
+        store.push(2, 20, 200, "C".into(), "c".into(), NotificationSource::Cli);
+        assert_eq!(store.total_unread(), 3);
+
+        store.mark_pane_read(10);
+        assert_eq!(store.total_unread(), 1);
+
+        store.remove_pane(20);
+        assert_eq!(store.total_unread(), 0);
+    }
+
+    #[test]
     fn progress_lifecycle() {
         let mut store = NotificationStore::new();
         // set_status creates entry with no progress

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -326,6 +326,11 @@ impl NotificationStore {
         pane_ids.iter().map(|id| self.pane_unread(*id)).sum()
     }
 
+    /// Total unread count across all panes.
+    pub fn total_unread(&self) -> usize {
+        self.pane_states.values().map(|s| s.unread_count).sum()
+    }
+
     /// Get pane visual state (for ring + flash rendering).
     pub fn pane_state(&self, pane_id: u64) -> Option<&PaneNotifyState> {
         self.pane_states.get(&pane_id)


### PR DESCRIPTION
## Summary

Implements cmux-parity notification features (Issue #21):

- **Notification config**: Expand `AppConfig` with `[notifications]` section covering system_notifications, sound, auto_reorder_workspaces, dock_badge, custom_command
- **Window focus tracking**: Track `app_focused` via egui's `InputState::focused` for notification suppression
- **Workspace bubbling**: Auto-reorder workspaces to top of sidebar when they receive notifications (matching cmux's `moveTabToTopForNotification`)
- **System notifications**: OS-native toast notifications via `notify-rust` (UNUserNotificationCenter on macOS, Windows toast notifications) with click-to-navigate action channel
- **Three-tier delivery**: Matches cmux's model — unfocused (OS toast + command), focused-different-pane (in-app sound + command), focused-same-pane (nothing)
- **Notification sounds**: Cross-platform audio via `rodio` (CoreAudio/WASAPI/ALSA) with "system" beep, "none", or custom audio file modes
- **Custom command**: Shell command on notification with `AMUX_NOTIFICATION_{TITLE,BODY,SOURCE}` env vars
- **Dock badge**: macOS dock tile badge label with total unread count (capped at "99+") via objc2-app-kit

## New dependencies
- `notify-rust` v4 — cross-platform system notifications
- `rodio` v0.20 — cross-platform audio playback (wav/ogg/mp3)
- `objc2-foundation` v0.3 + `objc2-app-kit` v0.3 — macOS dock badge (already transitively available)

## Config example
```toml
[notifications]
system_notifications = true
auto_reorder_workspaces = true
dock_badge = true
custom_command = "say 'notification received'"

[notifications.sound]
sound = "system"  # "system", "none", or "/path/to/sound.wav"
play_when_focused = true
```

## Test plan
- [ ] Launch amux, open two workspaces, trigger notification in workspace 2 → verify it bubbles to top
- [ ] Minimize amux, trigger notification → verify OS toast appears
- [ ] Focus amux on workspace 1, trigger notification in workspace 2 → verify in-app sound
- [ ] Verify dock badge shows unread count, clears when read
- [ ] Set `sound = "none"` → verify silent
- [ ] Set `auto_reorder_workspaces = false` → verify no bubbling
- [ ] `cargo build --no-default-features` (soft renderer fallback)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System notifications with clickable actions to navigate to workspaces.
  * Configurable notification sound playback (system, none, or custom file).
  * Dock/taskbar badge shows unread counts (with cap/clear behavior).
  * Smart delivery: OS toasts when app unfocused, in-app sounds when focused.
  * Optional custom command execution on notifications.
  * IPC-triggered notifications and automatic workspace "bubbling" to top.

* **Tests**
  * Added unit test verifying total unread count across panes.

* **Chores**
  * Added platform audio/notification libraries and macOS integrations; CI installs Linux audio packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->