### PR TITLE
Add token-based IPC socket authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "wezterm-surface",
  "wezterm-term",
  "winit",

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -35,6 +35,7 @@ notify-rust = { workspace = true }
 rodio = { workspace = true }
 muda = { workspace = true }
 winit = { workspace = true }
+uuid = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-foundation = { workspace = true }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -404,7 +404,8 @@ fn main() -> anyhow::Result<()> {
         player.configure(&app_config.notifications.sound.sound);
     }
 
-    let (ipc_rx, ipc_addr, event_broadcaster) = amux_ipc::start_server()?;
+    let socket_token = uuid::Uuid::new_v4().to_string();
+    let (ipc_rx, ipc_addr, event_broadcaster) = amux_ipc::start_server(socket_token.clone())?;
     tracing::info!("IPC server: {}", ipc_addr);
 
     let theme = theme::Theme::default();
@@ -426,9 +427,9 @@ fn main() -> anyhow::Result<()> {
     };
 
     let state = if let Some(session) = restored {
-        restore_session(&session, &ipc_addr, &config)
+        restore_session(&session, &ipc_addr, &socket_token, &config)
     } else {
-        fresh_startup(&ipc_addr, &config)?
+        fresh_startup(&ipc_addr, &socket_token, &config)?
     };
 
     // Force dark appearance on macOS so the title bar matches the app's dark chrome.
@@ -501,6 +502,7 @@ fn main() -> anyhow::Result<()> {
                 ipc_rx,
                 event_broadcaster,
                 socket_addr: ipc_addr,
+                socket_token,
                 config,
                 theme,
                 last_panel_rect: None,
@@ -552,10 +554,11 @@ struct StartupState {
 /// Create a fresh default startup (one workspace, one pane).
 fn fresh_startup(
     ipc_addr: &amux_ipc::IpcAddr,
+    socket_token: &str,
     config: &Arc<AmuxTermConfig>,
 ) -> anyhow::Result<StartupState> {
     let initial_pane_id: PaneId = 0;
-    let surface = spawn_surface(80, 24, ipc_addr, config, 0, 0, None, None)?;
+    let surface = spawn_surface(80, 24, ipc_addr, socket_token, config, 0, 0, None, None)?;
 
     let managed = ManagedPane {
         surfaces: vec![surface],
@@ -597,6 +600,7 @@ fn fresh_startup(
 fn restore_session(
     session: &SessionData,
     ipc_addr: &amux_ipc::IpcAddr,
+    socket_token: &str,
     config: &Arc<AmuxTermConfig>,
 ) -> StartupState {
     let mut workspaces = Vec::new();
@@ -625,6 +629,7 @@ fn restore_session(
                     saved_sf.cols,
                     saved_sf.rows,
                     ipc_addr,
+                    socket_token,
                     config,
                     saved_ws.id,
                     saved_sf.id,
@@ -706,7 +711,7 @@ fn restore_session(
     // If nothing restored, fall back to fresh
     if workspaces.is_empty() {
         tracing::warn!("Session restore produced no workspaces, starting fresh");
-        return match fresh_startup(ipc_addr, config) {
+        return match fresh_startup(ipc_addr, socket_token, config) {
             Ok(result) => result,
             Err(e) => {
                 tracing::error!("Fresh startup also failed: {}", e);
@@ -958,6 +963,7 @@ fn spawn_surface(
     cols: u16,
     rows: u16,
     ipc_addr: &amux_ipc::IpcAddr,
+    socket_token: &str,
     config: &Arc<AmuxTermConfig>,
     workspace_id: u64,
     surface_id: u64,
@@ -967,6 +973,7 @@ fn spawn_surface(
     let shell = default_shell();
     let mut cmd = CommandBuilder::new(&shell);
     cmd.env("AMUX_SOCKET_PATH", ipc_addr.to_string());
+    cmd.env("AMUX_SOCKET_TOKEN", socket_token);
     cmd.env("AMUX_WORKSPACE_ID", workspace_id.to_string());
     cmd.env("AMUX_SURFACE_ID", surface_id.to_string());
     cmd.env("TERM", "xterm-256color");
@@ -1081,6 +1088,7 @@ struct AmuxApp {
     ipc_rx: std::sync::mpsc::Receiver<IpcCommand>,
     event_broadcaster: amux_ipc::EventBroadcaster,
     socket_addr: amux_ipc::IpcAddr,
+    socket_token: String,
     config: Arc<AmuxTermConfig>,
     theme: theme::Theme,
     last_panel_rect: Option<egui::Rect>,
@@ -2021,6 +2029,7 @@ impl AmuxApp {
                             80,
                             24,
                             &self.socket_addr,
+                            &self.socket_token,
                             &self.config,
                             ws_id,
                             sf_id,
@@ -2273,6 +2282,7 @@ impl AmuxApp {
             80,
             24,
             &self.socket_addr,
+            &self.socket_token,
             &self.config,
             ws_id,
             sf_id,
@@ -2310,6 +2320,7 @@ impl AmuxApp {
             80,
             24,
             &self.socket_addr,
+            &self.socket_token,
             &self.config,
             ws_id,
             sf_id,
@@ -2362,6 +2373,7 @@ impl AmuxApp {
             80,
             24,
             &self.socket_addr,
+            &self.socket_token,
             &self.config,
             ws_id,
             sf_id,
@@ -2879,6 +2891,7 @@ impl AmuxApp {
             cols as u16,
             rows as u16,
             &self.socket_addr,
+            &self.socket_token,
             &self.config,
             ws_id,
             sf_id,
@@ -4747,6 +4760,7 @@ impl AmuxApp {
                                 80,
                                 24,
                                 &self.socket_addr,
+                                &self.socket_token,
                                 &self.config,
                                 ws_id,
                                 sf_id,

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -273,6 +273,9 @@ async fn main() -> anyhow::Result<()> {
     let addr = resolve_addr(&cli)?;
     let mut client = IpcClient::connect(&addr).await?;
 
+    let token = std::env::var("AMUX_SOCKET_TOKEN").unwrap_or_default();
+    client.authenticate(&token).await?;
+
     match cli.command {
         Command::Ping => {
             let resp = client.call("system.ping", serde_json::json!({})).await?;

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -1,4 +1,4 @@
-use amux_ipc::{read_last_addr, IpcAddr, IpcClient};
+use amux_ipc::{read_last_addr, read_last_token, IpcAddr, IpcClient};
 use clap::{Parser, Subcommand};
 use std::io::Read as _;
 
@@ -8,6 +8,10 @@ struct Cli {
     /// Socket path (auto-detected if omitted)
     #[arg(long, global = true)]
     socket: Option<String>,
+
+    /// Auth token (auto-detected from AMUX_SOCKET_TOKEN or stored token)
+    #[arg(long, global = true)]
+    token: Option<String>,
 
     /// Output as JSON
     #[arg(long, global = true)]
@@ -273,7 +277,15 @@ async fn main() -> anyhow::Result<()> {
     let addr = resolve_addr(&cli)?;
     let mut client = IpcClient::connect(&addr).await?;
 
-    let token = std::env::var("AMUX_SOCKET_TOKEN").unwrap_or_default();
+    let token = cli
+        .token
+        .clone()
+        .or_else(|| std::env::var("AMUX_SOCKET_TOKEN").ok())
+        .or_else(|| read_last_token().ok())
+        .unwrap_or_default();
+    if token.is_empty() {
+        anyhow::bail!("No auth token found. Set AMUX_SOCKET_TOKEN or use --token.");
+    }
     client.authenticate(&token).await?;
 
     match cli.command {

--- a/crates/amux-ipc/src/client.rs
+++ b/crates/amux-ipc/src/client.rs
@@ -1,6 +1,6 @@
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 
-use crate::protocol::{Request, Response};
+use crate::protocol::{AuthMessage, AuthResponse, Request, Response};
 use crate::socket_path::IpcAddr;
 
 /// IPC client for connecting to the amux server.
@@ -40,6 +40,29 @@ impl IpcClient {
                 writer: write_half,
             })
         }
+    }
+
+    /// Authenticate with the server using a token.
+    /// Must be called before any other method.
+    pub async fn authenticate(&mut self, token: &str) -> anyhow::Result<()> {
+        let msg = AuthMessage {
+            token: token.to_string(),
+        };
+        let mut json = serde_json::to_string(&msg)?;
+        json.push('\n');
+        self.writer.write_all(json.as_bytes()).await?;
+        self.writer.flush().await?;
+
+        let line = self
+            .reader
+            .next_line()
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("connection closed during auth"))?;
+        let resp: AuthResponse = serde_json::from_str(&line)?;
+        if !resp.ok {
+            anyhow::bail!("authentication failed: {}", resp.error.unwrap_or_default());
+        }
+        Ok(())
     }
 
     /// Send a JSON-RPC request and wait for the response.

--- a/crates/amux-ipc/src/lib.rs
+++ b/crates/amux-ipc/src/lib.rs
@@ -8,4 +8,4 @@ pub use client::IpcClient;
 pub use protocol::ServerEvent;
 pub use protocol::{Request, Response, RpcError};
 pub use server::{start_server, EventBroadcaster, IpcCommand, EVENT_TYPES};
-pub use socket_path::{read_last_addr, IpcAddr};
+pub use socket_path::{read_last_addr, read_last_token, write_last_token, IpcAddr};

--- a/crates/amux-ipc/src/protocol.rs
+++ b/crates/amux-ipc/src/protocol.rs
@@ -27,6 +27,20 @@ pub struct RpcError {
     pub message: String,
 }
 
+/// Authentication handshake message (first message on every connection).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthMessage {
+    pub token: String,
+}
+
+/// Authentication response.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthResponse {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 /// A server-pushed event (no `id` field — distinguished from responses by `event` field).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerEvent {

--- a/crates/amux-ipc/src/server.rs
+++ b/crates/amux-ipc/src/server.rs
@@ -5,7 +5,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{broadcast, oneshot};
 
 use crate::protocol::{AuthMessage, AuthResponse, Request, Response, ServerEvent};
-use crate::socket_path::{default_addr, write_last_addr, IpcAddr};
+use crate::socket_path::{default_addr, write_last_addr, write_last_token, IpcAddr};
 
 /// A command sent from the IPC server to the main (eframe) thread.
 pub struct IpcCommand {
@@ -33,6 +33,10 @@ impl EventBroadcaster {
 pub fn start_server(
     token: String,
 ) -> anyhow::Result<(std_mpsc::Receiver<IpcCommand>, IpcAddr, EventBroadcaster)> {
+    if token.is_empty() {
+        anyhow::bail!("IPC auth token must not be empty");
+    }
+
     let addr = default_addr();
     cleanup_stale(&addr);
 
@@ -43,6 +47,7 @@ pub fn start_server(
         tx: event_tx.clone(),
     };
     let addr_clone = addr.clone();
+    let token_for_file = token.clone();
 
     std::thread::Builder::new()
         .name("ipc-server".to_string())
@@ -58,6 +63,7 @@ pub fn start_server(
     match bind_rx.recv() {
         Ok(Ok(())) => {
             write_last_addr(&addr)?;
+            write_last_token(&token_for_file)?;
             Ok((cmd_rx, addr, broadcaster))
         }
         Ok(Err(e)) => anyhow::bail!("IPC server bind failed: {}", e),

--- a/crates/amux-ipc/src/server.rs
+++ b/crates/amux-ipc/src/server.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc as std_mpsc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{broadcast, oneshot};
 
-use crate::protocol::{Request, Response, ServerEvent};
+use crate::protocol::{AuthMessage, AuthResponse, Request, Response, ServerEvent};
 use crate::socket_path::{default_addr, write_last_addr, IpcAddr};
 
 /// A command sent from the IPC server to the main (eframe) thread.
@@ -30,8 +30,9 @@ impl EventBroadcaster {
 ///
 /// Returns the command receiver (for the main thread to drain), the IPC address,
 /// and an `EventBroadcaster` for pushing events to subscribed clients.
-pub fn start_server() -> anyhow::Result<(std_mpsc::Receiver<IpcCommand>, IpcAddr, EventBroadcaster)>
-{
+pub fn start_server(
+    token: String,
+) -> anyhow::Result<(std_mpsc::Receiver<IpcCommand>, IpcAddr, EventBroadcaster)> {
     let addr = default_addr();
     cleanup_stale(&addr);
 
@@ -50,7 +51,7 @@ pub fn start_server() -> anyhow::Result<(std_mpsc::Receiver<IpcCommand>, IpcAddr
                 .enable_all()
                 .build()
                 .expect("tokio runtime");
-            rt.block_on(run_server(addr_clone, cmd_tx, bind_tx, event_tx));
+            rt.block_on(run_server(addr_clone, cmd_tx, bind_tx, event_tx, token));
         })?;
 
     // Wait for the server thread to report bind success/failure
@@ -88,6 +89,7 @@ async fn run_server(
     cmd_tx: std_mpsc::Sender<IpcCommand>,
     bind_tx: std_mpsc::Sender<Result<(), String>>,
     event_tx: broadcast::Sender<ServerEvent>,
+    token: String,
 ) {
     let IpcAddr::Unix(ref path) = addr;
     let listener = match tokio::net::UnixListener::bind(path) {
@@ -108,12 +110,14 @@ async fn run_server(
             Ok((stream, _)) => {
                 let tx = cmd_tx.clone();
                 let event_rx = event_tx.subscribe();
+                let tok = token.clone();
                 let (reader, writer) = stream.into_split();
                 tokio::spawn(handle_connection(
                     BufReader::new(reader),
                     writer,
                     tx,
                     event_rx,
+                    tok,
                 ));
             }
             Err(e) => {
@@ -133,6 +137,7 @@ async fn run_server(
     cmd_tx: std_mpsc::Sender<IpcCommand>,
     bind_tx: std_mpsc::Sender<Result<(), String>>,
     event_tx: broadcast::Sender<ServerEvent>,
+    token: String,
 ) {
     use tokio::net::windows::named_pipe::ServerOptions;
 
@@ -169,12 +174,14 @@ async fn run_server(
 
         let tx = cmd_tx.clone();
         let event_rx = event_tx.subscribe();
+        let tok = token.clone();
         let (reader, writer) = tokio::io::split(connected);
         tokio::spawn(handle_connection(
             BufReader::new(reader),
             writer,
             tx,
             event_rx,
+            tok,
         ));
     }
 }
@@ -196,11 +203,39 @@ async fn handle_connection<R, W>(
     mut writer: W,
     cmd_tx: std_mpsc::Sender<IpcCommand>,
     mut event_rx: broadcast::Receiver<ServerEvent>,
+    expected_token: String,
 ) where
     R: tokio::io::AsyncRead + Unpin,
     W: tokio::io::AsyncWrite + Unpin,
 {
     let mut lines = reader.lines();
+
+    // --- Auth handshake: first message must be a valid token ---
+    let auth_line = match lines.next_line().await {
+        Ok(Some(line)) => line,
+        _ => return,
+    };
+    let auth_ok = match serde_json::from_str::<AuthMessage>(&auth_line) {
+        Ok(msg) => msg.token == expected_token,
+        Err(_) => false,
+    };
+    if !auth_ok {
+        let resp = AuthResponse {
+            ok: false,
+            error: Some("unauthorized".to_string()),
+        };
+        let _ = write_json(&mut writer, &resp).await;
+        return;
+    }
+    let resp = AuthResponse {
+        ok: true,
+        error: None,
+    };
+    if write_json(&mut writer, &resp).await.is_err() {
+        return;
+    }
+
+    // --- Authenticated: proceed with normal request handling ---
     let mut subscriptions: HashSet<String> = HashSet::new();
 
     loop {
@@ -363,26 +398,29 @@ fn handle_unsubscribe(request: &Request, subscriptions: &mut HashSet<String>) ->
     )
 }
 
-async fn write_response<W: tokio::io::AsyncWrite + Unpin>(
+async fn write_json<W: tokio::io::AsyncWrite + Unpin, T: serde::Serialize>(
     writer: &mut W,
-    response: &Response,
+    value: &T,
 ) -> anyhow::Result<()> {
-    let mut json = serde_json::to_string(response)?;
+    let mut json = serde_json::to_string(value)?;
     json.push('\n');
     writer.write_all(json.as_bytes()).await?;
     writer.flush().await?;
     Ok(())
 }
 
+async fn write_response<W: tokio::io::AsyncWrite + Unpin>(
+    writer: &mut W,
+    response: &Response,
+) -> anyhow::Result<()> {
+    write_json(writer, response).await
+}
+
 async fn write_event<W: tokio::io::AsyncWrite + Unpin>(
     writer: &mut W,
     event: &ServerEvent,
 ) -> anyhow::Result<()> {
-    let mut json = serde_json::to_string(event)?;
-    json.push('\n');
-    writer.write_all(json.as_bytes()).await?;
-    writer.flush().await?;
-    Ok(())
+    write_json(writer, event).await
 }
 
 #[cfg(test)]

--- a/crates/amux-ipc/src/socket_path.rs
+++ b/crates/amux-ipc/src/socket_path.rs
@@ -80,3 +80,23 @@ pub fn read_last_addr() -> anyhow::Result<IpcAddr> {
     let content = std::fs::read_to_string(data_dir.join("last-socket-path"))?;
     Ok(IpcAddr::from_stored(content.trim()))
 }
+
+/// Write the auth token to `{data_dir}/amux/last-socket-token`
+/// so the CLI can discover it alongside the socket address.
+pub fn write_last_token(token: &str) -> anyhow::Result<()> {
+    let data_dir = dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("amux");
+    std::fs::create_dir_all(&data_dir)?;
+    std::fs::write(data_dir.join("last-socket-token"), token)?;
+    Ok(())
+}
+
+/// Read the last-known auth token (for CLI auto-discovery).
+pub fn read_last_token() -> anyhow::Result<String> {
+    let data_dir = dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("amux");
+    let content = std::fs::read_to_string(data_dir.join("last-socket-token"))?;
+    Ok(content.trim().to_string())
+}


### PR DESCRIPTION
## Summary

Closes #50

- Generates a UUID token at app startup, passed to child processes via `AMUX_SOCKET_TOKEN` env var
- Every IPC connection must authenticate with the token as its first message before any requests are accepted
- Unauthenticated connections receive `{"ok": false, "error": "unauthorized"}` and are disconnected
- CLI reads `AMUX_SOCKET_TOKEN` and authenticates automatically after connecting

## Protocol

The auth handshake is the first message exchange on every connection:

```
Client → Server: {"token": "uuid-here"}\n
Server → Client: {"ok": true}\n          (success)
Server → Client: {"ok": false, "error": "unauthorized"}\n  (failure, then disconnect)
```

## Changes

| File | Change |
|------|--------|
| `amux-ipc/src/protocol.rs` | Add `AuthMessage` and `AuthResponse` types |
| `amux-ipc/src/server.rs` | Accept token param, validate on every connection before request loop |
| `amux-ipc/src/client.rs` | Add `authenticate()` method |
| `amux-app/src/main.rs` | Generate token, thread through all `spawn_surface` call sites |
| `amux-app/Cargo.toml` | Add `uuid` dependency |
| `amux-cli/src/main.rs` | Read `AMUX_SOCKET_TOKEN` env var and authenticate after connect |

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] App starts and terminal works normally (token passed transparently)
- [ ] CLI commands (`amux ping`, `amux tree`) work with token set
- [ ] CLI fails gracefully when `AMUX_SOCKET_TOKEN` is missing/wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented token-based authentication between CLI client and server.
  * CLI now accepts `--token` option for explicit token authentication.

* **Chores**
  * Added UUID dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->