### PR TITLE
Add Theme struct and consolidate UI colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "amux-app"
 version = "0.1.0"
 dependencies = [
@@ -102,8 +124,12 @@ dependencies = [
  "dirs",
  "eframe",
  "egui",
+ "notify-rust",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "open",
  "portable-pty",
+ "rodio",
  "serde",
  "serde_json",
  "toml",
@@ -217,7 +243,7 @@ dependencies = [
  "jni-sys 0.3.1",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
@@ -369,6 +395,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +591,24 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bit-set"
@@ -505,6 +680,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +732,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -618,6 +821,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +846,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -785,6 +1008,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
 name = "cosmic-text"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +1048,29 @@ dependencies = [
  "unicode-linebreak",
  "unicode-script",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -883,10 +1149,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -1099,6 +1380,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enumn"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1500,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1387,6 +1725,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,7 +1778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1482,6 +1839,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,7 +1893,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 1.0.69",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1616,6 +1979,12 @@ checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "humansize"
@@ -1824,6 +2193,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1867,7 +2245,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1973,6 +2351,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
+name = "lewton"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
+dependencies = [
+ "byteorder",
+ "ogg",
+ "tinyvec",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,7 +2384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2074,6 +2463,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "time",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,6 +2522,15 @@ name = "memmem"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "metal"
@@ -2194,6 +2613,20 @@ dependencies = [
  "termcolor",
  "thiserror 2.0.18",
  "unicode-xid",
+]
+
+[[package]]
+name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2297,6 +2730,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "notify-rust"
+version = "4.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,6 +2761,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -2419,13 +2872,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -2435,9 +2888,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
+ "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -2447,10 +2909,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2459,7 +2932,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2471,9 +2944,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2506,10 +2990,20 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2518,10 +3012,35 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -2537,7 +3056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "dispatch",
  "libc",
  "objc2 0.5.2",
@@ -2550,6 +3069,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2571,7 +3092,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -2584,7 +3105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2596,10 +3117,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2619,15 +3151,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
@@ -2639,7 +3171,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2651,10 +3183,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni 0.21.1",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ogg"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2706,6 +3270,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,6 +3287,12 @@ checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser 0.25.1",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2734,7 +3314,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2883,6 +3463,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,6 +3547,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3039,6 +3636,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -3142,7 +3748,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -3251,6 +3857,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3278,6 +3896,18 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "rodio"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
+dependencies = [
+ "cpal",
+ "hound",
+ "lewton",
+ "symphonia",
+]
 
 [[package]]
 name = "ron"
@@ -3454,6 +4084,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3755,6 +4396,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-mp3",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,6 +4484,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]
@@ -3944,6 +4646,25 @@ dependencies = [
  "weezl",
  "zune-jpeg",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tiny-skia"
@@ -4190,6 +4911,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4290,6 +5022,7 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4570,7 +5303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.2",
  "quote",
 ]
 
@@ -4893,8 +5626,8 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows",
- "windows-core",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4942,11 +5675,53 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -4956,11 +5731,35 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4968,6 +5767,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4986,10 +5796,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-result"
@@ -5001,13 +5847,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5043,7 +5907,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5075,6 +5939,24 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5177,7 +6059,7 @@ dependencies = [
  "android-activity",
  "atomic-waker",
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
  "cfg_aliases 0.2.1",
@@ -5189,7 +6071,7 @@ dependencies = [
  "js-sys",
  "libc",
  "memmap2",
- "ndk",
+ "ndk 0.9.0",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -5439,6 +6321,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zeno"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5546,4 +6489,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
 ]

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1647,6 +1647,9 @@ impl AmuxApp {
         {
             let painter = ui.painter();
             painter.rect_filled(tab_rect, 0.0, self.theme.tab_bar_bg());
+            let bar_stroke = egui::Stroke::new(1.0, self.theme.chrome.tab_bar_border);
+            painter.hline(tab_rect.x_range(), tab_rect.min.y, bar_stroke);
+            painter.hline(tab_rect.x_range(), tab_rect.max.y, bar_stroke);
 
             let active_idx = managed.active_surface_idx;
             let tab_font = egui::FontId::proportional(11.0);

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1631,7 +1631,7 @@ impl AmuxApp {
         let tab_rect =
             egui::Rect::from_min_size(rect.min, egui::vec2(rect.width(), TAB_BAR_HEIGHT));
         let content_rect = egui::Rect::from_min_max(
-            egui::pos2(rect.min.x, rect.min.y + TAB_BAR_HEIGHT),
+            egui::pos2(rect.min.x, rect.min.y + TAB_BAR_HEIGHT + 1.0),
             egui::pos2(rect.max.x, rect.max.y - TERMINAL_BOTTOM_PAD),
         );
         // Paint bottom padding strip with terminal background color.
@@ -1708,7 +1708,7 @@ impl AmuxApp {
                         egui::pos2(x, tab_rect.min.y),
                         egui::vec2(tab_w, 2.0),
                     );
-                    painter.rect_filled(topline, 0.0, egui::Color32::from_rgb(80, 140, 220));
+                    painter.rect_filled(topline, 0.0, self.theme.chrome.accent);
                 }
                 // 1px border around each tab
                 painter.rect_stroke(

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -66,6 +66,8 @@ fn get_cwd_from_pid(pid: u32) -> Option<String> {
 const DEFAULT_FONT_SIZE: f32 = 14.0;
 const DEFAULT_SIDEBAR_WIDTH: f32 = 200.0;
 const TAB_BAR_HEIGHT: f32 = 24.0;
+/// Content top inset: tab bar height + 1px border between tab bar and content.
+const TAB_CONTENT_TOP_INSET: f32 = TAB_BAR_HEIGHT + 1.0;
 /// Visual padding above the tab bar. On macOS with fullSizeContentView,
 /// this covers the native title bar area where traffic light buttons sit.
 const TERMINAL_TOP_PAD: f32 = 28.0;
@@ -338,13 +340,18 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    let options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default()
-            .with_inner_size([1000.0, 600.0])
-            .with_title("amux")
+    let mut viewport = egui::ViewportBuilder::default()
+        .with_inner_size([1000.0, 600.0])
+        .with_title("amux");
+    #[cfg(target_os = "macos")]
+    {
+        viewport = viewport
             .with_fullsize_content_view(true)
             .with_titlebar_shown(false)
-            .with_title_shown(false),
+            .with_title_shown(false);
+    }
+    let options = eframe::NativeOptions {
+        viewport,
         ..Default::default()
     };
 
@@ -1689,7 +1696,7 @@ impl AmuxApp {
         let tab_rect =
             egui::Rect::from_min_size(rect.min, egui::vec2(rect.width(), TAB_BAR_HEIGHT));
         let content_rect = egui::Rect::from_min_max(
-            egui::pos2(rect.min.x, rect.min.y + TAB_BAR_HEIGHT + 1.0),
+            egui::pos2(rect.min.x, rect.min.y + TAB_CONTENT_TOP_INSET),
             egui::pos2(rect.max.x, rect.max.y - TERMINAL_BOTTOM_PAD),
         );
         // Paint bottom padding strip with terminal background color.

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1,5 +1,6 @@
 mod sidebar;
 mod system_notify;
+mod theme;
 
 use std::collections::HashMap;
 use std::io::Read;
@@ -65,12 +66,11 @@ fn get_cwd_from_pid(pid: u32) -> Option<String> {
 const DEFAULT_FONT_SIZE: f32 = 14.0;
 const DEFAULT_SIDEBAR_WIDTH: f32 = 200.0;
 const TAB_BAR_HEIGHT: f32 = 24.0;
+/// Visual padding above the tab bar, equal to one tab bar height.
+const TERMINAL_TOP_PAD: f32 = TAB_BAR_HEIGHT;
 /// Visual padding below the terminal grid (does not reduce PTY rows).
-/// Painted with TERMINAL_BG so it blends with the terminal background.
+/// Painted with terminal background color so it blends with the terminal.
 const TERMINAL_BOTTOM_PAD: f32 = 4.0;
-/// Default terminal background color, used for padding strips and unfilled areas.
-/// Will be replaced by palette-based color when color scheme config is added.
-const TERMINAL_BG: egui::Color32 = egui::Color32::from_gray(0);
 
 // ---------------------------------------------------------------------------
 // App config (loaded from ~/.config/amux/config.toml)
@@ -266,7 +266,11 @@ fn main() -> anyhow::Result<()> {
     let (ipc_rx, ipc_addr) = amux_ipc::start_server()?;
     tracing::info!("IPC server: {}", ipc_addr);
 
-    let config = Arc::new(AmuxTermConfig::default());
+    let theme = theme::Theme::default();
+    let mut term_config = AmuxTermConfig::default();
+    term_config.color_palette.background = theme.terminal_bg_srgba();
+    term_config.color_palette.foreground = theme.terminal_fg_srgba();
+    let config = Arc::new(term_config);
 
     // Try to restore a previous session
     let restored = match amux_session::load() {
@@ -319,6 +323,7 @@ fn main() -> anyhow::Result<()> {
                 ipc_rx,
                 socket_addr: ipc_addr,
                 config,
+                theme,
                 last_panel_rect: None,
                 notifications: state.notifications,
                 show_notification_panel: false,
@@ -997,6 +1002,7 @@ struct AmuxApp {
     ipc_rx: std::sync::mpsc::Receiver<IpcCommand>,
     socket_addr: amux_ipc::IpcAddr,
     config: Arc<AmuxTermConfig>,
+    theme: theme::Theme,
     last_panel_rect: Option<egui::Rect>,
     notifications: NotificationStore,
     show_notification_panel: bool,
@@ -1379,6 +1385,7 @@ impl eframe::App for AmuxApp {
                 self.active_workspace_idx,
                 &self.notifications,
                 &workspace_metadata,
+                &self.theme,
             );
             for action in sidebar_actions {
                 match action {
@@ -1448,7 +1455,21 @@ impl eframe::App for AmuxApp {
         egui::CentralPanel::default()
             .frame(egui::Frame::NONE)
             .show(ctx, |ui| {
-                let panel_rect = ui.available_rect_before_wrap();
+                let full_rect = ui.available_rect_before_wrap();
+                // Paint top padding strip with titlebar color.
+                ui.painter().rect_filled(
+                    egui::Rect::from_min_max(
+                        full_rect.min,
+                        egui::pos2(full_rect.max.x, full_rect.min.y + TERMINAL_TOP_PAD),
+                    ),
+                    0.0,
+                    self.theme.titlebar_bg(),
+                );
+                // Shift content area down by the top padding.
+                let panel_rect = egui::Rect::from_min_max(
+                    egui::pos2(full_rect.min.x, full_rect.min.y + TERMINAL_TOP_PAD),
+                    full_rect.max,
+                );
                 self.last_panel_rect = Some(panel_rect);
 
                 // Handle divider dragging
@@ -1509,7 +1530,7 @@ impl eframe::App for AmuxApp {
                     let dividers = self.active_workspace().tree.dividers(panel_rect);
                     let painter = ui.painter();
                     for div in &dividers {
-                        painter.rect_filled(div.rect, 0.0, egui::Color32::from_gray(60));
+                        painter.rect_filled(div.rect, 0.0, self.theme.chrome.divider);
                     }
 
                     // Render each pane (with its own tab bar)
@@ -1620,12 +1641,12 @@ impl AmuxApp {
                 rect.max,
             ),
             0.0,
-            TERMINAL_BG,
+            self.theme.terminal_bg(),
         );
 
         {
             let painter = ui.painter();
-            painter.rect_filled(tab_rect, 0.0, egui::Color32::from_gray(35));
+            painter.rect_filled(tab_rect, 0.0, self.theme.tab_bar_bg());
 
             let active_idx = managed.active_surface_idx;
             let tab_font = egui::FontId::proportional(11.0);
@@ -1654,7 +1675,7 @@ impl AmuxApp {
                     .as_deref()
                     .unwrap_or_else(|| surface.pane.title());
                 let label = if raw_title.is_empty() {
-                    format!("tab {}", surface.id)
+                    format!("tab {}", idx + 1)
                 } else if raw_title.chars().count() > 20 {
                     let prefix: String = raw_title.chars().take(17).collect();
                     format!("{prefix}...")
@@ -1676,9 +1697,9 @@ impl AmuxApp {
                 let tab_hovered = hover_pos.is_some_and(|p| this_tab.contains(p));
 
                 // Tab background + border
-                let border_color = egui::Color32::from_gray(55);
+                let border_color = self.theme.chrome.tab_border;
                 if is_active {
-                    painter.rect_filled(this_tab, 0.0, egui::Color32::from_gray(50));
+                    painter.rect_filled(this_tab, 0.0, self.theme.chrome.tab_active_bg);
                     // Active highlight at the top
                     let topline = egui::Rect::from_min_size(
                         egui::pos2(x, tab_rect.min.y),
@@ -1820,11 +1841,7 @@ impl AmuxApp {
                             egui::pos2(drop_x - 1.0, tab_rect.min.y + 2.0),
                             egui::vec2(2.0, TAB_BAR_HEIGHT - 4.0),
                         );
-                        painter.rect_filled(
-                            indicator_rect,
-                            1.0,
-                            egui::Color32::from_rgb(0, 145, 255),
-                        );
+                        painter.rect_filled(indicator_rect, 1.0, self.theme.chrome.accent);
                     }
                 }
             }
@@ -3571,7 +3588,7 @@ impl AmuxApp {
                                 let dot_color = if notif.read {
                                     egui::Color32::from_gray(60)
                                 } else {
-                                    egui::Color32::from_rgb(0, 145, 255)
+                                    self.theme.chrome.accent
                                 };
                                 ui.label(
                                     egui::RichText::new(source_icon).size(10.0).color(dot_color),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -66,8 +66,9 @@ fn get_cwd_from_pid(pid: u32) -> Option<String> {
 const DEFAULT_FONT_SIZE: f32 = 14.0;
 const DEFAULT_SIDEBAR_WIDTH: f32 = 200.0;
 const TAB_BAR_HEIGHT: f32 = 24.0;
-/// Visual padding above the tab bar, equal to one tab bar height.
-const TERMINAL_TOP_PAD: f32 = TAB_BAR_HEIGHT;
+/// Visual padding above the tab bar. On macOS with fullSizeContentView,
+/// this covers the native title bar area where traffic light buttons sit.
+const TERMINAL_TOP_PAD: f32 = 28.0;
 /// Visual padding below the terminal grid (does not reduce PTY rows).
 /// Painted with terminal background color so it blends with the terminal.
 const TERMINAL_BOTTOM_PAD: f32 = 4.0;
@@ -184,27 +185,43 @@ fn install_system_font_fallback(ctx: &egui::Context) {
 
     // Platform-specific font candidates: (path, name, is_symbol_font)
     // We try to load a monospace font + a symbols font for maximum coverage.
-    let candidates: &[(&str, &str, bool)] = if cfg!(target_os = "macos") {
+    // (path, name, is_symbol_font, is_proportional)
+    let candidates: &[(&str, &str, bool, bool)] = if cfg!(target_os = "macos") {
         &[
+            // SF Pro (system font) for UI chrome text
+            ("/System/Library/Fonts/SFNS.ttf", "sf_pro", false, true),
             // SF Mono: single .ttf with good Unicode coverage
-            ("/System/Library/Fonts/SFNSMono.ttf", "sf_mono", false),
+            (
+                "/System/Library/Fonts/SFNSMono.ttf",
+                "sf_mono",
+                false,
+                false,
+            ),
             // Apple Symbols: broad Unicode symbol coverage
             (
                 "/System/Library/Fonts/Apple Symbols.ttf",
                 "apple_symbols",
                 true,
+                false,
             ),
             // Supplemental Andale Mono as another option
             (
                 "/System/Library/Fonts/Supplemental/Andale Mono.ttf",
                 "andale_mono",
                 false,
+                false,
             ),
         ]
     } else if cfg!(target_os = "windows") {
         &[
-            ("C:\\Windows\\Fonts\\consola.ttf", "consolas", false),
-            ("C:\\Windows\\Fonts\\segmdl2.ttf", "segoe_symbols", true),
+            ("C:\\Windows\\Fonts\\segoeui.ttf", "segoe_ui", false, true),
+            ("C:\\Windows\\Fonts\\consola.ttf", "consolas", false, false),
+            (
+                "C:\\Windows\\Fonts\\segmdl2.ttf",
+                "segoe_symbols",
+                true,
+                false,
+            ),
         ]
     } else {
         &[
@@ -212,16 +229,21 @@ fn install_system_font_fallback(ctx: &egui::Context) {
                 "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
                 "dejavu_mono",
                 false,
+                false,
             ),
             (
                 "/usr/share/fonts/TTF/DejaVuSansMono.ttf",
                 "dejavu_mono",
                 false,
+                false,
             ),
         ]
     };
 
-    for &(path, name, _is_symbol) in candidates {
+    let mut proportional_fonts = Vec::new();
+    let mut mono_fonts = Vec::new();
+
+    for &(path, name, _is_symbol, is_proportional) in candidates {
         if fonts.font_data.contains_key(name) {
             continue;
         }
@@ -230,6 +252,11 @@ fn install_system_font_fallback(ctx: &egui::Context) {
                 .font_data
                 .insert(name.to_owned(), egui::FontData::from_owned(data).into());
             loaded.push(name);
+            if is_proportional {
+                proportional_fonts.push(name);
+            } else {
+                mono_fonts.push(name);
+            }
         }
     }
 
@@ -238,12 +265,19 @@ fn install_system_font_fallback(ctx: &egui::Context) {
         return;
     }
 
-    // Add all loaded fonts as fallbacks to both families
-    for family_key in [egui::FontFamily::Monospace, egui::FontFamily::Proportional] {
-        if let Some(family) = fonts.families.get_mut(&family_key) {
-            for name in &loaded {
-                family.push((*name).to_owned());
-            }
+    // Proportional fonts: put system UI font first, then mono as fallback
+    if let Some(family) = fonts.families.get_mut(&egui::FontFamily::Proportional) {
+        for name in &proportional_fonts {
+            family.insert(0, (*name).to_owned());
+        }
+        for name in &mono_fonts {
+            family.push((*name).to_owned());
+        }
+    }
+    // Monospace fonts: add all as fallbacks
+    if let Some(family) = fonts.families.get_mut(&egui::FontFamily::Monospace) {
+        for name in &loaded {
+            family.push((*name).to_owned());
         }
     }
 
@@ -268,8 +302,7 @@ fn main() -> anyhow::Result<()> {
 
     let theme = theme::Theme::default();
     let mut term_config = AmuxTermConfig::default();
-    term_config.color_palette.background = theme.terminal_bg_srgba();
-    term_config.color_palette.foreground = theme.terminal_fg_srgba();
+    theme.apply_to_palette(&mut term_config.color_palette);
     let config = Arc::new(term_config);
 
     // Try to restore a previous session
@@ -291,10 +324,27 @@ fn main() -> anyhow::Result<()> {
         fresh_startup(&ipc_addr, &config)?
     };
 
+    // Force dark appearance on macOS so the title bar matches the app's dark chrome.
+    #[cfg(target_os = "macos")]
+    {
+        use objc2_app_kit::{NSAppearance, NSApplication};
+        use objc2_foundation::{MainThreadMarker, NSString};
+
+        if let Some(mtm) = MainThreadMarker::new() {
+            let app = NSApplication::sharedApplication(mtm);
+            let dark =
+                NSAppearance::appearanceNamed(&NSString::from_str("NSAppearanceNameDarkAqua"));
+            app.setAppearance(dark.as_deref());
+        }
+    }
+
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([1000.0, 600.0])
-            .with_title("amux"),
+            .with_title("amux")
+            .with_fullsize_content_view(true)
+            .with_titlebar_shown(false)
+            .with_title_shown(false),
         ..Default::default()
     };
 
@@ -305,6 +355,14 @@ fn main() -> anyhow::Result<()> {
         Box::new(move |_cc| {
             // Add system monospace font as fallback for braille/symbol coverage
             install_system_font_fallback(&_cc.egui_ctx);
+
+            // Hide the panel resize handle entirely (cursor still changes on hover).
+            _cc.egui_ctx.style_mut(|style| {
+                style.visuals.widgets.noninteractive.fg_stroke.color = egui::Color32::TRANSPARENT;
+                style.visuals.widgets.inactive.fg_stroke.color = egui::Color32::TRANSPARENT;
+                style.visuals.widgets.hovered.fg_stroke.color = egui::Color32::TRANSPARENT;
+                style.visuals.widgets.active.fg_stroke.color = egui::Color32::TRANSPARENT;
+            });
 
             #[cfg(feature = "gpu-renderer")]
             let gpu_renderer = _cc.wgpu_render_state.as_ref().map(|rs| {
@@ -1678,7 +1736,7 @@ impl AmuxApp {
                     .as_deref()
                     .unwrap_or_else(|| surface.pane.title());
                 let label = if raw_title.is_empty() {
-                    format!("tab {}", idx + 1)
+                    format!("tab {}", surface.id + 1)
                 } else if raw_title.chars().count() > 20 {
                     let prefix: String = raw_title.chars().take(17).collect();
                     format!("{prefix}...")

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -12,7 +12,6 @@ use crate::{SidebarDragState, SidebarState, SurfaceMetadata, Workspace};
 const ROW_HOVER_BG: Color32 = Color32::from_rgba_premultiplied(15, 15, 15, 15);
 const TEXT_ACTIVE: Color32 = Color32::WHITE;
 const TEXT_INACTIVE: Color32 = Color32::from_gray(180);
-const TEXT_SECONDARY: Color32 = Color32::from_gray(140);
 const BADGE_ACTIVE_BG: Color32 = Color32::from_rgba_premultiplied(64, 64, 64, 64);
 const NEW_BTN_TEXT: Color32 = Color32::from_gray(140);
 const NEW_BTN_HOVER: Color32 = Color32::from_rgba_premultiplied(15, 15, 15, 15);
@@ -33,7 +32,6 @@ const ROW_CORNER_RADIUS: f32 = 6.0;
 const TITLE_FONT_SIZE: f32 = 12.5;
 const BADGE_RADIUS: f32 = 8.0;
 const BADGE_FONT_SIZE: f32 = 9.0;
-const COUNT_FONT_SIZE: f32 = 10.0;
 const NOTIF_FONT_SIZE: f32 = 10.0;
 const NOTIF_PREVIEW_HEIGHT: f32 = 24.0;
 const CLOSE_BTN_SIZE: f32 = 16.0;
@@ -532,15 +530,6 @@ fn render_workspace_row(
             format!("{unread}"),
             egui::FontId::proportional(BADGE_FONT_SIZE),
             Color32::WHITE,
-        );
-    } else {
-        let count = pane_ids.len();
-        ui.painter().text(
-            egui::pos2(rect.right() - ROW_H_PAD, rect.min.y + ROW_V_PAD),
-            egui::Align2::RIGHT_TOP,
-            format!("{count}"),
-            egui::FontId::proportional(COUNT_FONT_SIZE),
-            TEXT_SECONDARY,
         );
     }
 

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -400,7 +400,7 @@ fn render_workspace_row(
     // --- Background ---
     let opacity = if is_being_dragged { 0.6 } else { 1.0 };
     let bg = if is_active {
-        with_opacity(theme.chrome.accent, opacity)
+        with_opacity(theme.chrome.sidebar_active_bg, opacity)
     } else if hovered {
         with_opacity(ROW_HOVER_BG, opacity)
     } else {

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -309,9 +309,32 @@ fn render_workspace_row(
     let has_git_or_cwd = metadata.is_some_and(|m| m.git_branch.is_some() || m.cwd.is_some());
     let has_pr = metadata.is_some_and(|m| m.pr_number.is_some());
 
+    // Compute title text early so we can measure if it needs two lines.
+    let title_font = egui::FontId::proportional(TITLE_FONT_SIZE);
+    let display_title = if let Some(task) = status.as_ref().and_then(|s| s.task.as_ref()) {
+        format!("\u{2731} {task}")
+    } else if let Some(st) = metadata.and_then(|m| m.surface_title.as_ref()) {
+        st.clone()
+    } else {
+        ws.title.clone()
+    };
+    let content_left_est = if has_color {
+        ROW_H_PAD + COLOR_CAPSULE_WIDTH + 4.0
+    } else {
+        ROW_H_PAD
+    };
+    let right_reserve_est = BADGE_RADIUS * 2.0 + 4.0;
+    let max_title_w_est = ui.available_width() - content_left_est - ROW_H_PAD - right_reserve_est;
+    let title_text_w = ui
+        .fonts(|f| f.layout_no_wrap(display_title.clone(), title_font.clone(), Color32::WHITE))
+        .size()
+        .x;
+    let title_needs_wrap = title_text_w > max_title_w_est;
+
     // Dynamic row height
     let title_line_h = TITLE_FONT_SIZE + 2.0;
-    let mut row_h = ROW_V_PAD * 2.0 + title_line_h;
+    let title_lines = if title_needs_wrap { 2.0 } else { 1.0 };
+    let mut row_h = ROW_V_PAD * 2.0 + title_line_h * title_lines;
     if has_agent_message {
         row_h += METADATA_LINE_HEIGHT + 2.0;
     }
@@ -442,24 +465,33 @@ fn render_workspace_row(
 
     {
         let title_pos = rect.min + egui::vec2(content_left, ROW_V_PAD);
-        let title_font = egui::FontId::proportional(TITLE_FONT_SIZE);
-        // Show agent task as title if available, with star prefix like cmux.
-        // Fall back to surface title (OSC 0/2), then workspace title.
-        let display_title = if let Some(task) = status.as_ref().and_then(|s| s.task.as_ref()) {
-            format!("\u{2731} {task}")
-        } else if let Some(st) = metadata.and_then(|m| m.surface_title.as_ref()) {
-            st.clone()
+        if title_needs_wrap {
+            // Wrap to two lines with ellipsis on overflow.
+            let mut job = egui::text::LayoutJob::single_section(
+                display_title.clone(),
+                egui::TextFormat {
+                    font_id: title_font.clone(),
+                    color: title_color,
+                    ..Default::default()
+                },
+            );
+            job.wrap = egui::text::TextWrapping {
+                max_width: max_title_w,
+                max_rows: 2,
+                break_anywhere: false,
+                overflow_character: Some('\u{2026}'),
+            };
+            let galley = ui.fonts(|f| f.layout_job(job));
+            ui.painter().galley(title_pos, galley, title_color);
         } else {
-            ws.title.clone()
-        };
-        let truncated_title = truncate_text(ui, &display_title, &title_font, max_title_w);
-        ui.painter().text(
-            title_pos,
-            egui::Align2::LEFT_TOP,
-            &truncated_title,
-            title_font,
-            title_color,
-        );
+            ui.painter().text(
+                title_pos,
+                egui::Align2::LEFT_TOP,
+                &display_title,
+                title_font.clone(),
+                title_color,
+            );
+        }
     }
 
     // --- Close button on hover (replaces badge) or badge/count ---
@@ -513,7 +545,7 @@ fn render_workspace_row(
     }
 
     // --- Status indicator (icon + text, matching cmux) ---
-    let mut content_bottom = rect.min.y + ROW_V_PAD + title_line_h;
+    let mut content_bottom = rect.min.y + ROW_V_PAD + title_line_h * title_lines;
 
     // Metadata text color: light grey
     let meta_color = Color32::from_gray(190);

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -9,9 +9,6 @@ use crate::{SidebarDragState, SidebarState, SurfaceMetadata, Workspace};
 // Colors (cmux dark mode equivalents)
 // ---------------------------------------------------------------------------
 
-const ACCENT_BLUE: Color32 = Color32::from_rgb(0, 145, 255);
-const SIDEBAR_BG: Color32 = Color32::from_rgba_premultiplied(20, 20, 20, 230);
-const ROW_ACTIVE_BG: Color32 = Color32::from_rgb(0, 145, 255);
 const ROW_HOVER_BG: Color32 = Color32::from_rgba_premultiplied(15, 15, 15, 15);
 const TEXT_ACTIVE: Color32 = Color32::WHITE;
 const TEXT_INACTIVE: Color32 = Color32::from_gray(180);
@@ -114,17 +111,19 @@ pub(crate) fn render_sidebar(
     active_workspace_idx: usize,
     notifications: &NotificationStore,
     workspace_metadata: &HashMap<u64, SurfaceMetadata>,
+    theme: &crate::theme::Theme,
 ) -> Vec<SidebarAction> {
     let mut actions = Vec::new();
 
     egui::SidePanel::left("sidebar")
         .resizable(true)
+        .show_separator_line(false)
         .default_width(state.width)
         .min_width(SIDEBAR_MIN_WIDTH)
         .max_width(SIDEBAR_MAX_WIDTH)
         .frame(
             egui::Frame::new()
-                .fill(SIDEBAR_BG)
+                .fill(theme.chrome.sidebar_bg)
                 .inner_margin(egui::Margin::symmetric(ROW_OUTER_H_PAD as i8, 0)),
         )
         .show(ctx, |ui| {
@@ -158,6 +157,7 @@ pub(crate) fn render_sidebar(
                             notifications,
                             state,
                             meta,
+                            theme,
                         );
                         actions.extend(row_actions);
                         row_rects.push(row_rect);
@@ -193,7 +193,8 @@ pub(crate) fn render_sidebar(
                             egui::pos2(indicator_x, drop_y - DROP_INDICATOR_HEIGHT / 2.0),
                             egui::vec2(avail_w, DROP_INDICATOR_HEIGHT),
                         );
-                        ui.painter().rect_filled(indicator_rect, 1.0, ACCENT_BLUE);
+                        ui.painter()
+                            .rect_filled(indicator_rect, 1.0, theme.chrome.accent);
                     }
 
                     ui.add_space(8.0);
@@ -293,6 +294,7 @@ fn render_workspace_row(
     notifications: &NotificationStore,
     state: &mut SidebarState,
     metadata: Option<&SurfaceMetadata>,
+    theme: &crate::theme::Theme,
 ) -> (Vec<SidebarAction>, egui::Rect) {
     let mut actions = Vec::new();
     let pane_ids: Vec<u64> = ws.tree.iter_panes();
@@ -398,7 +400,7 @@ fn render_workspace_row(
     // --- Background ---
     let opacity = if is_being_dragged { 0.6 } else { 1.0 };
     let bg = if is_active {
-        with_opacity(ROW_ACTIVE_BG, opacity)
+        with_opacity(theme.chrome.accent, opacity)
     } else if hovered {
         with_opacity(ROW_HOVER_BG, opacity)
     } else {
@@ -488,7 +490,7 @@ fn render_workspace_row(
         let badge_color = if is_active {
             BADGE_ACTIVE_BG
         } else {
-            ACCENT_BLUE
+            theme.chrome.accent
         };
         ui.painter()
             .circle_filled(badge_center, BADGE_RADIUS, badge_color);
@@ -519,7 +521,7 @@ fn render_workspace_row(
     let status_color = if is_active {
         Color32::WHITE
     } else {
-        ACCENT_BLUE
+        theme.chrome.accent
     };
 
     if let Some(status) = &status {
@@ -662,7 +664,7 @@ fn render_workspace_row(
                 egui::vec2(fill_w, PROGRESS_BAR_HEIGHT),
             );
             ui.painter()
-                .rect_filled(fill_rect, PROGRESS_BAR_HEIGHT / 2.0, ACCENT_BLUE);
+                .rect_filled(fill_rect, PROGRESS_BAR_HEIGHT / 2.0, theme.chrome.accent);
         }
     }
 

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -7,7 +7,12 @@ use wezterm_term::color::SrgbaTuple;
 pub(crate) struct TerminalColors {
     pub background: [u8; 3],
     pub foreground: [u8; 3],
-    // Future: ansi, brights, cursor_bg, cursor_fg, selection_bg, selection_fg
+    /// 16 ANSI colors: 0-7 normal, 8-15 bright.
+    pub ansi: [[u8; 3]; 16],
+    pub cursor_fg: [u8; 3],
+    pub cursor_bg: [u8; 3],
+    pub selection_fg: [u8; 3],
+    pub selection_bg: [u8; 3],
 }
 
 /// UI chrome colors — tab bar, sidebar, dividers, accents.
@@ -56,6 +61,29 @@ impl Theme {
         SrgbaTuple(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0, 1.0)
     }
 
+    /// Apply terminal colors to a wezterm ColorPalette.
+    pub fn apply_to_palette(&self, palette: &mut wezterm_term::color::ColorPalette) {
+        palette.background = self.terminal_bg_srgba();
+        palette.foreground = self.terminal_fg_srgba();
+        for (i, [r, g, b]) in self.terminal.ansi.iter().enumerate() {
+            palette.colors.0[i] =
+                SrgbaTuple(*r as f32 / 255.0, *g as f32 / 255.0, *b as f32 / 255.0, 1.0);
+        }
+        let to_srgba = |c: [u8; 3]| {
+            SrgbaTuple(
+                c[0] as f32 / 255.0,
+                c[1] as f32 / 255.0,
+                c[2] as f32 / 255.0,
+                1.0,
+            )
+        };
+        palette.cursor_fg = to_srgba(self.terminal.cursor_fg);
+        palette.cursor_bg = to_srgba(self.terminal.cursor_bg);
+        palette.cursor_border = to_srgba(self.terminal.cursor_bg);
+        palette.selection_fg = to_srgba(self.terminal.selection_fg);
+        palette.selection_bg = to_srgba(self.terminal.selection_bg);
+    }
+
     /// Resolved tab bar background: chrome override → terminal background.
     pub fn tab_bar_bg(&self) -> Color32 {
         self.chrome.tab_bar_bg.unwrap_or_else(|| self.terminal_bg())
@@ -71,15 +99,38 @@ impl Default for Theme {
     fn default() -> Self {
         Self {
             terminal: TerminalColors {
-                background: [30, 32, 36],
-                foreground: [0xe5, 0xe5, 0xe5],
+                // Tokyo Night
+                background: [0x1a, 0x1b, 0x26],
+                foreground: [0xc0, 0xca, 0xf5],
+                ansi: [
+                    [0x15, 0x16, 0x1e], // 0  black
+                    [0xf7, 0x76, 0x8e], // 1  red
+                    [0x9e, 0xce, 0x6a], // 2  green
+                    [0xe0, 0xaf, 0x68], // 3  yellow
+                    [0x7a, 0xa2, 0xf7], // 4  blue
+                    [0xbb, 0x9a, 0xf7], // 5  magenta
+                    [0x7d, 0xcf, 0xff], // 6  cyan
+                    [0xa9, 0xb1, 0xd6], // 7  white
+                    [0x41, 0x48, 0x68], // 8  bright black
+                    [0xf7, 0x76, 0x8e], // 9  bright red
+                    [0x9e, 0xce, 0x6a], // 10 bright green
+                    [0xe0, 0xaf, 0x68], // 11 bright yellow
+                    [0x7a, 0xa2, 0xf7], // 12 bright blue
+                    [0xbb, 0x9a, 0xf7], // 13 bright magenta
+                    [0x7d, 0xcf, 0xff], // 14 bright cyan
+                    [0xc0, 0xca, 0xf5], // 15 bright white
+                ],
+                cursor_fg: [0x15, 0x16, 0x1e],
+                cursor_bg: [0xc0, 0xca, 0xf5],
+                selection_fg: [0xc0, 0xca, 0xf5],
+                selection_bg: [0x33, 0x46, 0x7c],
             },
             chrome: ChromeColors {
                 sidebar_bg: Color32::from_gray(35),
                 sidebar_active_bg: Color32::from_rgb(24, 64, 120),
                 tab_bar_bg: None,  // falls back to terminal background
                 titlebar_bg: None, // falls back to tab bar background
-                tab_active_bg: Color32::from_gray(50),
+                tab_active_bg: Color32::from_rgb(0x24, 0x28, 0x3b), // Tokyo Night Storm
                 tab_bar_border: Color32::from_gray(55),
                 tab_border: Color32::from_gray(55),
                 divider: Color32::from_gray(60),

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -16,6 +16,8 @@ pub(crate) struct TerminalColors {
 #[derive(Debug, Clone)]
 pub(crate) struct ChromeColors {
     pub sidebar_bg: Color32,
+    /// Active/selected row background in the sidebar.
+    pub sidebar_active_bg: Color32,
     /// Tab bar background. Falls back to terminal background when `None`.
     pub tab_bar_bg: Option<Color32>,
     /// Title bar / top padding background. Falls back to `tab_bar_bg` when `None`.
@@ -74,6 +76,7 @@ impl Default for Theme {
             },
             chrome: ChromeColors {
                 sidebar_bg: Color32::from_gray(35),
+                sidebar_active_bg: Color32::from_rgb(24, 64, 120),
                 tab_bar_bg: None,  // falls back to terminal background
                 titlebar_bg: None, // falls back to tab bar background
                 tab_active_bg: Color32::from_gray(50),

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -21,6 +21,8 @@ pub(crate) struct ChromeColors {
     /// Title bar / top padding background. Falls back to `tab_bar_bg` when `None`.
     pub titlebar_bg: Option<Color32>,
     pub tab_active_bg: Color32,
+    /// 1px border around the tab bar (top and bottom edges).
+    pub tab_bar_border: Color32,
     pub tab_border: Color32,
     pub divider: Color32,
     pub accent: Color32,
@@ -67,14 +69,15 @@ impl Default for Theme {
     fn default() -> Self {
         Self {
             terminal: TerminalColors {
-                background: [35, 35, 35],
+                background: [30, 32, 36],
                 foreground: [0xe5, 0xe5, 0xe5],
             },
             chrome: ChromeColors {
-                sidebar_bg: Color32::from_rgba_premultiplied(20, 20, 20, 230),
+                sidebar_bg: Color32::from_gray(35),
                 tab_bar_bg: None,  // falls back to terminal background
                 titlebar_bg: None, // falls back to tab bar background
                 tab_active_bg: Color32::from_gray(50),
+                tab_bar_border: Color32::from_gray(55),
                 tab_border: Color32::from_gray(55),
                 divider: Color32::from_gray(60),
                 accent: Color32::from_rgb(0, 145, 255),

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -1,0 +1,84 @@
+use egui::Color32;
+use wezterm_term::color::SrgbaTuple;
+
+/// Terminal color scheme — feeds into wezterm-term's ColorPalette.
+/// Later: loadable from named schemes (Dracula, Solarized, etc.)
+#[derive(Debug, Clone)]
+pub(crate) struct TerminalColors {
+    pub background: [u8; 3],
+    pub foreground: [u8; 3],
+    // Future: ansi, brights, cursor_bg, cursor_fg, selection_bg, selection_fg
+}
+
+/// UI chrome colors — tab bar, sidebar, dividers, accents.
+/// Distinct from terminal colors (wezterm/ghostty pattern).
+/// Fields that are `None` fall back to the terminal background (ghostty pattern).
+#[derive(Debug, Clone)]
+pub(crate) struct ChromeColors {
+    pub sidebar_bg: Color32,
+    /// Tab bar background. Falls back to terminal background when `None`.
+    pub tab_bar_bg: Option<Color32>,
+    /// Title bar / top padding background. Falls back to `tab_bar_bg` when `None`.
+    pub titlebar_bg: Option<Color32>,
+    pub tab_active_bg: Color32,
+    pub tab_border: Color32,
+    pub divider: Color32,
+    pub accent: Color32,
+}
+
+/// Combined theme: terminal colors + UI chrome.
+#[derive(Debug, Clone)]
+pub(crate) struct Theme {
+    pub terminal: TerminalColors,
+    pub chrome: ChromeColors,
+}
+
+impl Theme {
+    /// Terminal background as `Color32`.
+    pub fn terminal_bg(&self) -> Color32 {
+        let [r, g, b] = self.terminal.background;
+        Color32::from_rgb(r, g, b)
+    }
+
+    /// Terminal background as `SrgbaTuple` for wezterm palette.
+    pub fn terminal_bg_srgba(&self) -> SrgbaTuple {
+        let [r, g, b] = self.terminal.background;
+        SrgbaTuple(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0, 1.0)
+    }
+
+    /// Terminal foreground as `SrgbaTuple` for wezterm palette.
+    pub fn terminal_fg_srgba(&self) -> SrgbaTuple {
+        let [r, g, b] = self.terminal.foreground;
+        SrgbaTuple(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0, 1.0)
+    }
+
+    /// Resolved tab bar background: chrome override → terminal background.
+    pub fn tab_bar_bg(&self) -> Color32 {
+        self.chrome.tab_bar_bg.unwrap_or_else(|| self.terminal_bg())
+    }
+
+    /// Resolved titlebar background: chrome override → tab bar background.
+    pub fn titlebar_bg(&self) -> Color32 {
+        self.chrome.titlebar_bg.unwrap_or_else(|| self.tab_bar_bg())
+    }
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self {
+            terminal: TerminalColors {
+                background: [35, 35, 35],
+                foreground: [0xe5, 0xe5, 0xe5],
+            },
+            chrome: ChromeColors {
+                sidebar_bg: Color32::from_rgba_premultiplied(20, 20, 20, 230),
+                tab_bar_bg: None,  // falls back to terminal background
+                titlebar_bg: None, // falls back to tab bar background
+                tab_active_bg: Color32::from_gray(50),
+                tab_border: Color32::from_gray(55),
+                divider: Color32::from_gray(60),
+                accent: Color32::from_rgb(0, 145, 255),
+            },
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `Theme` struct in `theme.rs` with two-layer architecture following wezterm/ghostty patterns:
  - `TerminalColors` — bg/fg fed into wezterm-term's `ColorPalette`
  - `ChromeColors` — sidebar, tab bar, titlebar, dividers, accent (with fallback-to-terminal-bg pattern from ghostty)
- Replace scattered magic color constants across `main.rs` (2 constants + 5 inline values) and `sidebar.rs` (3 constants + 4 usages) with `Theme` fields
- Terminal background is now `gray(35)` matching tab bar, via palette override
- Chrome `tab_bar_bg` and `titlebar_bg` default to `None`, falling back to terminal background automatically
- UI polish: tab labels show "tab 1" not "tab 0", top padding strip above tab bar, sidebar separator hidden until hover

## Future

`Theme::default()` is hardcoded today. Next steps:
- Load from `[theme]` section in `config.toml`
- Named color schemes (Dracula, Solarized, etc.)
- Expand `TerminalColors` with ANSI palette, cursor, selection colors

## Test plan

- [ ] `cargo fmt --check && cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Terminal background is gray(35), not black
- [ ] Tab bar, top padding, and terminal content are visually unified
- [ ] Sidebar is still distinct dark charcoal
- [ ] Accent blue on active sidebar row, tab drag indicator, notification dots
- [ ] Pane dividers visible at gray(60)
- [ ] Sidebar resize handle hidden until hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized theming system for terminal and UI colors (chrome, tabs, sidebar, terminal).

* **Style**
  * UI elements (sidebar, tab bar, dividers, badges, drag indicators, progress fills) now follow the theme; added top titlebar padding and adjusted panel/tab/terminal spacing.
  * Sidebar rows now support wrapped titles (up to 2 lines) with ellipsis; sidebar separator line hidden.
  * Tab labels use human-friendly ordinals when empty.
  * Improved font-fallback ordering and hid the visual panel resize handle.

* **Platform**
  * macOS now defaults to dark window appearance and full-size content layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->