### PR TITLE
Add per-surface PTY byte budget to prevent input lag

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1518,15 +1518,32 @@ impl eframe::App for AmuxApp {
         self.selection_changed = false;
         self.app_focused = ctx.input(|i| i.focused);
 
-        // Drain PTY output from all surfaces in all panes
+        // Drain PTY output from all surfaces, with a per-surface byte budget
+        // to prevent high-throughput output (e.g. `cat large_file`) from
+        // blocking input handling and causing frame drops.
+        const MAX_BYTES_PER_SURFACE_PER_FRAME: usize = 64 * 1024;
         let mut got_data = false;
+        let mut pending_data = false;
         for managed in self.panes.values_mut() {
             for surface in &mut managed.surfaces {
-                while let Ok(bytes) = surface.byte_rx.try_recv() {
-                    got_data = true;
-                    surface.pane.feed_bytes(&bytes);
+                let mut bytes_this_frame = 0;
+                while bytes_this_frame < MAX_BYTES_PER_SURFACE_PER_FRAME {
+                    match surface.byte_rx.try_recv() {
+                        Ok(bytes) => {
+                            bytes_this_frame += bytes.len();
+                            got_data = true;
+                            surface.pane.feed_bytes(&bytes);
+                        }
+                        Err(_) => break,
+                    }
+                }
+                if bytes_this_frame >= MAX_BYTES_PER_SURFACE_PER_FRAME {
+                    pending_data = true;
                 }
             }
+        }
+        if pending_data {
+            ctx.request_repaint();
         }
 
         // Handle clicks on system notifications (navigate to workspace/pane).

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1335,7 +1335,14 @@ impl AmuxApp {
                                     .map(|p| p.to_string_lossy().to_string())
                                     .or_else(|| sf.pane.child_pid().and_then(get_cwd_from_pid))
                             });
-                            let scrollback = sf.pane.read_scrollback_text(4096);
+                            let raw_scrollback = sf
+                                .pane
+                                .read_scrollback_text(amux_session::MAX_SCROLLBACK_LINES);
+                            let scrollback = amux_session::truncate_scrollback(
+                                &raw_scrollback,
+                                amux_session::MAX_SCROLLBACK_CHARS,
+                            )
+                            .to_string();
                             let (cols, rows) = sf.pane.dimensions();
                             amux_session::SavedSurface {
                                 id: sf.id,

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1338,11 +1338,15 @@ impl AmuxApp {
                             let raw_scrollback = sf
                                 .pane
                                 .read_scrollback_text(amux_session::MAX_SCROLLBACK_LINES);
-                            let scrollback = amux_session::truncate_scrollback(
+                            let truncated = amux_session::truncate_scrollback(
                                 &raw_scrollback,
-                                amux_session::MAX_SCROLLBACK_CHARS,
-                            )
-                            .to_string();
+                                amux_session::MAX_SCROLLBACK_BYTES,
+                            );
+                            let scrollback = if truncated.len() == raw_scrollback.len() {
+                                raw_scrollback
+                            } else {
+                                truncated.to_string()
+                            };
                             let (cols, rows) = sf.pane.dimensions();
                             amux_session::SavedSurface {
                                 id: sf.id,

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -5,6 +5,29 @@ use std::path::PathBuf;
 use amux_layout::PaneTree;
 use serde::{Deserialize, Serialize};
 
+// --- Limits ---
+
+/// Maximum scrollback lines saved per surface.
+pub const MAX_SCROLLBACK_LINES: usize = 4_000;
+
+/// Maximum total characters of scrollback saved per surface.
+/// Prevents unbounded session file growth from long lines (e.g., minified JSON).
+pub const MAX_SCROLLBACK_CHARS: usize = 400_000;
+
+/// Truncate scrollback text to fit within `max_chars`, keeping the most recent
+/// output (truncating from the top). Avoids cutting mid-line.
+pub fn truncate_scrollback(text: &str, max_chars: usize) -> &str {
+    if text.len() <= max_chars {
+        return text;
+    }
+    let excess = text.len() - max_chars;
+    // Find the next newline after the truncation point to avoid mid-line cut.
+    match text[excess..].find('\n') {
+        Some(i) => &text[excess + i + 1..],
+        None => &text[excess..],
+    }
+}
+
 // --- Data Model ---
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -305,5 +328,31 @@ mod tests {
 
         let result = load_from_path(&path).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn truncate_scrollback_noop_when_under_limit() {
+        let text = "line1\nline2\nline3\n";
+        assert_eq!(truncate_scrollback(text, 1000), text);
+    }
+
+    #[test]
+    fn truncate_scrollback_cuts_from_top() {
+        let text = "aaaa\nbbbb\ncccc\ndddd\n";
+        // 20 chars, limit=15: excess=5, text[5..]="bbbb\ncccc\ndddd\n",
+        // find('\n')=Some(4), start=5+4+1=10, text[10..]="cccc\ndddd\n"
+        let result = truncate_scrollback(text, 15);
+        assert_eq!(result, "cccc\ndddd\n");
+    }
+
+    #[test]
+    fn truncate_scrollback_avoids_mid_line_cut() {
+        // "abc\ndef\nghi\n" = 12 chars, limit 8 → excess 4
+        // text[4..] = "def\nghi\n", first \n at index 3 → skip to "ghi\n"
+        // Wait: excess=4, text[4..]="def\nghi\n", find('\n')=Some(3), so start=4+3+1=8
+        // text[8..] = "ghi\n"
+        let text = "abc\ndef\nghi\n";
+        let result = truncate_scrollback(text, 8);
+        assert_eq!(result, "ghi\n");
     }
 }

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -10,17 +10,22 @@ use serde::{Deserialize, Serialize};
 /// Maximum scrollback lines saved per surface.
 pub const MAX_SCROLLBACK_LINES: usize = 4_000;
 
-/// Maximum total characters of scrollback saved per surface.
+/// Maximum total bytes of scrollback saved per surface.
 /// Prevents unbounded session file growth from long lines (e.g., minified JSON).
-pub const MAX_SCROLLBACK_CHARS: usize = 400_000;
+pub const MAX_SCROLLBACK_BYTES: usize = 400_000;
 
-/// Truncate scrollback text to fit within `max_chars`, keeping the most recent
-/// output (truncating from the top). Avoids cutting mid-line.
-pub fn truncate_scrollback(text: &str, max_chars: usize) -> &str {
-    if text.len() <= max_chars {
+/// Truncate scrollback text to fit within `max_bytes`, keeping the most recent
+/// output (truncating from the top). Avoids cutting mid-line when possible.
+/// Safe for multi-byte UTF-8: advances to the next char boundary if needed.
+pub fn truncate_scrollback(text: &str, max_bytes: usize) -> &str {
+    if text.len() <= max_bytes {
         return text;
     }
-    let excess = text.len() - max_chars;
+    let mut excess = text.len() - max_bytes;
+    // Advance to a valid UTF-8 char boundary.
+    while excess < text.len() && !text.is_char_boundary(excess) {
+        excess += 1;
+    }
     // Find the next newline after the truncation point to avoid mid-line cut.
     match text[excess..].find('\n') {
         Some(i) => &text[excess + i + 1..],
@@ -347,12 +352,40 @@ mod tests {
 
     #[test]
     fn truncate_scrollback_avoids_mid_line_cut() {
-        // "abc\ndef\nghi\n" = 12 chars, limit 8 → excess 4
+        // "abc\ndef\nghi\n" = 12 bytes, limit 8 → excess 4
         // text[4..] = "def\nghi\n", first \n at index 3 → skip to "ghi\n"
-        // Wait: excess=4, text[4..]="def\nghi\n", find('\n')=Some(3), so start=4+3+1=8
-        // text[8..] = "ghi\n"
         let text = "abc\ndef\nghi\n";
         let result = truncate_scrollback(text, 8);
         assert_eq!(result, "ghi\n");
+    }
+
+    #[test]
+    fn truncate_scrollback_multibyte_utf8() {
+        // "你好\n世界\n" = 6+1+6+1 = 14 bytes
+        let text = "你好\n世界\n";
+        assert_eq!(text.len(), 14);
+        // limit=8 → excess=6, byte 6 is '\n', find('\n')=Some(0), start=6+0+1=7
+        let result = truncate_scrollback(text, 8);
+        assert_eq!(result, "世界\n");
+    }
+
+    #[test]
+    fn truncate_scrollback_mid_codepoint_boundary() {
+        // "café\ndata\n" — 'é' is 2 bytes (0xC3 0xA9), total = 5+1+5 = 11 bytes
+        let text = "café\ndata\n";
+        assert_eq!(text.len(), 11);
+        // limit=7 → excess=4, byte 4 is inside 'é' (0xA9), advance to 5 ('\n')
+        // find('\n')=Some(0), start=5+0+1=6
+        let result = truncate_scrollback(text, 7);
+        assert_eq!(result, "data\n");
+    }
+
+    #[test]
+    fn truncate_scrollback_no_newline() {
+        // Single long line with no newlines — falls through to &text[excess..]
+        let text = "abcdefghijklmnop";
+        let result = truncate_scrollback(text, 10);
+        // excess=6, no newline found, returns text[6..] = "ghijklmnop"
+        assert_eq!(result, "ghijklmnop");
     }
 }


### PR DESCRIPTION
## Summary

- Cap each surface to 64KB of PTY output per frame in the `update()` loop
- When a surface hits the budget, call `ctx.request_repaint()` so remaining bytes drain across subsequent frames
- `flush_pending_io()` (pre-session-save) remains unbounded — no data loss

At 60fps this allows ~3.8MB/s per surface, more than enough for interactive use. During `cat large_file`, the terminal catches up across multiple frames without blocking keyboard/mouse input.

## Test plan

- [x] All 77 workspace tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: run `cat /dev/urandom | base64 | head -c 100000000` while typing — keystrokes should appear with <50ms latency
- [ ] Manual: verify `flush_pending_io()` still drains everything before session save

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable scrollback limits for sessions.

* **Bug Fixes**
  * Improved UI frame update performance by enforcing per-surface byte limits, preventing rendering lag during high data throughput.
  * Session saving now dynamically manages scrollback with intelligent truncation at UTF-8 boundaries and newline alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->