### PR TITLE
Extract shell integration into amux-core (issue #42 step 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,7 @@ version = "0.1.0"
 dependencies = [
  "amux-layout",
  "dirs",
+ "portable-pty",
  "serde",
  "toml",
  "tracing",

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 
 use amux_core::config::{self, AppConfig};
 use amux_core::model::{DragState, SidebarState, Workspace};
+use amux_core::shell;
 use amux_ipc::IpcCommand;
 use amux_layout::{NavDirection, PaneId, PaneTree, SplitDirection};
 use amux_notify::{
@@ -673,145 +674,6 @@ fn restore_session(
     }
 }
 
-fn default_shell() -> String {
-    #[cfg(unix)]
-    {
-        std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string())
-    }
-    #[cfg(windows)]
-    {
-        std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
-    }
-}
-
-/// Write shell integration files to ~/.config/amux/shell/ and set env vars to
-/// auto-inject them. For zsh: ZDOTDIR override. For bash: PROMPT_COMMAND bootstrap.
-/// Matching cmux's approach — no user dotfile modification required.
-fn inject_shell_integration(shell: &str, cmd: &mut CommandBuilder) {
-    let shell_name = std::path::Path::new(shell)
-        .file_name()
-        .and_then(|f| f.to_str())
-        .unwrap_or("");
-
-    let Some(integration_dir) = ensure_shell_integration_dir() else {
-        return;
-    };
-
-    cmd.env(
-        "AMUX_SHELL_INTEGRATION_DIR",
-        integration_dir.to_string_lossy().as_ref(),
-    );
-
-    match shell_name {
-        "zsh" => {
-            let zsh_dir = integration_dir.join("zsh");
-            // Save user's original ZDOTDIR (if set) so bootstrap can restore it
-            if let Ok(original) = std::env::var("ZDOTDIR") {
-                cmd.env("AMUX_ZSH_ZDOTDIR", &original);
-            }
-            cmd.env("ZDOTDIR", zsh_dir.to_string_lossy().as_ref());
-        }
-        "bash" => {
-            // Bootstrap integration via PROMPT_COMMAND on first interactive prompt.
-            // This runs once, then restores any original PROMPT_COMMAND.
-            let bash_script = integration_dir.join("amux-bash-integration.bash");
-            let bootstrap = format!(
-                concat!(
-                    "unset PROMPT_COMMAND; ",
-                    "if [[ -r \"{}\" ]]; then source \"{}\"; fi",
-                ),
-                bash_script.display(),
-                bash_script.display(),
-            );
-            cmd.env("PROMPT_COMMAND", &bootstrap);
-        }
-        _ => {}
-    }
-}
-
-/// Ensure shell integration scripts are written to ~/.config/amux/shell/.
-/// Returns the directory path, or None on failure.
-fn ensure_shell_integration_dir() -> Option<std::path::PathBuf> {
-    let config_dir = dirs::config_dir()?.join("amux").join("shell");
-
-    // Write zsh bootstrap files
-    let zsh_dir = config_dir.join("zsh");
-    if std::fs::create_dir_all(&zsh_dir).is_err() {
-        return None;
-    }
-
-    // Embed integration scripts at compile time
-    let files: &[(&str, &str)] = &[
-        (
-            "zsh/.zshenv",
-            include_str!("../../../resources/shell-integration/zsh/.zshenv"),
-        ),
-        (
-            "zsh/.zprofile",
-            include_str!("../../../resources/shell-integration/zsh/.zprofile"),
-        ),
-        (
-            "zsh/.zshrc",
-            include_str!("../../../resources/shell-integration/zsh/.zshrc"),
-        ),
-        (
-            "zsh/.zlogin",
-            include_str!("../../../resources/shell-integration/zsh/.zlogin"),
-        ),
-        (
-            "amux-zsh-integration.zsh",
-            include_str!("../../../resources/shell-integration/amux-zsh-integration.zsh"),
-        ),
-        (
-            "amux-bash-integration.bash",
-            include_str!("../../../resources/shell-integration/amux-bash-integration.bash"),
-        ),
-    ];
-
-    for (name, content) in files {
-        let path = config_dir.join(name);
-        // Only write if content changed (avoid unnecessary disk writes)
-        let needs_write = std::fs::read_to_string(&path)
-            .map(|existing| existing != *content)
-            .unwrap_or(true);
-        if needs_write && std::fs::write(&path, content).is_err() {
-            return None;
-        }
-    }
-
-    Some(config_dir)
-}
-
-/// Ensure the claude wrapper script is written to ~/.config/amux/bin/claude.
-/// Returns the bin directory path, or None on failure.
-fn ensure_claude_wrapper_dir() -> Option<std::path::PathBuf> {
-    // Use ~/.config/amux/bin/ instead of dirs::config_dir() because on macOS
-    // that returns ~/Library/Application Support/ which has a space — spaces
-    // in PATH entries break many tools.
-    let bin_dir = dirs::home_dir()?.join(".config").join("amux").join("bin");
-    if std::fs::create_dir_all(&bin_dir).is_err() {
-        return None;
-    }
-
-    let wrapper_path = bin_dir.join("claude");
-    let wrapper_content = include_str!("../../../resources/bin/claude");
-
-    let needs_write = std::fs::read_to_string(&wrapper_path)
-        .map(|existing| existing != wrapper_content)
-        .unwrap_or(true);
-
-    if needs_write && std::fs::write(&wrapper_path, wrapper_content).is_err() {
-        return None;
-    }
-    // Make executable (unix)
-    #[cfg(unix)]
-    if needs_write {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755));
-    }
-
-    Some(bin_dir)
-}
 fn cleanup_addr(addr: &amux_ipc::IpcAddr) {
     match addr {
         #[cfg(unix)]
@@ -835,7 +697,7 @@ fn spawn_surface(
     cwd: Option<&str>,
     scrollback: Option<&str>,
 ) -> anyhow::Result<PaneSurface> {
-    let shell = default_shell();
+    let shell = shell::default_shell();
     let mut cmd = CommandBuilder::new(&shell);
     cmd.env("AMUX_SOCKET_PATH", ipc_addr.to_string());
     cmd.env("AMUX_SOCKET_TOKEN", socket_token);
@@ -858,7 +720,7 @@ fn spawn_surface(
 
     // Prepend amux bin dir (containing claude wrapper) to PATH so hooks are
     // injected at runtime via --settings, scoped to amux sessions only.
-    if let Some(bin_dir) = ensure_claude_wrapper_dir() {
+    if let Some(bin_dir) = shell::ensure_claude_wrapper_dir() {
         let current_path = std::env::var("PATH").unwrap_or_default();
         let bin_str = bin_dir.to_string_lossy();
         if !current_path.split(':').any(|d| d == bin_str.as_ref()) {
@@ -868,7 +730,7 @@ fn spawn_surface(
     }
 
     // Auto-inject shell integration (matching cmux's ZDOTDIR/PROMPT_COMMAND approach)
-    inject_shell_integration(&shell, &mut cmd);
+    shell::inject_shell_integration(&shell, &mut cmd);
 
     let actual_cwd = if let Some(dir) = cwd {
         let path = std::path::Path::new(dir);

--- a/crates/amux-core/Cargo.toml
+++ b/crates/amux-core/Cargo.toml
@@ -7,6 +7,7 @@ description = "amux shared logic: key encoding, data model, config, session mana
 
 [dependencies]
 amux-layout = { workspace = true }
+portable-pty = { workspace = true }
 # Note: amux-term is NOT a dependency here to avoid cycles (amux-term depends on amux-core).
 # Font defaults are defined locally in config.rs.
 serde = { workspace = true }

--- a/crates/amux-core/src/lib.rs
+++ b/crates/amux-core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod keys;
 pub mod model;
+pub mod shell;

--- a/crates/amux-core/src/shell.rs
+++ b/crates/amux-core/src/shell.rs
@@ -1,0 +1,147 @@
+//! Shell detection and integration setup.
+//!
+//! These functions prepare the environment for shell integration scripts
+//! and the claude wrapper binary without depending on any terminal crate.
+
+use portable_pty::CommandBuilder;
+
+/// Return the user's default shell.
+pub fn default_shell() -> String {
+    #[cfg(unix)]
+    {
+        std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string())
+    }
+    #[cfg(windows)]
+    {
+        std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+    }
+}
+
+/// Write shell integration files to ~/.config/amux/shell/ and set env vars to
+/// auto-inject them. For zsh: ZDOTDIR override. For bash: PROMPT_COMMAND bootstrap.
+/// Matching cmux's approach — no user dotfile modification required.
+pub fn inject_shell_integration(shell: &str, cmd: &mut CommandBuilder) {
+    let shell_name = std::path::Path::new(shell)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("");
+
+    let Some(integration_dir) = ensure_shell_integration_dir() else {
+        return;
+    };
+
+    cmd.env(
+        "AMUX_SHELL_INTEGRATION_DIR",
+        integration_dir.to_string_lossy().as_ref(),
+    );
+
+    match shell_name {
+        "zsh" => {
+            let zsh_dir = integration_dir.join("zsh");
+            // Save user's original ZDOTDIR (if set) so bootstrap can restore it
+            if let Ok(original) = std::env::var("ZDOTDIR") {
+                cmd.env("AMUX_ZSH_ZDOTDIR", &original);
+            }
+            cmd.env("ZDOTDIR", zsh_dir.to_string_lossy().as_ref());
+        }
+        "bash" => {
+            // Bootstrap integration via PROMPT_COMMAND on first interactive prompt.
+            // This runs once, then restores any original PROMPT_COMMAND.
+            let bash_script = integration_dir.join("amux-bash-integration.bash");
+            let bootstrap = format!(
+                concat!(
+                    "unset PROMPT_COMMAND; ",
+                    "if [[ -r \"{}\" ]]; then source \"{}\"; fi",
+                ),
+                bash_script.display(),
+                bash_script.display(),
+            );
+            cmd.env("PROMPT_COMMAND", &bootstrap);
+        }
+        _ => {}
+    }
+}
+
+/// Ensure shell integration scripts are written to ~/.config/amux/shell/.
+/// Returns the directory path, or None on failure.
+fn ensure_shell_integration_dir() -> Option<std::path::PathBuf> {
+    let config_dir = dirs::config_dir()?.join("amux").join("shell");
+
+    // Write zsh bootstrap files
+    let zsh_dir = config_dir.join("zsh");
+    if std::fs::create_dir_all(&zsh_dir).is_err() {
+        return None;
+    }
+
+    // Embed integration scripts at compile time
+    let files: &[(&str, &str)] = &[
+        (
+            "zsh/.zshenv",
+            include_str!("../../../resources/shell-integration/zsh/.zshenv"),
+        ),
+        (
+            "zsh/.zprofile",
+            include_str!("../../../resources/shell-integration/zsh/.zprofile"),
+        ),
+        (
+            "zsh/.zshrc",
+            include_str!("../../../resources/shell-integration/zsh/.zshrc"),
+        ),
+        (
+            "zsh/.zlogin",
+            include_str!("../../../resources/shell-integration/zsh/.zlogin"),
+        ),
+        (
+            "amux-zsh-integration.zsh",
+            include_str!("../../../resources/shell-integration/amux-zsh-integration.zsh"),
+        ),
+        (
+            "amux-bash-integration.bash",
+            include_str!("../../../resources/shell-integration/amux-bash-integration.bash"),
+        ),
+    ];
+
+    for (name, content) in files {
+        let path = config_dir.join(name);
+        // Only write if content changed (avoid unnecessary disk writes)
+        let needs_write = std::fs::read_to_string(&path)
+            .map(|existing| existing != *content)
+            .unwrap_or(true);
+        if needs_write && std::fs::write(&path, content).is_err() {
+            return None;
+        }
+    }
+
+    Some(config_dir)
+}
+
+/// Ensure the claude wrapper script is written to ~/.config/amux/bin/claude.
+/// Returns the bin directory path, or None on failure.
+pub fn ensure_claude_wrapper_dir() -> Option<std::path::PathBuf> {
+    // Use ~/.config/amux/bin/ instead of dirs::config_dir() because on macOS
+    // that returns ~/Library/Application Support/ which has a space — spaces
+    // in PATH entries break many tools.
+    let bin_dir = dirs::home_dir()?.join(".config").join("amux").join("bin");
+    if std::fs::create_dir_all(&bin_dir).is_err() {
+        return None;
+    }
+
+    let wrapper_path = bin_dir.join("claude");
+    let wrapper_content = include_str!("../../../resources/bin/claude");
+
+    let needs_write = std::fs::read_to_string(&wrapper_path)
+        .map(|existing| existing != wrapper_content)
+        .unwrap_or(true);
+
+    if needs_write && std::fs::write(&wrapper_path, wrapper_content).is_err() {
+        return None;
+    }
+    // Make executable (unix)
+    #[cfg(unix)]
+    if needs_write {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755));
+    }
+
+    Some(bin_dir)
+}


### PR DESCRIPTION
## Summary

Continues #42 — extracts shell integration helpers from amux-app into amux-core::shell.

**Stacked on:** #65 (data model + config extraction)

**Moved to amux-core::shell:**
- `default_shell()` — platform-aware shell detection
- `inject_shell_integration()` — zsh ZDOTDIR / bash PROMPT_COMMAND setup
- `ensure_shell_integration_dir()` — writes embedded shell scripts to ~/.config/amux/shell/
- `ensure_claude_wrapper_dir()` — writes claude wrapper to ~/.config/amux/bin/

**What stays in amux-app:**
- `spawn_surface()` — returns `PaneSurface` which depends on `TerminalPane` (can't move without cycle)

No behavioral changes.

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] App starts and shell integration works (zsh prompt, bash prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)