### PR TITLE
Eliminate font/color duplication between renderers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ name = "amux-term"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cosmic-text",
  "portable-pty",
  "tracing",
  "tracing-subscriber",

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -5,8 +5,7 @@ mod pipeline;
 pub mod snapshot;
 
 use amux_term::font::{self, FontConfig};
-use cosmic_text::fontdb::Family;
-use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, SwashCache};
+use cosmic_text::{Metrics, SwashCache};
 
 use atlas::GlyphAtlas;
 use callback::{PhysRect, TerminalGpuResources, TerminalPaintCallback};
@@ -52,55 +51,7 @@ impl GpuRenderer {
             ..Default::default()
         });
 
-        let t0 = std::time::Instant::now();
-        let mut font_system = FontSystem::new();
-        tracing::info!(
-            "FontSystem::new() loaded {} fonts in {:.0?}",
-            font_system.db().len(),
-            t0.elapsed()
-        );
-
-        // Load bundled IBM Plex Mono (all weights/styles) so they're always
-        // available as our default. Italic faces are needed because cosmic-text
-        // 0.12 does not synthesize faux italic.
-        font_system
-            .db_mut()
-            .load_font_data(font::MONO_REGULAR.to_vec());
-        font_system
-            .db_mut()
-            .load_font_data(font::MONO_BOLD.to_vec());
-        font_system
-            .db_mut()
-            .load_font_data(font::MONO_ITALIC.to_vec());
-        font_system
-            .db_mut()
-            .load_font_data(font::MONO_BOLD_ITALIC.to_vec());
-
-        // Default to the bundled IBM Plex Mono for Family::Monospace resolution.
-        font_system
-            .db_mut()
-            .set_monospace_family(font::DEFAULT_FONT_FAMILY);
-
-        // Override with the user-configured family if it's available and differs
-        // from the default.
-        let family = &font_config.family;
-        if family != font::DEFAULT_FONT_FAMILY {
-            let has_family = font_system.db().faces().any(|f| {
-                f.families
-                    .iter()
-                    .any(|(name, _)| name.eq_ignore_ascii_case(family))
-            });
-            if has_family {
-                font_system.db_mut().set_monospace_family(family);
-            } else {
-                tracing::warn!(
-                    "Font family '{}' not found, falling back to {}",
-                    family,
-                    font::DEFAULT_FONT_FAMILY,
-                );
-            }
-        }
-
+        let mut font_system = font::create_font_system(font_config);
         let swash_cache = SwashCache::new();
 
         let font_size = font_config.size;
@@ -108,7 +59,7 @@ impl GpuRenderer {
         let metrics = Metrics::new(font_size, line_height);
         // Ceil cell width to an integer pixel to prevent hairline gaps between
         // adjacent cells caused by fractional coordinates accumulating rounding errors.
-        let cell_width = measure_cell_width(&mut font_system, metrics).ceil();
+        let cell_width = font::measure_cell_width(&mut font_system, metrics).ceil();
         let cell_height = line_height;
 
         // Register resources in egui's callback_resources.
@@ -191,7 +142,7 @@ impl GpuRenderer {
             .callback_resources
             .get_mut::<TerminalGpuResources>()
         {
-            let cell_width = measure_cell_width(&mut r.font_system, metrics).ceil();
+            let cell_width = font::measure_cell_width(&mut r.font_system, metrics).ceil();
             r.metrics = metrics;
             // Clear all pane render states to force full rebuild with new metrics.
             r.pane_states.clear();
@@ -218,30 +169,4 @@ impl GpuRenderer {
             r.evict_unused_images();
         }
     }
-}
-
-/// Measure monospace cell width by laying out "M" and reading the advance.
-/// Uses `Family::Monospace` which resolves to whatever was set via
-/// `set_monospace_family()` (the user's configured font or system default).
-fn measure_cell_width(font_system: &mut FontSystem, metrics: Metrics) -> f32 {
-    let mut buffer = Buffer::new_empty(metrics);
-    {
-        let mut borrowed = buffer.borrow_with(font_system);
-        borrowed.set_size(Some(200.0), Some(metrics.line_height));
-        borrowed.set_text(
-            "M",
-            Attrs::new().family(Family::Monospace),
-            Shaping::Advanced,
-        );
-        borrowed.shape_until_scroll(true);
-    }
-
-    for run in buffer.layout_runs() {
-        if let Some(glyph) = run.glyphs.iter().next() {
-            return glyph.w;
-        }
-    }
-
-    // Fallback: estimate from font size
-    metrics.font_size * 0.6
 }

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use wezterm_term::color::{ColorAttribute, ColorPalette, SrgbaTuple};
+use amux_term::color::{resolve_color, srgba_to_f32};
+use wezterm_term::color::{ColorPalette, SrgbaTuple};
 use wezterm_term::image::{ImageData, ImageDataType};
 use wezterm_term::CursorPosition;
 
@@ -308,30 +309,6 @@ fn decode_images(seen: HashMap<[u8; 32], Arc<ImageData>>) -> Vec<DecodedImage> {
         }
     }
     result
-}
-
-fn resolve_color(
-    color: &ColorAttribute,
-    palette: &ColorPalette,
-    is_fg: bool,
-    reverse: bool,
-) -> SrgbaTuple {
-    let effective_is_fg = if reverse { !is_fg } else { is_fg };
-    if effective_is_fg {
-        palette.resolve_fg(*color)
-    } else {
-        palette.resolve_bg(*color)
-    }
-}
-
-/// Convert wezterm-term color tuple to [f32; 4].
-///
-/// Colors are kept in sRGB space here. The GPU callback converts to linear
-/// only when the render target uses an sRGB format (which applies hardware
-/// linear→sRGB on store). For non-sRGB targets (e.g., Bgra8Unorm on macOS),
-/// sRGB values are passed through directly.
-fn srgba_to_f32(c: SrgbaTuple) -> [f32; 4] {
-    [c.0, c.1, c.2, c.3]
 }
 
 /// Dim a color by multiplying RGB channels toward black.

--- a/crates/amux-render-soft/src/lib.rs
+++ b/crates/amux-render-soft/src/lib.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
+use amux_term::color::{resolve_color, srgba_to_rgba8};
 use amux_term::font::{self, FontConfig};
 use cosmic_text::fontdb::Family;
 use cosmic_text::{
     Attrs, Buffer, CacheKey, FontSystem, Metrics, Shaping, SwashCache, SwashContent, SwashImage,
 };
-use wezterm_term::color::{ColorAttribute, ColorPalette, SrgbaTuple};
+use wezterm_term::color::ColorPalette;
 
 /// RGBA pixel (4 bytes).
 pub type Pixel = [u8; 4];
@@ -36,62 +37,14 @@ struct CachedGlyph {
 impl SoftRenderer {
     /// Create a new renderer with the given font configuration.
     pub fn new(font_config: &FontConfig) -> Self {
-        let t0 = std::time::Instant::now();
-        let mut font_system = FontSystem::new();
-        tracing::info!(
-            "SoftRenderer FontSystem::new() loaded {} fonts in {:.0?}",
-            font_system.db().len(),
-            t0.elapsed()
-        );
-
-        // Load bundled IBM Plex Mono (all weights/styles) so they're always
-        // available as our default. Italic faces are needed because cosmic-text
-        // 0.12 does not synthesize faux italic.
-        font_system
-            .db_mut()
-            .load_font_data(font::MONO_REGULAR.to_vec());
-        font_system
-            .db_mut()
-            .load_font_data(font::MONO_BOLD.to_vec());
-        font_system
-            .db_mut()
-            .load_font_data(font::MONO_ITALIC.to_vec());
-        font_system
-            .db_mut()
-            .load_font_data(font::MONO_BOLD_ITALIC.to_vec());
-
-        // Default to the bundled IBM Plex Mono for Family::Monospace resolution.
-        font_system
-            .db_mut()
-            .set_monospace_family(font::DEFAULT_FONT_FAMILY);
-
-        // Override with the user-configured family if it's available and differs
-        // from the default.
-        let family = &font_config.family;
-        if family != font::DEFAULT_FONT_FAMILY {
-            let has_family = font_system.db().faces().any(|f| {
-                f.families
-                    .iter()
-                    .any(|(name, _)| name.eq_ignore_ascii_case(family))
-            });
-            if has_family {
-                font_system.db_mut().set_monospace_family(family);
-            } else {
-                tracing::warn!(
-                    "Font family '{}' not found, falling back to {}",
-                    family,
-                    font::DEFAULT_FONT_FAMILY,
-                );
-            }
-        }
-
+        let mut font_system = font::create_font_system(font_config);
         let swash_cache = SwashCache::new();
 
         let font_size = font_config.size;
         let line_height = (font_size * 1.3).ceil();
         let metrics = Metrics::new(font_size, line_height);
 
-        let cell_width = measure_cell_width(&mut font_system, metrics).ceil();
+        let cell_width = font::measure_cell_width(&mut font_system, metrics).ceil();
         let cell_height = line_height;
 
         Self {
@@ -384,29 +337,6 @@ impl SoftRenderer {
 }
 
 /// Measure monospace cell width by laying out "M" and reading the advance.
-fn measure_cell_width(font_system: &mut FontSystem, metrics: Metrics) -> f32 {
-    let mut buffer = Buffer::new_empty(metrics);
-    {
-        let mut borrowed = buffer.borrow_with(font_system);
-        borrowed.set_size(Some(200.0), Some(metrics.line_height));
-        borrowed.set_text(
-            "M",
-            Attrs::new().family(Family::Monospace),
-            Shaping::Advanced,
-        );
-        borrowed.shape_until_scroll(true);
-    }
-
-    for run in buffer.layout_runs() {
-        if let Some(glyph) = run.glyphs.iter().next() {
-            return glyph.w;
-        }
-    }
-
-    // Fallback: estimate from font size
-    metrics.font_size * 0.6
-}
-
 /// Alpha-blend src over dst (premultiplied).
 fn blend_pixel(dst: &mut [u8], src: &[u8]) {
     let sa = src[3] as u32;
@@ -415,27 +345,4 @@ fn blend_pixel(dst: &mut [u8], src: &[u8]) {
     dst[1] = ((src[1] as u32 * sa + dst[1] as u32 * da) / 255) as u8;
     dst[2] = ((src[2] as u32 * sa + dst[2] as u32 * da) / 255) as u8;
     dst[3] = (sa + dst[3] as u32 * da / 255).min(255) as u8;
-}
-
-fn resolve_color(
-    color: &ColorAttribute,
-    palette: &ColorPalette,
-    is_fg: bool,
-    reverse: bool,
-) -> SrgbaTuple {
-    let effective_is_fg = if reverse { !is_fg } else { is_fg };
-    if effective_is_fg {
-        palette.resolve_fg(*color)
-    } else {
-        palette.resolve_bg(*color)
-    }
-}
-
-fn srgba_to_rgba8(color: SrgbaTuple) -> Pixel {
-    [
-        (color.0 * 255.0).round() as u8,
-        (color.1 * 255.0).round() as u8,
-        (color.2 * 255.0).round() as u8,
-        (color.3 * 255.0).round() as u8,
-    ]
 }

--- a/crates/amux-term/Cargo.toml
+++ b/crates/amux-term/Cargo.toml
@@ -10,6 +10,7 @@ wezterm-term = { workspace = true }
 portable-pty = { workspace = true }
 winit = { workspace = true }
 url = { workspace = true }
+cosmic-text = { workspace = true }
 tracing = { workspace = true }
 anyhow = "1"
 

--- a/crates/amux-term/src/color.rs
+++ b/crates/amux-term/src/color.rs
@@ -20,6 +20,11 @@ pub fn resolve_color(
     }
 }
 
+/// Convert an `SrgbaTuple` to `[f32; 4]` (identity — for GPU uniform buffers).
+pub fn srgba_to_f32(color: SrgbaTuple) -> [f32; 4] {
+    [color.0, color.1, color.2, color.3]
+}
+
 /// Convert an `SrgbaTuple` (f32 components 0.0–1.0) to 8-bit RGBA.
 pub fn srgba_to_rgba8(color: SrgbaTuple) -> [u8; 4] {
     [

--- a/crates/amux-term/src/font.rs
+++ b/crates/amux-term/src/font.rs
@@ -1,3 +1,6 @@
+use cosmic_text::fontdb::Family;
+use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping};
+
 /// Bundled font bytes (IBM Plex, SIL OFL license). Single source of truth —
 /// all crates reference these statics instead of their own `include_bytes!`.
 pub static MONO_REGULAR: &[u8] = include_bytes!("../fonts/IBMPlexMono-Regular.ttf");
@@ -28,4 +31,74 @@ impl Default for FontConfig {
             size: DEFAULT_FONT_SIZE,
         }
     }
+}
+
+/// Create a `FontSystem` with bundled fonts loaded and the monospace family
+/// set according to `config`. This is the single initialization point used
+/// by both the soft and GPU renderers.
+pub fn create_font_system(config: &FontConfig) -> FontSystem {
+    let t0 = std::time::Instant::now();
+    let mut font_system = FontSystem::new();
+    tracing::info!(
+        "FontSystem::new() loaded {} fonts in {:.0?}",
+        font_system.db().len(),
+        t0.elapsed()
+    );
+
+    font_system.db_mut().load_font_data(MONO_REGULAR.to_vec());
+    font_system.db_mut().load_font_data(MONO_BOLD.to_vec());
+    font_system.db_mut().load_font_data(MONO_ITALIC.to_vec());
+    font_system
+        .db_mut()
+        .load_font_data(MONO_BOLD_ITALIC.to_vec());
+
+    font_system
+        .db_mut()
+        .set_monospace_family(DEFAULT_FONT_FAMILY);
+
+    // Override with the user-configured family if available.
+    let family = &config.family;
+    if family != DEFAULT_FONT_FAMILY {
+        let has_family = font_system.db().faces().any(|f| {
+            f.families
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case(family))
+        });
+        if has_family {
+            font_system.db_mut().set_monospace_family(family);
+        } else {
+            tracing::warn!(
+                "Font family '{}' not found, falling back to {}",
+                family,
+                DEFAULT_FONT_FAMILY,
+            );
+        }
+    }
+
+    font_system
+}
+
+/// Measure the width of a single monospace cell by laying out "M" with
+/// cosmic-text and reading the glyph advance. Falls back to `font_size * 0.6`.
+pub fn measure_cell_width(font_system: &mut FontSystem, metrics: Metrics) -> f32 {
+    let mut buffer = Buffer::new_empty(metrics);
+    {
+        let mut borrowed = buffer.borrow_with(font_system);
+        borrowed.set_size(Some(200.0), Some(metrics.line_height));
+        borrowed.set_text(
+            "M",
+            Attrs::new().family(Family::Monospace),
+            Shaping::Advanced,
+        );
+        borrowed.shape_until_scroll(true);
+    }
+
+    for run in buffer.layout_runs() {
+        if let Some(glyph) = run.glyphs.iter().next() {
+            return glyph.w;
+        }
+    }
+
+    // Fallback: estimate from font size
+    metrics.font_size * 0.6
 }


### PR DESCRIPTION
## Summary

- Move `create_font_system()` and `measure_cell_width()` to `amux-term::font` as the single source of truth
- Move `srgba_to_f32()` to `amux-term::color`
- Delete duplicate `resolve_color()` from both renderers (now imported from `amux-term`)
- Delete duplicate `srgba_to_rgba8()` from soft renderer
- Delete duplicate `measure_cell_width()` from both renderers
- Delete ~50 lines of font init boilerplate from each renderer (now one call to `create_font_system()`)

Net result: -111 lines across 7 files. Both renderers now stay in sync automatically.

## Test plan

- [x] All 78 workspace tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: verify soft renderer still renders correctly
- [ ] Manual: verify GPU renderer still renders correctly
- [ ] Manual: verify custom font family override still works

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)