### PR TITLE
Extract data model and config into amux-core (issue #42 step 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,13 @@ dependencies = [
 [[package]]
 name = "amux-core"
 version = "0.1.0"
+dependencies = [
+ "amux-layout",
+ "dirs",
+ "serde",
+ "toml",
+ "tracing",
+]
 
 [[package]]
 name = "amux-ipc"

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -10,6 +10,8 @@ use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use amux_core::config::{self, AppConfig};
+use amux_core::model::{DragState, SidebarState, Workspace};
 use amux_ipc::IpcCommand;
 use amux_layout::{NavDirection, PaneId, PaneTree, SplitDirection};
 use amux_notify::{
@@ -81,114 +83,6 @@ const TERMINAL_BOTTOM_PAD: f32 = 4.0;
 // ---------------------------------------------------------------------------
 // App config (loaded from ~/.config/amux/config.toml)
 // ---------------------------------------------------------------------------
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(default)]
-struct AppConfig {
-    font_size: f32,
-    /// Font family for terminal text (e.g. "JetBrains Mono", "Menlo").
-    /// Resolved against system-installed fonts by cosmic-text.
-    font_family: String,
-    notifications: NotificationConfig,
-}
-
-impl Default for AppConfig {
-    fn default() -> Self {
-        Self {
-            font_size: font::DEFAULT_FONT_SIZE,
-            font_family: font::DEFAULT_FONT_FAMILY.to_owned(),
-            notifications: NotificationConfig::default(),
-        }
-    }
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(default)]
-struct NotificationConfig {
-    /// Deliver OS-native toast notifications when the app is unfocused.
-    system_notifications: bool,
-    /// Automatically move workspaces to the top of the sidebar on notification.
-    auto_reorder_workspaces: bool,
-    /// Show unread count on macOS dock icon / Windows taskbar.
-    dock_badge: bool,
-    /// Shell command to run on each notification (receives AMUX_NOTIFICATION_* env vars).
-    custom_command: Option<String>,
-    /// Notification sound settings.
-    sound: NotificationSoundConfig,
-}
-
-impl Default for NotificationConfig {
-    fn default() -> Self {
-        Self {
-            system_notifications: true,
-            auto_reorder_workspaces: true,
-            dock_badge: true,
-            custom_command: None,
-            sound: NotificationSoundConfig::default(),
-        }
-    }
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(default)]
-struct NotificationSoundConfig {
-    /// "system", "none", or path to a .wav/.ogg/.mp3 file.
-    sound: String,
-    /// Play sound even when app is focused (suppressed notification feedback).
-    play_when_focused: bool,
-}
-
-impl Default for NotificationSoundConfig {
-    fn default() -> Self {
-        Self {
-            sound: "system".to_string(),
-            play_when_focused: true,
-        }
-    }
-}
-
-fn load_app_config() -> AppConfig {
-    let config_path = if cfg!(target_os = "windows") {
-        dirs::config_dir().map(|d| d.join("amux").join("config.toml"))
-    } else {
-        dirs::home_dir().map(|d| d.join(".config").join("amux").join("config.toml"))
-    };
-
-    if let Some(path) = config_path {
-        match std::fs::read_to_string(&path) {
-            Ok(contents) => match toml::from_str::<AppConfig>(&contents) {
-                Ok(mut config) => {
-                    tracing::info!("Loaded config from {}", path.display());
-                    config.font_size = validate_font_size(config.font_size);
-                    // Trim whitespace; treat empty as default.
-                    config.font_family = config.font_family.trim().to_owned();
-                    if config.font_family.is_empty() {
-                        config.font_family = font::DEFAULT_FONT_FAMILY.to_owned();
-                    }
-                    return config;
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to parse {}: {}", path.display(), e);
-                }
-            },
-            Err(_) => {
-                tracing::debug!("No config file at {}", path.display());
-            }
-        }
-    }
-
-    AppConfig::default()
-}
-
-fn validate_font_size(size: f32) -> f32 {
-    const MIN_FONT_SIZE: f32 = 4.0;
-    const MAX_FONT_SIZE: f32 = 96.0;
-    if !size.is_finite() || size <= 0.0 {
-        font::DEFAULT_FONT_SIZE
-    } else {
-        size.clamp(MIN_FONT_SIZE, MAX_FONT_SIZE)
-    }
-}
 
 /// Cached font family for semibold/bold UI text (sidebar titles, active tabs).
 /// Uses a static Arc<str> to avoid allocating on every call.
@@ -387,7 +281,7 @@ fn install_system_font_fallback(ctx: &egui::Context) {
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
-    let app_config = load_app_config();
+    let app_config = config::load_app_config();
     let font_size = app_config.font_size;
     // FontConfig is only consumed by the GPU renderer; gate to avoid unused
     // warnings in non-GPU builds. font_family is GPU-only — the egui fallback
@@ -927,47 +821,6 @@ fn cleanup_addr(addr: &amux_ipc::IpcAddr) {
         #[cfg(windows)]
         amux_ipc::IpcAddr::NamedPipe(_) => {}
     }
-}
-
-// --- Data Model ---
-// Hierarchy: Workspace > PaneTree (splits) > Pane (each has tab bar) > Surface (terminal tab)
-// Core pane types (ManagedPane, PaneSurface, SurfaceMetadata, SelectionState, etc.)
-// live in managed_pane.rs.
-
-/// A workspace shown in the sidebar. Owns the split tree.
-pub(crate) struct Workspace {
-    pub(crate) id: u64,
-    pub(crate) title: String,
-    pub(crate) tree: PaneTree,
-    pub(crate) focused_pane: PaneId,
-    pub(crate) zoomed: Option<PaneId>,
-    pub(crate) dragging_divider: Option<DragState>,
-    pub(crate) last_pane_sizes: HashMap<PaneId, (usize, usize)>,
-    /// Optional workspace color for sidebar indicator.
-    pub(crate) color: Option<[u8; 4]>,
-}
-
-pub(crate) struct SidebarState {
-    pub(crate) visible: bool,
-    pub(crate) width: f32,
-    /// Drag reorder state.
-    pub(crate) drag: Option<SidebarDragState>,
-}
-
-pub(crate) struct SidebarDragState {
-    /// Index of workspace being dragged.
-    pub(crate) source_idx: usize,
-    /// Current pointer Y position.
-    pub(crate) current_y: f32,
-    /// Computed drop target index.
-    pub(crate) drop_target_idx: usize,
-    /// Y midpoints of each row for computing drop position.
-    pub(crate) row_midpoints: Vec<f32>,
-}
-
-struct DragState {
-    node_path: Vec<usize>,
-    direction: SplitDirection,
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/amux-app/src/managed_pane.rs
+++ b/crates/amux-app/src/managed_pane.rs
@@ -21,38 +21,17 @@
 
 use std::sync::mpsc;
 
-use amux_layout::PaneId;
 use amux_term::pane::TerminalPane;
 
+// Re-export core model types so existing `use managed_pane::*` keeps working.
+pub(crate) use amux_core::model::{
+    CopyModeState, DeadPaneAction, ExitInfo, FindState, PanelInfo, SelectionMode, SelectionState,
+    SurfaceMetadata, WORD_DELIMITERS,
+};
+
 // ---------------------------------------------------------------------------
-// Data Model
+// Terminal-dependent types (stay in amux-app)
 // ---------------------------------------------------------------------------
-// Hierarchy: Workspace > PaneTree (splits) > Pane (each has tab bar) > Surface (terminal tab)
-
-/// Per-surface metadata reported by shell integration, agent hooks, or OSC sequences.
-#[derive(Default, Clone)]
-pub(crate) struct SurfaceMetadata {
-    pub(crate) cwd: Option<String>,
-    pub(crate) git_branch: Option<String>,
-    pub(crate) git_dirty: bool,
-    pub(crate) pr_number: Option<u32>,
-    pub(crate) pr_title: Option<String>,
-    pub(crate) pr_state: Option<String>, // "open", "merged", "closed"
-    /// Surface title from OSC 0/2 (window title set by shell/agent).
-    pub(crate) surface_title: Option<String>,
-}
-
-/// Info about a process that has exited.
-pub(crate) struct ExitInfo {
-    pub(crate) message: String,
-}
-
-/// Action to take when user presses a key on a dead pane.
-pub(crate) enum DeadPaneAction {
-    None,
-    Close,
-    Restart,
-}
 
 /// A terminal tab within a pane. Each pane can have multiple surfaces.
 pub(crate) struct PaneSurface {
@@ -137,92 +116,3 @@ impl ManagedPane {
         }
     }
 }
-
-/// Summary of a pane's state, usable without knowing the concrete panel type.
-#[allow(dead_code)]
-pub(crate) struct PanelInfo {
-    pub(crate) panel_type: &'static str,
-    pub(crate) title: String,
-    pub(crate) is_alive: bool,
-    pub(crate) surface_count: usize,
-}
-
-// ---------------------------------------------------------------------------
-// Selection
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SelectionMode {
-    Cell,
-    Word,
-    Line,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct SelectionState {
-    pub(crate) anchor: (usize, usize), // (col, stable_row)
-    pub(crate) end: (usize, usize),    // (col, stable_row)
-    pub(crate) mode: SelectionMode,
-    pub(crate) active: bool, // true while mouse is held
-}
-
-impl SelectionState {
-    /// Return (start, end) normalized so start <= end in reading order.
-    pub(crate) fn normalized(&self) -> ((usize, usize), (usize, usize)) {
-        let a = self.anchor;
-        let b = self.end;
-        if a.1 < b.1 || (a.1 == b.1 && a.0 <= b.0) {
-            (a, b)
-        } else {
-            (b, a)
-        }
-    }
-
-    /// Check if a cell at (col, stable_row) is within the selection.
-    pub(crate) fn contains(&self, col: usize, stable_row: usize) -> bool {
-        let (start, end) = self.normalized();
-        if stable_row < start.1 || stable_row > end.1 {
-            return false;
-        }
-        if start.1 == end.1 {
-            // Single line
-            col >= start.0 && col <= end.0
-        } else if stable_row == start.1 {
-            col >= start.0
-        } else if stable_row == end.1 {
-            col <= end.0
-        } else {
-            true // middle line
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Find / Copy Mode
-// ---------------------------------------------------------------------------
-
-/// State for the in-pane find/search bar.
-pub(crate) struct FindState {
-    pub(crate) query: String,
-    /// Matches as (phys_row, start_col, end_col_exclusive).
-    pub(crate) matches: Vec<(usize, usize, usize)>,
-    pub(crate) current_match: usize,
-    /// The pane this search applies to.
-    pub(crate) pane_id: PaneId,
-    /// True on the first frame after opening, for initial focus.
-    pub(crate) just_opened: bool,
-}
-
-/// State for vi-style copy mode (scrollback navigation + visual selection).
-pub(crate) struct CopyModeState {
-    pub(crate) pane_id: PaneId,
-    /// Cursor position in (col, phys_row).
-    pub(crate) cursor: (usize, usize),
-    /// Visual selection anchor (col, phys_row), set when 'v' is pressed.
-    pub(crate) visual_anchor: Option<(usize, usize)>,
-    /// Line-visual mode (V).
-    pub(crate) line_visual: bool,
-}
-
-/// Word boundary delimiters for double-click selection.
-pub(crate) const WORD_DELIMITERS: &str = " \t\n()[]{}'\"|<>&;:,.`~!@#$%^*-+=?/\\";

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use amux_notify::NotificationStore;
 use egui::Color32;
 
-use crate::{SidebarDragState, SidebarState, SurfaceMetadata, Workspace};
+use amux_core::model::{SidebarDragState, SidebarState, SurfaceMetadata, Workspace};
 
 // ---------------------------------------------------------------------------
 // Colors (cmux dark mode equivalents)

--- a/crates/amux-core/Cargo.toml
+++ b/crates/amux-core/Cargo.toml
@@ -3,8 +3,15 @@ name = "amux-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "amux shared logic: key encoding, session management, IPC dispatch"
+description = "amux shared logic: key encoding, data model, config, session management, IPC dispatch"
 
 [dependencies]
+amux-layout = { workspace = true }
+# Note: amux-term is NOT a dependency here to avoid cycles (amux-term depends on amux-core).
+# Font defaults are defined locally in config.rs.
+serde = { workspace = true }
+toml = { workspace = true }
+dirs = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -94,8 +94,11 @@ pub fn load_app_config() -> AppConfig {
                     tracing::warn!("Failed to parse {}: {}", path.display(), e);
                 }
             },
-            Err(_) => {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 tracing::debug!("No config file at {}", path.display());
+            }
+            Err(e) => {
+                tracing::warn!("Failed to read {}: {}", path.display(), e);
             }
         }
     }

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -1,0 +1,114 @@
+//! Application configuration loaded from config.toml.
+
+/// Default font family — must match `amux_term::DEFAULT_FONT_FAMILY`.
+pub const DEFAULT_FONT_FAMILY: &str = "IBM Plex Mono";
+/// Default font size — must match `amux_term::DEFAULT_FONT_SIZE`.
+pub const DEFAULT_FONT_SIZE: f32 = 14.0;
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(default)]
+pub struct AppConfig {
+    pub font_size: f32,
+    /// Font family for terminal text (e.g. "JetBrains Mono", "Menlo").
+    /// Resolved against system-installed fonts by cosmic-text.
+    pub font_family: String,
+    pub notifications: NotificationConfig,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            font_size: DEFAULT_FONT_SIZE,
+            font_family: DEFAULT_FONT_FAMILY.to_owned(),
+            notifications: NotificationConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(default)]
+pub struct NotificationConfig {
+    /// Deliver OS-native toast notifications when the app is unfocused.
+    pub system_notifications: bool,
+    /// Automatically move workspaces to the top of the sidebar on notification.
+    pub auto_reorder_workspaces: bool,
+    /// Show unread count on macOS dock icon / Windows taskbar.
+    pub dock_badge: bool,
+    /// Shell command to run on each notification (receives AMUX_NOTIFICATION_* env vars).
+    pub custom_command: Option<String>,
+    /// Notification sound settings.
+    pub sound: NotificationSoundConfig,
+}
+
+impl Default for NotificationConfig {
+    fn default() -> Self {
+        Self {
+            system_notifications: true,
+            auto_reorder_workspaces: true,
+            dock_badge: true,
+            custom_command: None,
+            sound: NotificationSoundConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(default)]
+pub struct NotificationSoundConfig {
+    /// "system", "none", or path to a .wav/.ogg/.mp3 file.
+    pub sound: String,
+    /// Play sound even when app is focused (suppressed notification feedback).
+    pub play_when_focused: bool,
+}
+
+impl Default for NotificationSoundConfig {
+    fn default() -> Self {
+        Self {
+            sound: "system".to_string(),
+            play_when_focused: true,
+        }
+    }
+}
+
+pub fn load_app_config() -> AppConfig {
+    let config_path = if cfg!(target_os = "windows") {
+        dirs::config_dir().map(|d| d.join("amux").join("config.toml"))
+    } else {
+        dirs::home_dir().map(|d| d.join(".config").join("amux").join("config.toml"))
+    };
+
+    if let Some(path) = config_path {
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => match toml::from_str::<AppConfig>(&contents) {
+                Ok(mut config) => {
+                    tracing::info!("Loaded config from {}", path.display());
+                    config.font_size = validate_font_size(config.font_size);
+                    // Trim whitespace; treat empty as default.
+                    config.font_family = config.font_family.trim().to_owned();
+                    if config.font_family.is_empty() {
+                        config.font_family = DEFAULT_FONT_FAMILY.to_owned();
+                    }
+                    return config;
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to parse {}: {}", path.display(), e);
+                }
+            },
+            Err(_) => {
+                tracing::debug!("No config file at {}", path.display());
+            }
+        }
+    }
+
+    AppConfig::default()
+}
+
+pub fn validate_font_size(size: f32) -> f32 {
+    const MIN_FONT_SIZE: f32 = 4.0;
+    const MAX_FONT_SIZE: f32 = 96.0;
+    if !size.is_finite() || size <= 0.0 {
+        DEFAULT_FONT_SIZE
+    } else {
+        size.clamp(MIN_FONT_SIZE, MAX_FONT_SIZE)
+    }
+}

--- a/crates/amux-core/src/lib.rs
+++ b/crates/amux-core/src/lib.rs
@@ -1,1 +1,3 @@
+pub mod config;
 pub mod keys;
+pub mod model;

--- a/crates/amux-core/src/model.rs
+++ b/crates/amux-core/src/model.rs
@@ -1,0 +1,167 @@
+//! Core data model types shared between amux-app and amux-cli.
+//!
+//! These types represent the application's domain model without any
+//! GUI framework dependency. Types that depend on terminal internals
+//! (e.g. `PaneSurface`, `ManagedPane`) remain in amux-app.
+
+use std::collections::HashMap;
+
+use amux_layout::{PaneId, PaneTree, SplitDirection};
+
+// ---------------------------------------------------------------------------
+// Workspace / Sidebar
+// ---------------------------------------------------------------------------
+
+/// A workspace shown in the sidebar. Owns the split tree.
+pub struct Workspace {
+    pub id: u64,
+    pub title: String,
+    pub tree: PaneTree,
+    pub focused_pane: PaneId,
+    pub zoomed: Option<PaneId>,
+    pub dragging_divider: Option<DragState>,
+    pub last_pane_sizes: HashMap<PaneId, (usize, usize)>,
+    /// Optional workspace color for sidebar indicator.
+    pub color: Option<[u8; 4]>,
+}
+
+pub struct SidebarState {
+    pub visible: bool,
+    pub width: f32,
+    /// Drag reorder state.
+    pub drag: Option<SidebarDragState>,
+}
+
+pub struct SidebarDragState {
+    /// Index of workspace being dragged.
+    pub source_idx: usize,
+    /// Current pointer Y position.
+    pub current_y: f32,
+    /// Computed drop target index.
+    pub drop_target_idx: usize,
+    /// Y midpoints of each row for computing drop position.
+    pub row_midpoints: Vec<f32>,
+}
+
+pub struct DragState {
+    pub node_path: Vec<usize>,
+    pub direction: SplitDirection,
+}
+
+// ---------------------------------------------------------------------------
+// Surface metadata
+// ---------------------------------------------------------------------------
+
+/// Per-surface metadata reported by shell integration, agent hooks, or OSC sequences.
+#[derive(Default, Clone)]
+pub struct SurfaceMetadata {
+    pub cwd: Option<String>,
+    pub git_branch: Option<String>,
+    pub git_dirty: bool,
+    pub pr_number: Option<u32>,
+    pub pr_title: Option<String>,
+    pub pr_state: Option<String>, // "open", "merged", "closed"
+    /// Surface title from OSC 0/2 (window title set by shell/agent).
+    pub surface_title: Option<String>,
+}
+
+/// Info about a process that has exited.
+pub struct ExitInfo {
+    pub message: String,
+}
+
+/// Action to take when user presses a key on a dead pane.
+pub enum DeadPaneAction {
+    None,
+    Close,
+    Restart,
+}
+
+/// Summary of a pane's state, usable without knowing the concrete panel type.
+#[allow(dead_code)]
+pub struct PanelInfo {
+    pub panel_type: &'static str,
+    pub title: String,
+    pub is_alive: bool,
+    pub surface_count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionMode {
+    Cell,
+    Word,
+    Line,
+}
+
+#[derive(Debug, Clone)]
+pub struct SelectionState {
+    pub anchor: (usize, usize), // (col, stable_row)
+    pub end: (usize, usize),    // (col, stable_row)
+    pub mode: SelectionMode,
+    pub active: bool, // true while mouse is held
+}
+
+impl SelectionState {
+    /// Return (start, end) normalized so start <= end in reading order.
+    pub fn normalized(&self) -> ((usize, usize), (usize, usize)) {
+        let a = self.anchor;
+        let b = self.end;
+        if a.1 < b.1 || (a.1 == b.1 && a.0 <= b.0) {
+            (a, b)
+        } else {
+            (b, a)
+        }
+    }
+
+    /// Check if a cell at (col, stable_row) is within the selection.
+    pub fn contains(&self, col: usize, stable_row: usize) -> bool {
+        let (start, end) = self.normalized();
+        if stable_row < start.1 || stable_row > end.1 {
+            return false;
+        }
+        if start.1 == end.1 {
+            // Single line
+            col >= start.0 && col <= end.0
+        } else if stable_row == start.1 {
+            col >= start.0
+        } else if stable_row == end.1 {
+            col <= end.0
+        } else {
+            true // middle line
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Find / Copy Mode
+// ---------------------------------------------------------------------------
+
+/// State for the in-pane find/search bar.
+pub struct FindState {
+    pub query: String,
+    /// Matches as (phys_row, start_col, end_col_exclusive).
+    pub matches: Vec<(usize, usize, usize)>,
+    pub current_match: usize,
+    /// The pane this search applies to.
+    pub pane_id: PaneId,
+    /// True on the first frame after opening, for initial focus.
+    pub just_opened: bool,
+}
+
+/// State for vi-style copy mode (scrollback navigation + visual selection).
+pub struct CopyModeState {
+    pub pane_id: PaneId,
+    /// Cursor position in (col, phys_row).
+    pub cursor: (usize, usize),
+    /// Visual selection anchor (col, phys_row), set when 'v' is pressed.
+    pub visual_anchor: Option<(usize, usize)>,
+    /// Line-visual mode (V).
+    pub line_visual: bool,
+}
+
+/// Word boundary delimiters for double-click selection.
+pub const WORD_DELIMITERS: &str = " \t\n()[]{}'\"|<>&;:,.`~!@#$%^*-+=?/\\";


### PR DESCRIPTION
## Summary

Continues #42 — extracts pure data model types and config from the amux-app monolith into amux-core.

**New modules in amux-core:**
- `model` — Workspace, SidebarState, SurfaceMetadata, SelectionState, FindState, CopyModeState, DragState, ExitInfo, DeadPaneAction, PanelInfo, WORD_DELIMITERS
- `config` — AppConfig, NotificationConfig, NotificationSoundConfig, load_app_config(), validate_font_size()

**What stays in amux-app:**
- `PaneSurface` and `ManagedPane` (depend on TerminalPane / PTY channels)
- All GUI/rendering code

Removes ~240 lines from amux-app. No behavioral changes.

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] App starts and behaves identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized configuration loading and validation logic into reusable core modules
  * Extracted and reorganized shared data model types for improved code reuse
  * Enhanced code organization and maintainability by reducing duplication across application components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->