### PR TITLE
Set TERM_PROGRAM=amux in PTY environment

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -971,6 +971,8 @@ fn spawn_surface(
     cmd.env("AMUX_WORKSPACE_ID", workspace_id.to_string());
     cmd.env("AMUX_SURFACE_ID", surface_id.to_string());
     cmd.env("TERM", "xterm-256color");
+    cmd.env("TERM_PROGRAM", "amux");
+    cmd.env("TERM_PROGRAM_VERSION", env!("CARGO_PKG_VERSION"));
 
     // Point AMUX_BIN to the CLI binary so shell integration scripts can invoke it
     // without relying on PATH (macOS path_helper in /etc/zprofile rebuilds PATH).


### PR DESCRIPTION
## Summary

- Set `TERM_PROGRAM=amux` and `TERM_PROGRAM_VERSION` in the PTY environment for spawned shells
- Helps Claude Code and other tools detect they're inside a proper terminal emulator

## Context

Issue #36 reports raw XML markup tags (`<task-notification>`, `<task-id>`, `<tool-use-id>`) rendered visibly in the terminal pane. Investigation found:

1. These tags are **not from amux** — they don't appear anywhere in our codebase
2. They originate from Claude Code's internal streaming protocol leaking to PTY output
3. The GPU rendering pipeline (snapshot extraction → paint callback) is correct and wouldn't cause overlapping
4. The sidebar status display reads from IPC, not PTY — it's unrelated

Setting `TERM_PROGRAM` is standard practice for terminal emulators (iTerm2, WezTerm, Ghostty all do this) and may help Claude Code adjust its output behavior. If the issue persists after this change, it's an upstream Claude Code bug.

## Test plan

- [ ] Verify `echo $TERM_PROGRAM` prints `amux` in a spawned shell
- [ ] Run Claude Code inside amux and check if XML tags still appear
- [ ] Verify no regression in shell integration or hook injection

Relates to #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated terminal environment configuration in spawned terminal sessions to improve compatibility with applications and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->