### PR TITLE
Bidirectional IPC with event subscriptions

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -404,7 +404,7 @@ fn main() -> anyhow::Result<()> {
         player.configure(&app_config.notifications.sound.sound);
     }
 
-    let (ipc_rx, ipc_addr) = amux_ipc::start_server()?;
+    let (ipc_rx, ipc_addr, event_broadcaster) = amux_ipc::start_server()?;
     tracing::info!("IPC server: {}", ipc_addr);
 
     let theme = theme::Theme::default();
@@ -499,6 +499,7 @@ fn main() -> anyhow::Result<()> {
                 next_surface_id: state.next_surface_id,
                 sidebar: state.sidebar,
                 ipc_rx,
+                event_broadcaster,
                 socket_addr: ipc_addr,
                 config,
                 theme,
@@ -1078,6 +1079,7 @@ struct AmuxApp {
     next_surface_id: u64,
     sidebar: SidebarState,
     ipc_rx: std::sync::mpsc::Receiver<IpcCommand>,
+    event_broadcaster: amux_ipc::EventBroadcaster,
     socket_addr: amux_ipc::IpcAddr,
     config: Arc<AmuxTermConfig>,
     theme: theme::Theme,
@@ -3059,8 +3061,11 @@ impl AmuxApp {
     ) -> u64 {
         let focused = self.focused_pane_id();
         let source_str = source.as_str();
+        // Clone for the IPC broadcast after the notification is stored.
+        let bc_title = title.clone();
+        let bc_body = body.clone();
 
-        if !self.app_focused {
+        let nid = if !self.app_focused {
             // Tier 1: app is unfocused — always treat as background
             if self.app_config.notifications.system_notifications && !skip_toast {
                 self.system_notifier.send(&title, &body, ws_id, pane_id);
@@ -3098,7 +3103,22 @@ impl AmuxApp {
                 self.bubble_workspace(ws_id);
             }
             nid
-        }
+        };
+
+        // Broadcast to subscribed IPC clients
+        self.event_broadcaster.send(amux_ipc::ServerEvent {
+            event: "notification".to_string(),
+            data: serde_json::json!({
+                "notification_id": nid,
+                "workspace_id": ws_id.to_string(),
+                "pane_id": pane_id.to_string(),
+                "title": bc_title,
+                "body": bc_body,
+                "source": source_str,
+            }),
+        });
+
+        nid
     }
 
     /// Move a workspace to the top of the sidebar (just index 0 for now,

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -734,10 +734,14 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
             // Stream events until the connection closes or Ctrl+C
+            let stdout = std::io::stdout();
             loop {
                 match client.read_line().await {
                     Ok(Some(line)) => {
-                        println!("{}", line);
+                        use std::io::Write;
+                        let mut lock = stdout.lock();
+                        let _ = writeln!(lock, "{}", line);
+                        let _ = lock.flush();
                     }
                     Ok(None) => break,
                     Err(e) => {

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -217,6 +217,12 @@ enum Command {
         #[arg(long)]
         uninstall: bool,
     },
+    /// Subscribe to server events and print them as newline-delimited JSON
+    Subscribe {
+        /// Event types to subscribe to (e.g. notification, focus_change)
+        #[arg(required = true)]
+        events: Vec<String>,
+    },
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -709,6 +715,37 @@ async fn main() -> anyhow::Result<()> {
         }
         Command::ClaudeHook { event } => {
             handle_claude_hook(&mut client, &event).await?;
+        }
+        Command::Subscribe { events } => {
+            let resp = client
+                .call("subscribe", serde_json::json!({ "events": events }))
+                .await?;
+            if !resp.ok {
+                print_response(&resp, cli.json);
+                std::process::exit(1);
+            }
+            if cli.json {
+                // Print the subscribe confirmation
+                print_response(&resp, true);
+            } else if let Some(result) = &resp.result {
+                if let Some(subscribed) = result.get("subscribed").and_then(|s| s.as_array()) {
+                    let names: Vec<&str> = subscribed.iter().filter_map(|v| v.as_str()).collect();
+                    eprintln!("Subscribed to: {}", names.join(", "));
+                }
+            }
+            // Stream events until the connection closes or Ctrl+C
+            loop {
+                match client.read_line().await {
+                    Ok(Some(line)) => {
+                        println!("{}", line);
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        eprintln!("Error reading event: {}", e);
+                        break;
+                    }
+                }
+            }
         }
         Command::SessionClear | Command::InstallShellIntegration | Command::InstallHooks { .. } => {
             unreachable!("handled before IPC connection");

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -724,13 +724,12 @@ async fn main() -> anyhow::Result<()> {
                 print_response(&resp, cli.json);
                 std::process::exit(1);
             }
-            if cli.json {
-                // Print the subscribe confirmation
-                print_response(&resp, true);
-            } else if let Some(result) = &resp.result {
+            if let Some(result) = &resp.result {
                 if let Some(subscribed) = result.get("subscribed").and_then(|s| s.as_array()) {
                     let names: Vec<&str> = subscribed.iter().filter_map(|v| v.as_str()).collect();
-                    eprintln!("Subscribed to: {}", names.join(", "));
+                    if !cli.json {
+                        eprintln!("Subscribed to: {}", names.join(", "));
+                    }
                 }
             }
             // Stream events until the connection closes or Ctrl+C

--- a/crates/amux-ipc/src/client.rs
+++ b/crates/amux-ipc/src/client.rs
@@ -66,4 +66,10 @@ impl IpcClient {
         let resp: Response = serde_json::from_str(&line)?;
         Ok(resp)
     }
+
+    /// Read the next line from the server (event or response).
+    /// Returns `None` if the connection is closed.
+    pub async fn read_line(&mut self) -> anyhow::Result<Option<String>> {
+        Ok(self.reader.next_line().await?)
+    }
 }

--- a/crates/amux-ipc/src/lib.rs
+++ b/crates/amux-ipc/src/lib.rs
@@ -7,5 +7,5 @@ pub mod socket_path;
 pub use client::IpcClient;
 pub use protocol::ServerEvent;
 pub use protocol::{Request, Response, RpcError};
-pub use server::{start_server, EventBroadcaster, IpcCommand};
+pub use server::{start_server, EventBroadcaster, IpcCommand, EVENT_TYPES};
 pub use socket_path::{read_last_addr, IpcAddr};

--- a/crates/amux-ipc/src/lib.rs
+++ b/crates/amux-ipc/src/lib.rs
@@ -5,6 +5,7 @@ pub mod server;
 pub mod socket_path;
 
 pub use client::IpcClient;
+pub use protocol::ServerEvent;
 pub use protocol::{Request, Response, RpcError};
-pub use server::{start_server, IpcCommand};
+pub use server::{start_server, EventBroadcaster, IpcCommand};
 pub use socket_path::{read_last_addr, IpcAddr};

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -27,6 +27,8 @@ pub const METHODS: &[&str] = &[
     "notify.list",
     "notify.clear",
     "session.save",
+    "subscribe",
+    "unsubscribe",
 ];
 
 // --- Params ---

--- a/crates/amux-ipc/src/protocol.rs
+++ b/crates/amux-ipc/src/protocol.rs
@@ -27,6 +27,13 @@ pub struct RpcError {
     pub message: String,
 }
 
+/// A server-pushed event (no `id` field — distinguished from responses by `event` field).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerEvent {
+    pub event: String,
+    pub data: serde_json::Value,
+}
+
 impl Response {
     pub fn ok(id: String, result: serde_json::Value) -> Self {
         Self {

--- a/crates/amux-ipc/src/server.rs
+++ b/crates/amux-ipc/src/server.rs
@@ -315,17 +315,21 @@ fn handle_subscribe(request: &Request, subscriptions: &mut HashSet<String>) -> R
     };
 
     let mut subscribed = Vec::new();
+    let mut unknown = Vec::new();
     for event in &events {
         if EVENT_TYPES.contains(&event.as_str()) {
             subscriptions.insert(event.clone());
             subscribed.push(event.clone());
+        } else {
+            unknown.push(event.clone());
         }
     }
 
-    Response::ok(
-        request.id.clone(),
-        serde_json::json!({ "subscribed": subscribed }),
-    )
+    let mut result = serde_json::json!({ "subscribed": subscribed });
+    if !unknown.is_empty() {
+        result["unknown"] = serde_json::json!(unknown);
+    }
+    Response::ok(request.id.clone(), result)
 }
 
 fn handle_unsubscribe(request: &Request, subscriptions: &mut HashSet<String>) -> Response {
@@ -346,13 +350,16 @@ fn handle_unsubscribe(request: &Request, subscriptions: &mut HashSet<String>) ->
         }
     };
 
+    let mut unsubscribed = Vec::new();
     for event in &events {
-        subscriptions.remove(event);
+        if subscriptions.remove(event) {
+            unsubscribed.push(event.clone());
+        }
     }
 
     Response::ok(
         request.id.clone(),
-        serde_json::json!({ "unsubscribed": events }),
+        serde_json::json!({ "unsubscribed": unsubscribed }),
     )
 }
 
@@ -407,7 +414,7 @@ mod tests {
     }
 
     #[test]
-    fn subscribe_ignores_unknown_events() {
+    fn subscribe_reports_unknown_events() {
         let mut subs = HashSet::new();
         let req = make_request(
             "2",
@@ -419,6 +426,24 @@ mod tests {
         assert!(subs.contains("notification"));
         assert!(!subs.contains("bogus"));
         assert_eq!(subs.len(), 1);
+        let result = resp.result.unwrap();
+        let unknown = result.get("unknown").unwrap().as_array().unwrap();
+        assert_eq!(unknown.len(), 1);
+        assert_eq!(unknown[0].as_str().unwrap(), "bogus");
+    }
+
+    #[test]
+    fn subscribe_no_unknown_field_when_all_valid() {
+        let mut subs = HashSet::new();
+        let req = make_request(
+            "2b",
+            "subscribe",
+            serde_json::json!({"events": ["notification"]}),
+        );
+        let resp = handle_subscribe(&req, &mut subs);
+        assert!(resp.ok);
+        let result = resp.result.unwrap();
+        assert!(result.get("unknown").is_none());
     }
 
     #[test]
@@ -448,14 +473,21 @@ mod tests {
         assert!(resp.ok);
         assert!(!subs.contains("notification"));
         assert!(subs.contains("focus_change"));
+        let result = resp.result.unwrap();
+        let unsubscribed = result.get("unsubscribed").unwrap().as_array().unwrap();
+        assert_eq!(unsubscribed.len(), 1);
+        assert_eq!(unsubscribed[0].as_str().unwrap(), "notification");
     }
 
     #[test]
-    fn unsubscribe_nonexistent_is_ok() {
+    fn unsubscribe_nonexistent_returns_empty() {
         let mut subs = HashSet::new();
         let req = make_request("5", "unsubscribe", serde_json::json!({"events": ["bogus"]}));
         let resp = handle_unsubscribe(&req, &mut subs);
         assert!(resp.ok);
+        let result = resp.result.unwrap();
+        let unsubscribed = result.get("unsubscribed").unwrap().as_array().unwrap();
+        assert!(unsubscribed.is_empty());
     }
 
     #[test]

--- a/crates/amux-ipc/src/server.rs
+++ b/crates/amux-ipc/src/server.rs
@@ -1,9 +1,10 @@
+use std::collections::HashSet;
 use std::sync::mpsc as std_mpsc;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::sync::oneshot;
+use tokio::sync::{broadcast, oneshot};
 
-use crate::protocol::{Request, Response};
+use crate::protocol::{Request, Response, ServerEvent};
 use crate::socket_path::{default_addr, write_last_addr, IpcAddr};
 
 /// A command sent from the IPC server to the main (eframe) thread.
@@ -12,17 +13,34 @@ pub struct IpcCommand {
     pub reply_tx: oneshot::Sender<Response>,
 }
 
+/// Handle returned from `start_server` for sending events to connected clients.
+#[derive(Clone)]
+pub struct EventBroadcaster {
+    tx: broadcast::Sender<ServerEvent>,
+}
+
+impl EventBroadcaster {
+    /// Broadcast an event to all subscribed clients. Silently drops if no receivers.
+    pub fn send(&self, event: ServerEvent) {
+        let _ = self.tx.send(event);
+    }
+}
+
 /// Start the IPC server on a background thread.
 ///
-/// Returns the command receiver (for the main thread to drain) and the IPC address.
-/// The socket path is only written after the bind succeeds, avoiding a race where
-/// clients could discover an address that isn't ready yet.
-pub fn start_server() -> anyhow::Result<(std_mpsc::Receiver<IpcCommand>, IpcAddr)> {
+/// Returns the command receiver (for the main thread to drain), the IPC address,
+/// and an `EventBroadcaster` for pushing events to subscribed clients.
+pub fn start_server() -> anyhow::Result<(std_mpsc::Receiver<IpcCommand>, IpcAddr, EventBroadcaster)>
+{
     let addr = default_addr();
     cleanup_stale(&addr);
 
     let (cmd_tx, cmd_rx) = std_mpsc::channel::<IpcCommand>();
     let (bind_tx, bind_rx) = std::sync::mpsc::channel::<Result<(), String>>();
+    let (event_tx, _) = broadcast::channel::<ServerEvent>(256);
+    let broadcaster = EventBroadcaster {
+        tx: event_tx.clone(),
+    };
     let addr_clone = addr.clone();
 
     std::thread::Builder::new()
@@ -32,14 +50,14 @@ pub fn start_server() -> anyhow::Result<(std_mpsc::Receiver<IpcCommand>, IpcAddr
                 .enable_all()
                 .build()
                 .expect("tokio runtime");
-            rt.block_on(run_server(addr_clone, cmd_tx, bind_tx));
+            rt.block_on(run_server(addr_clone, cmd_tx, bind_tx, event_tx));
         })?;
 
     // Wait for the server thread to report bind success/failure
     match bind_rx.recv() {
         Ok(Ok(())) => {
             write_last_addr(&addr)?;
-            Ok((cmd_rx, addr))
+            Ok((cmd_rx, addr, broadcaster))
         }
         Ok(Err(e)) => anyhow::bail!("IPC server bind failed: {}", e),
         Err(_) => anyhow::bail!("IPC server thread exited before binding"),
@@ -69,6 +87,7 @@ async fn run_server(
     addr: IpcAddr,
     cmd_tx: std_mpsc::Sender<IpcCommand>,
     bind_tx: std_mpsc::Sender<Result<(), String>>,
+    event_tx: broadcast::Sender<ServerEvent>,
 ) {
     let IpcAddr::Unix(ref path) = addr;
     let listener = match tokio::net::UnixListener::bind(path) {
@@ -88,8 +107,14 @@ async fn run_server(
         match listener.accept().await {
             Ok((stream, _)) => {
                 let tx = cmd_tx.clone();
+                let event_rx = event_tx.subscribe();
                 let (reader, writer) = stream.into_split();
-                tokio::spawn(handle_connection(BufReader::new(reader), writer, tx));
+                tokio::spawn(handle_connection(
+                    BufReader::new(reader),
+                    writer,
+                    tx,
+                    event_rx,
+                ));
             }
             Err(e) => {
                 tracing::error!("accept error: {}", e);
@@ -107,6 +132,7 @@ async fn run_server(
     addr: IpcAddr,
     cmd_tx: std_mpsc::Sender<IpcCommand>,
     bind_tx: std_mpsc::Sender<Result<(), String>>,
+    event_tx: broadcast::Sender<ServerEvent>,
 ) {
     use tokio::net::windows::named_pipe::ServerOptions;
 
@@ -142,8 +168,14 @@ async fn run_server(
         };
 
         let tx = cmd_tx.clone();
+        let event_rx = event_tx.subscribe();
         let (reader, writer) = tokio::io::split(connected);
-        tokio::spawn(handle_connection(BufReader::new(reader), writer, tx));
+        tokio::spawn(handle_connection(
+            BufReader::new(reader),
+            writer,
+            tx,
+            event_rx,
+        ));
     }
 }
 
@@ -151,41 +183,177 @@ async fn run_server(
 // Shared connection handler
 // ---------------------------------------------------------------------------
 
+/// Known event types that clients can subscribe to.
+pub const EVENT_TYPES: &[&str] = &[
+    "notification",
+    "surface_exit",
+    "focus_change",
+    "status_change",
+];
+
 async fn handle_connection<R, W>(
     reader: BufReader<R>,
     mut writer: W,
     cmd_tx: std_mpsc::Sender<IpcCommand>,
+    mut event_rx: broadcast::Receiver<ServerEvent>,
 ) where
     R: tokio::io::AsyncRead + Unpin,
     W: tokio::io::AsyncWrite + Unpin,
 {
     let mut lines = reader.lines();
+    let mut subscriptions: HashSet<String> = HashSet::new();
 
-    while let Ok(Some(line)) = lines.next_line().await {
-        let request: Request = match serde_json::from_str(&line) {
-            Ok(r) => r,
-            Err(e) => {
-                let err_resp = Response::err(String::new(), "parse_error", &e.to_string());
-                let _ = write_response(&mut writer, &err_resp).await;
-                continue;
+    loop {
+        // If we have subscriptions, use select! to handle both requests and events.
+        // Otherwise, just wait for the next request line.
+        if subscriptions.is_empty() {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    if !handle_request_line(&line, &cmd_tx, &mut writer, &mut subscriptions).await {
+                        break;
+                    }
+                }
+                _ => break,
             }
-        };
-
-        let (reply_tx, reply_rx) = oneshot::channel();
-        let cmd = IpcCommand { request, reply_tx };
-
-        if cmd_tx.send(cmd).is_err() {
-            break; // main thread gone
-        }
-
-        // Wait for the main thread to process and reply.
-        match reply_rx.await {
-            Ok(response) => {
-                let _ = write_response(&mut writer, &response).await;
+        } else {
+            tokio::select! {
+                line_result = lines.next_line() => {
+                    match line_result {
+                        Ok(Some(line)) => {
+                            if !handle_request_line(
+                                &line,
+                                &cmd_tx,
+                                &mut writer,
+                                &mut subscriptions,
+                            ).await {
+                                break;
+                            }
+                        }
+                        _ => break,
+                    }
+                }
+                event_result = event_rx.recv() => {
+                    match event_result {
+                        Ok(event) => {
+                            if subscriptions.contains(&event.event)
+                                && write_event(&mut writer, &event).await.is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!("IPC client lagged, dropped {} events", n);
+                        }
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    }
+                }
             }
-            Err(_) => break,
         }
     }
+}
+
+/// Handle a single request line. Returns `false` if the connection should close.
+async fn handle_request_line<W: tokio::io::AsyncWrite + Unpin>(
+    line: &str,
+    cmd_tx: &std_mpsc::Sender<IpcCommand>,
+    writer: &mut W,
+    subscriptions: &mut HashSet<String>,
+) -> bool {
+    let request: Request = match serde_json::from_str(line) {
+        Ok(r) => r,
+        Err(e) => {
+            let err_resp = Response::err(String::new(), "parse_error", &e.to_string());
+            let _ = write_response(writer, &err_resp).await;
+            return true;
+        }
+    };
+
+    // Handle subscribe/unsubscribe locally in the server (no main thread round-trip).
+    if request.method == "subscribe" {
+        let response = handle_subscribe(&request, subscriptions);
+        let _ = write_response(writer, &response).await;
+        return true;
+    }
+    if request.method == "unsubscribe" {
+        let response = handle_unsubscribe(&request, subscriptions);
+        let _ = write_response(writer, &response).await;
+        return true;
+    }
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let cmd = IpcCommand { request, reply_tx };
+
+    if cmd_tx.send(cmd).is_err() {
+        return false; // main thread gone
+    }
+
+    match reply_rx.await {
+        Ok(response) => {
+            let _ = write_response(writer, &response).await;
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+fn handle_subscribe(request: &Request, subscriptions: &mut HashSet<String>) -> Response {
+    let events: Vec<String> = match serde_json::from_value(
+        request
+            .params
+            .get("events")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+    ) {
+        Ok(v) => v,
+        Err(_) => {
+            return Response::err(
+                request.id.clone(),
+                "invalid_params",
+                "params.events must be an array of strings",
+            );
+        }
+    };
+
+    let mut subscribed = Vec::new();
+    for event in &events {
+        if EVENT_TYPES.contains(&event.as_str()) {
+            subscriptions.insert(event.clone());
+            subscribed.push(event.clone());
+        }
+    }
+
+    Response::ok(
+        request.id.clone(),
+        serde_json::json!({ "subscribed": subscribed }),
+    )
+}
+
+fn handle_unsubscribe(request: &Request, subscriptions: &mut HashSet<String>) -> Response {
+    let events: Vec<String> = match serde_json::from_value(
+        request
+            .params
+            .get("events")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+    ) {
+        Ok(v) => v,
+        Err(_) => {
+            return Response::err(
+                request.id.clone(),
+                "invalid_params",
+                "params.events must be an array of strings",
+            );
+        }
+    };
+
+    for event in &events {
+        subscriptions.remove(event);
+    }
+
+    Response::ok(
+        request.id.clone(),
+        serde_json::json!({ "unsubscribed": events }),
+    )
 }
 
 async fn write_response<W: tokio::io::AsyncWrite + Unpin>(
@@ -197,4 +365,104 @@ async fn write_response<W: tokio::io::AsyncWrite + Unpin>(
     writer.write_all(json.as_bytes()).await?;
     writer.flush().await?;
     Ok(())
+}
+
+async fn write_event<W: tokio::io::AsyncWrite + Unpin>(
+    writer: &mut W,
+    event: &ServerEvent,
+) -> anyhow::Result<()> {
+    let mut json = serde_json::to_string(event)?;
+    json.push('\n');
+    writer.write_all(json.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::Request;
+
+    fn make_request(id: &str, method: &str, params: serde_json::Value) -> Request {
+        Request {
+            id: id.to_string(),
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    #[test]
+    fn subscribe_valid_events() {
+        let mut subs = HashSet::new();
+        let req = make_request(
+            "1",
+            "subscribe",
+            serde_json::json!({"events": ["notification", "focus_change"]}),
+        );
+        let resp = handle_subscribe(&req, &mut subs);
+        assert!(resp.ok);
+        assert!(subs.contains("notification"));
+        assert!(subs.contains("focus_change"));
+        assert_eq!(subs.len(), 2);
+    }
+
+    #[test]
+    fn subscribe_ignores_unknown_events() {
+        let mut subs = HashSet::new();
+        let req = make_request(
+            "2",
+            "subscribe",
+            serde_json::json!({"events": ["notification", "bogus"]}),
+        );
+        let resp = handle_subscribe(&req, &mut subs);
+        assert!(resp.ok);
+        assert!(subs.contains("notification"));
+        assert!(!subs.contains("bogus"));
+        assert_eq!(subs.len(), 1);
+    }
+
+    #[test]
+    fn subscribe_invalid_params() {
+        let mut subs = HashSet::new();
+        let req = make_request(
+            "3",
+            "subscribe",
+            serde_json::json!({"events": "not_an_array"}),
+        );
+        let resp = handle_subscribe(&req, &mut subs);
+        assert!(!resp.ok);
+        assert!(subs.is_empty());
+    }
+
+    #[test]
+    fn unsubscribe_removes_events() {
+        let mut subs = HashSet::new();
+        subs.insert("notification".to_string());
+        subs.insert("focus_change".to_string());
+        let req = make_request(
+            "4",
+            "unsubscribe",
+            serde_json::json!({"events": ["notification"]}),
+        );
+        let resp = handle_unsubscribe(&req, &mut subs);
+        assert!(resp.ok);
+        assert!(!subs.contains("notification"));
+        assert!(subs.contains("focus_change"));
+    }
+
+    #[test]
+    fn unsubscribe_nonexistent_is_ok() {
+        let mut subs = HashSet::new();
+        let req = make_request("5", "unsubscribe", serde_json::json!({"events": ["bogus"]}));
+        let resp = handle_unsubscribe(&req, &mut subs);
+        assert!(resp.ok);
+    }
+
+    #[test]
+    fn event_types_contains_expected() {
+        assert!(EVENT_TYPES.contains(&"notification"));
+        assert!(EVENT_TYPES.contains(&"surface_exit"));
+        assert!(EVENT_TYPES.contains(&"focus_change"));
+        assert!(EVENT_TYPES.contains(&"status_change"));
+    }
 }


### PR DESCRIPTION
## Summary
- Adds server-push events to the IPC protocol via `tokio::sync::broadcast` channels
- Clients subscribe to event types (`notification`, `surface_exit`, `focus_change`, `status_change`) and receive newline-delimited JSON as events occur
- Subscribe/unsubscribe handled locally in the IPC server (no main thread round-trip)
- Notification events broadcast from `deliver_notification` in amux-app
- New `amux subscribe <events...>` CLI command streams events to stdout
- 6 new tests for subscribe/unsubscribe logic

Closes #46 (Phase 1)

## Test plan
- [ ] `cargo test --workspace` — all tests pass including 6 new IPC tests
- [ ] `cargo clippy --workspace -- -D warnings` — no warnings
- [ ] Run `amux subscribe notification` in one terminal, trigger a notification from another — verify JSON event arrives
- [ ] Verify normal request/response flow still works when no subscriptions active
- [ ] Test subscribe with unknown event type — should be silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `amux subscribe` CLI to receive real-time server events (subscribe/unsubscribe support).
  * Server now streams events to subscribed clients and broadcasts notifications to subscribers.
  * CLI prints confirmations (JSON or human-readable) and continuously outputs incoming events until the stream ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->