### PR TITLE
Extract ManagedPane module and add panel_type to session

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1,3 +1,4 @@
+mod managed_pane;
 mod menu_bar;
 mod sidebar;
 mod system_notify;
@@ -20,6 +21,7 @@ use amux_term::config::AmuxTermConfig;
 use amux_term::font;
 use amux_term::osc::NotificationEvent;
 use amux_term::pane::TerminalPane;
+use managed_pane::*;
 use portable_pty::CommandBuilder;
 use wezterm_surface::{CursorShape, CursorVisibility};
 use wezterm_term::color::SrgbaTuple;
@@ -903,48 +905,8 @@ fn cleanup_addr(addr: &amux_ipc::IpcAddr) {
 
 // --- Data Model ---
 // Hierarchy: Workspace > PaneTree (splits) > Pane (each has tab bar) > Surface (terminal tab)
-
-/// Per-surface metadata reported by shell integration, agent hooks, or OSC sequences.
-#[derive(Default, Clone)]
-pub(crate) struct SurfaceMetadata {
-    pub(crate) cwd: Option<String>,
-    pub(crate) git_branch: Option<String>,
-    pub(crate) git_dirty: bool,
-    pub(crate) pr_number: Option<u32>,
-    pub(crate) pr_title: Option<String>,
-    pub(crate) pr_state: Option<String>, // "open", "merged", "closed"
-    /// Surface title from OSC 0/2 (window title set by shell/agent).
-    pub(crate) surface_title: Option<String>,
-}
-
-/// A terminal tab within a pane. Each pane can have multiple surfaces.
-struct PaneSurface {
-    id: u64,
-    pane: TerminalPane,
-    byte_rx: mpsc::Receiver<Vec<u8>>,
-    scroll_offset: usize,
-    scroll_accum: f32,
-    metadata: SurfaceMetadata,
-    /// User-set title override. When set, takes precedence over OSC 0/2 title.
-    user_title: Option<String>,
-}
-
-/// A leaf in the split tree. Each pane has its own tab bar with surfaces.
-struct ManagedPane {
-    surfaces: Vec<PaneSurface>,
-    active_surface_idx: usize,
-    selection: Option<SelectionState>,
-}
-
-impl ManagedPane {
-    fn active_surface(&self) -> &PaneSurface {
-        &self.surfaces[self.active_surface_idx]
-    }
-
-    fn active_surface_mut(&mut self) -> &mut PaneSurface {
-        &mut self.surfaces[self.active_surface_idx]
-    }
-}
+// Core pane types (ManagedPane, PaneSurface, SurfaceMetadata, SelectionState, etc.)
+// live in managed_pane.rs.
 
 /// A workspace shown in the sidebar. Owns the split tree.
 pub(crate) struct Workspace {
@@ -981,80 +943,6 @@ struct DragState {
     node_path: Vec<usize>,
     direction: SplitDirection,
 }
-
-// --- Selection ---
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SelectionMode {
-    Cell,
-    Word,
-    Line,
-}
-
-#[derive(Debug, Clone)]
-struct SelectionState {
-    anchor: (usize, usize), // (col, stable_row)
-    end: (usize, usize),    // (col, stable_row)
-    mode: SelectionMode,
-    active: bool, // true while mouse is held
-}
-
-impl SelectionState {
-    /// Return (start, end) normalized so start <= end in reading order.
-    fn normalized(&self) -> ((usize, usize), (usize, usize)) {
-        let a = self.anchor;
-        let b = self.end;
-        if a.1 < b.1 || (a.1 == b.1 && a.0 <= b.0) {
-            (a, b)
-        } else {
-            (b, a)
-        }
-    }
-
-    /// Check if a cell at (col, stable_row) is within the selection.
-    fn contains(&self, col: usize, stable_row: usize) -> bool {
-        let (start, end) = self.normalized();
-        if stable_row < start.1 || stable_row > end.1 {
-            return false;
-        }
-        if start.1 == end.1 {
-            // Single line
-            col >= start.0 && col <= end.0
-        } else if stable_row == start.1 {
-            col >= start.0
-        } else if stable_row == end.1 {
-            col <= end.0
-        } else {
-            true // middle line
-        }
-    }
-}
-
-/// State for the in-pane find/search bar.
-struct FindState {
-    query: String,
-    /// Matches as (phys_row, start_col, end_col_exclusive).
-    matches: Vec<(usize, usize, usize)>,
-    current_match: usize,
-    /// The pane this search applies to.
-    pane_id: PaneId,
-    /// True on the first frame after opening, for initial focus.
-    just_opened: bool,
-}
-
-/// State for vi-style copy mode (scrollback navigation + visual selection).
-struct CopyModeState {
-    pane_id: PaneId,
-    /// Cursor position in (col, phys_row).
-    cursor: (usize, usize),
-    /// Visual selection anchor (col, phys_row), set when 'v' is pressed.
-    visual_anchor: Option<(usize, usize)>,
-    /// Line-visual mode (V).
-    line_visual: bool,
-}
-
-/// Word boundary delimiters for double-click selection.
-const WORD_DELIMITERS: &str = " \t\n()[]{}'\"|<>&;:,.`~!@#$%^*-+=?/\\";
 
 #[allow(clippy::too_many_arguments)]
 fn spawn_surface(
@@ -1354,6 +1242,7 @@ impl AmuxApp {
                     saved_panes.insert(
                         pane_id,
                         amux_session::SavedManagedPane {
+                            panel_type: managed.panel_type().to_string(),
                             surfaces,
                             active_surface_idx: managed.active_surface_idx,
                         },

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -603,6 +603,14 @@ fn restore_session(
 
     for saved_ws in &session.workspaces {
         for (&pane_id, saved_pane) in &saved_ws.panes {
+            if saved_pane.panel_type != amux_session::PANEL_TYPE_TERMINAL {
+                tracing::warn!(
+                    "Skipping pane {} with unsupported panel type {:?}",
+                    pane_id,
+                    saved_pane.panel_type,
+                );
+                continue;
+            }
             let mut surfaces = Vec::new();
             for saved_sf in &saved_pane.surfaces {
                 let cwd = saved_sf.working_dir.as_deref();

--- a/crates/amux-app/src/managed_pane.rs
+++ b/crates/amux-app/src/managed_pane.rs
@@ -1,0 +1,211 @@
+//! Managed pane types for the amux application.
+//!
+//! Currently all panes are terminal panes (`ManagedPane`). When a second
+//! panel type is introduced (e.g., markdown viewer, browser), extract the
+//! common interface into a `Panel` trait or enum:
+//!
+//! ```ignore
+//! pub(crate) trait Panel {
+//!     fn id(&self) -> PaneId;
+//!     fn panel_type(&self) -> &'static str;
+//!     fn title(&self) -> String;
+//!     fn is_alive(&self) -> bool;
+//!     fn panel_info(&self) -> PanelInfo;
+//!     fn resize(&mut self, cols: u16, rows: u16);
+//!     fn focus_changed(&mut self, focused: bool);
+//! }
+//! ```
+//!
+//! Then change `AmuxApp.panes` from `HashMap<PaneId, ManagedPane>`
+//! to `HashMap<PaneId, Box<dyn Panel>>` (or an enum).
+
+use std::sync::mpsc;
+
+use amux_layout::PaneId;
+use amux_term::pane::TerminalPane;
+
+// ---------------------------------------------------------------------------
+// Data Model
+// ---------------------------------------------------------------------------
+// Hierarchy: Workspace > PaneTree (splits) > Pane (each has tab bar) > Surface (terminal tab)
+
+/// Per-surface metadata reported by shell integration, agent hooks, or OSC sequences.
+#[derive(Default, Clone)]
+pub(crate) struct SurfaceMetadata {
+    pub(crate) cwd: Option<String>,
+    pub(crate) git_branch: Option<String>,
+    pub(crate) git_dirty: bool,
+    pub(crate) pr_number: Option<u32>,
+    pub(crate) pr_title: Option<String>,
+    pub(crate) pr_state: Option<String>, // "open", "merged", "closed"
+    /// Surface title from OSC 0/2 (window title set by shell/agent).
+    pub(crate) surface_title: Option<String>,
+}
+
+/// A terminal tab within a pane. Each pane can have multiple surfaces.
+pub(crate) struct PaneSurface {
+    pub(crate) id: u64,
+    pub(crate) pane: TerminalPane,
+    pub(crate) byte_rx: mpsc::Receiver<Vec<u8>>,
+    pub(crate) scroll_offset: usize,
+    pub(crate) scroll_accum: f32,
+    pub(crate) metadata: SurfaceMetadata,
+    /// User-set title override. When set, takes precedence over OSC 0/2 title.
+    pub(crate) user_title: Option<String>,
+}
+
+/// A leaf in the split tree. Each pane has its own tab bar with surfaces.
+pub(crate) struct ManagedPane {
+    pub(crate) surfaces: Vec<PaneSurface>,
+    pub(crate) active_surface_idx: usize,
+    pub(crate) selection: Option<SelectionState>,
+}
+
+#[allow(dead_code)]
+impl ManagedPane {
+    pub(crate) fn active_surface(&self) -> &PaneSurface {
+        &self.surfaces[self.active_surface_idx]
+    }
+
+    pub(crate) fn active_surface_mut(&mut self) -> &mut PaneSurface {
+        &mut self.surfaces[self.active_surface_idx]
+    }
+
+    /// Display title for this pane (user title > OSC title > shell fallback).
+    pub(crate) fn title(&self) -> String {
+        let surface = self.active_surface();
+        if let Some(ref t) = surface.user_title {
+            return t.clone();
+        }
+        if let Some(ref t) = surface.metadata.surface_title {
+            return t.clone();
+        }
+        surface.pane.title().to_string()
+    }
+
+    /// Whether the active surface's PTY process is still alive.
+    pub(crate) fn is_alive(&mut self) -> bool {
+        self.active_surface_mut().pane.is_alive()
+    }
+
+    /// Current dimensions (cols, rows) of the active surface.
+    pub(crate) fn dimensions(&self) -> (usize, usize) {
+        self.active_surface().pane.dimensions()
+    }
+
+    /// Panel type identifier for future multi-panel support.
+    pub(crate) fn panel_type(&self) -> &'static str {
+        "terminal"
+    }
+
+    /// Drain pending PTY output from the byte channel into the terminal state machine.
+    /// Returns `true` if any bytes were processed (screen may need repaint).
+    pub(crate) fn drain_pty_output(&mut self) -> bool {
+        let surface = &mut self.surfaces[self.active_surface_idx];
+        let mut any = false;
+        while let Ok(bytes) = surface.byte_rx.try_recv() {
+            surface.pane.feed_bytes(&bytes);
+            any = true;
+        }
+        any
+    }
+
+    /// Summary info for sidebar/IPC without exposing terminal internals.
+    pub(crate) fn panel_info(&mut self) -> PanelInfo {
+        PanelInfo {
+            panel_type: self.panel_type(),
+            title: self.title(),
+            is_alive: self.is_alive(),
+            surface_count: self.surfaces.len(),
+        }
+    }
+}
+
+/// Summary of a pane's state, usable without knowing the concrete panel type.
+#[allow(dead_code)]
+pub(crate) struct PanelInfo {
+    pub(crate) panel_type: &'static str,
+    pub(crate) title: String,
+    pub(crate) is_alive: bool,
+    pub(crate) surface_count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SelectionMode {
+    Cell,
+    Word,
+    Line,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SelectionState {
+    pub(crate) anchor: (usize, usize), // (col, stable_row)
+    pub(crate) end: (usize, usize),    // (col, stable_row)
+    pub(crate) mode: SelectionMode,
+    pub(crate) active: bool, // true while mouse is held
+}
+
+impl SelectionState {
+    /// Return (start, end) normalized so start <= end in reading order.
+    pub(crate) fn normalized(&self) -> ((usize, usize), (usize, usize)) {
+        let a = self.anchor;
+        let b = self.end;
+        if a.1 < b.1 || (a.1 == b.1 && a.0 <= b.0) {
+            (a, b)
+        } else {
+            (b, a)
+        }
+    }
+
+    /// Check if a cell at (col, stable_row) is within the selection.
+    pub(crate) fn contains(&self, col: usize, stable_row: usize) -> bool {
+        let (start, end) = self.normalized();
+        if stable_row < start.1 || stable_row > end.1 {
+            return false;
+        }
+        if start.1 == end.1 {
+            // Single line
+            col >= start.0 && col <= end.0
+        } else if stable_row == start.1 {
+            col >= start.0
+        } else if stable_row == end.1 {
+            col <= end.0
+        } else {
+            true // middle line
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Find / Copy Mode
+// ---------------------------------------------------------------------------
+
+/// State for the in-pane find/search bar.
+pub(crate) struct FindState {
+    pub(crate) query: String,
+    /// Matches as (phys_row, start_col, end_col_exclusive).
+    pub(crate) matches: Vec<(usize, usize, usize)>,
+    pub(crate) current_match: usize,
+    /// The pane this search applies to.
+    pub(crate) pane_id: PaneId,
+    /// True on the first frame after opening, for initial focus.
+    pub(crate) just_opened: bool,
+}
+
+/// State for vi-style copy mode (scrollback navigation + visual selection).
+pub(crate) struct CopyModeState {
+    pub(crate) pane_id: PaneId,
+    /// Cursor position in (col, phys_row).
+    pub(crate) cursor: (usize, usize),
+    /// Visual selection anchor (col, phys_row), set when 'v' is pressed.
+    pub(crate) visual_anchor: Option<(usize, usize)>,
+    /// Line-visual mode (V).
+    pub(crate) line_visual: bool,
+}
+
+/// Word boundary delimiters for double-click selection.
+pub(crate) const WORD_DELIMITERS: &str = " \t\n()[]{}'\"|<>&;:,.`~!@#$%^*-+=?/\\";

--- a/crates/amux-app/src/managed_pane.rs
+++ b/crates/amux-app/src/managed_pane.rs
@@ -95,17 +95,20 @@ impl ManagedPane {
 
     /// Panel type identifier for future multi-panel support.
     pub(crate) fn panel_type(&self) -> &'static str {
-        "terminal"
+        amux_session::PANEL_TYPE_TERMINAL
     }
 
-    /// Drain pending PTY output from the byte channel into the terminal state machine.
+    /// Drain pending PTY output from the byte channel into the terminal state machine
+    /// for all surfaces (not just the active one). Background tabs must keep their
+    /// terminal state current so that titles, metadata, and scrollback stay in sync.
     /// Returns `true` if any bytes were processed (screen may need repaint).
     pub(crate) fn drain_pty_output(&mut self) -> bool {
-        let surface = &mut self.surfaces[self.active_surface_idx];
         let mut any = false;
-        while let Ok(bytes) = surface.byte_rx.try_recv() {
-            surface.pane.feed_bytes(&bytes);
-            any = true;
+        for surface in &mut self.surfaces {
+            while let Ok(bytes) = surface.byte_rx.try_recv() {
+                surface.pane.feed_bytes(&bytes);
+                any = true;
+            }
         }
         any
     }

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -46,8 +46,11 @@ pub struct SavedManagedPane {
     pub active_surface_idx: usize,
 }
 
+/// The panel type identifier for terminal panes.
+pub const PANEL_TYPE_TERMINAL: &str = "terminal";
+
 fn default_panel_type() -> String {
-    "terminal".to_string()
+    PANEL_TYPE_TERMINAL.to_string()
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -301,6 +304,18 @@ mod tests {
         }"#;
         let surface: SavedSurface = serde_json::from_str(json).unwrap();
         assert!(surface.user_title.is_none());
+    }
+
+    #[test]
+    fn deserialize_without_panel_type_defaults_to_terminal() {
+        let json = r#"{
+            "surfaces": [
+                { "id": 0, "title": "zsh", "cols": 80, "rows": 24 }
+            ],
+            "active_surface_idx": 0
+        }"#;
+        let pane: SavedManagedPane = serde_json::from_str(json).unwrap();
+        assert_eq!(pane.panel_type, "terminal");
     }
 
     #[test]

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -38,8 +38,16 @@ pub struct SavedWorkspace {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SavedManagedPane {
+    /// Panel type identifier (default "terminal"). Future-proofing for
+    /// non-terminal panels (e.g., markdown, browser).
+    #[serde(default = "default_panel_type")]
+    pub panel_type: String,
     pub surfaces: Vec<SavedSurface>,
     pub active_surface_idx: usize,
+}
+
+fn default_panel_type() -> String {
+    "terminal".to_string()
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -179,6 +187,7 @@ mod tests {
         panes.insert(
             0,
             SavedManagedPane {
+                panel_type: "terminal".to_string(),
                 surfaces: vec![SavedSurface {
                     id: 0,
                     title: "zsh".to_string(),


### PR DESCRIPTION
## Summary

- Extract `ManagedPane`, `PaneSurface`, `SurfaceMetadata`, `SelectionState`, `FindState`, `CopyModeState` from the 5500-line `main.rs` into `managed_pane.rs` (~190 lines)
- Add facade methods (`title()`, `is_alive()`, `dimensions()`, `panel_type()`, `drain_pty_output()`, `panel_info()`) that encapsulate terminal internals
- Add `panel_type` field to `SavedManagedPane` with `serde(default)` for backward-compatible session files
- Document the future Panel trait extraction point (when a second panel type arrives)

### Design decision

The issue proposed `Box<dyn Panel>` with a trait. After analysis, all 71 access sites in main.rs assume terminal semantics — wrapping them in downcasts would produce worse code with zero functional gain while there's only one panel type. Instead, this PR:

1. **Extracts the module** — making future trait extraction trivial
2. **Adds facade methods** — the future trait interface, already implemented
3. **Future-proofs session format** — `panel_type` field ready for non-terminal panels
4. **Documents the path forward** — trait definition in doc comments

When a second panel type arrives, the migration is: extract the trait from the existing facade methods, rename `ManagedPane` → `TerminalPanel`, change the HashMap value type. All mechanical.

## Test plan

- [x] `cargo build --workspace` — compiles clean
- [x] `cargo clippy --workspace -- -D warnings` — no warnings  
- [x] `cargo test --workspace` — all tests pass (including 7 session serde tests)
- [x] Session backward compatibility: old files without `panel_type` deserialize with default `"terminal"`
- [ ] Smoke test: verify app launches and terminal panes work normally

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized terminal pane management architecture to improve code structure and maintainability.
  
* **Sessions**
  * Enhanced session persistence to capture panel type information for more accurate session restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->