### PR TITLE
Add subtitle field to notification system

### DIFF
--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -556,11 +556,13 @@ impl AmuxApp {
                             .parse::<u64>()
                             .unwrap_or(self.focused_pane_id());
                         let title = params.title.unwrap_or_default();
+                        let subtitle = params.subtitle.unwrap_or_default();
                         let nid = self.deliver_notification(
                             ws_id,
                             pane_id,
                             0,
                             title,
+                            subtitle,
                             params.body,
                             NotificationSource::Cli,
                             false,
@@ -586,6 +588,7 @@ impl AmuxApp {
                             "workspace_id": n.workspace_id.to_string(),
                             "pane_id": n.pane_id.to_string(),
                             "title": n.title,
+                            "subtitle": n.subtitle,
                             "body": n.body,
                             "source": source_str,
                             "read": n.read,

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -651,6 +651,7 @@ fn restore_session(
             saved_n.pane_id,
             saved_n.surface_id,
             saved_n.title.clone(),
+            saved_n.subtitle.clone(),
             saved_n.body.clone(),
             source,
         );
@@ -1030,6 +1031,7 @@ impl AmuxApp {
                 pane_id: n.pane_id,
                 surface_id: n.surface_id,
                 title: n.title.clone(),
+                subtitle: n.subtitle.clone(),
                 body: n.body.clone(),
                 source: match n.source {
                     NotificationSource::Toast => "toast",
@@ -2779,7 +2781,16 @@ impl AmuxApp {
             };
 
             let skip_toast = matches!(source, NotificationSource::Bell);
-            self.deliver_notification(ws_id, pane_id, surface_id, title, body, source, skip_toast);
+            self.deliver_notification(
+                ws_id,
+                pane_id,
+                surface_id,
+                title,
+                String::new(),
+                body,
+                source,
+                skip_toast,
+            );
         }
     }
 
@@ -2796,6 +2807,7 @@ impl AmuxApp {
         pane_id: PaneId,
         surface_id: u64,
         title: String,
+        subtitle: String,
         body: String,
         source: NotificationSource,
         skip_toast: bool,
@@ -2804,6 +2816,7 @@ impl AmuxApp {
         let source_str = source.as_str();
         // Clone for the IPC broadcast after the notification is stored.
         let bc_title = title.clone();
+        let bc_subtitle = subtitle.clone();
         let bc_body = body.clone();
 
         let nid = if !self.app_focused {
@@ -2817,7 +2830,7 @@ impl AmuxApp {
             }
             let nid = self
                 .notifications
-                .push(ws_id, pane_id, surface_id, title, body, source);
+                .push(ws_id, pane_id, surface_id, title, subtitle, body, source);
             if self.app_config.notifications.auto_reorder_workspaces {
                 self.bubble_workspace(ws_id);
             }
@@ -2825,7 +2838,7 @@ impl AmuxApp {
         } else if pane_id == focused {
             // Tier 3: app focused, same pane — mark read (flash only)
             self.notifications
-                .push_read(ws_id, pane_id, surface_id, title, body, source)
+                .push_read(ws_id, pane_id, surface_id, title, subtitle, body, source)
         } else {
             // Tier 2: app focused, different pane — in-app sound + command
             if self.app_config.notifications.sound.play_when_focused {
@@ -2839,7 +2852,7 @@ impl AmuxApp {
             }
             let nid = self
                 .notifications
-                .push(ws_id, pane_id, surface_id, title, body, source);
+                .push(ws_id, pane_id, surface_id, title, subtitle, body, source);
             if self.app_config.notifications.auto_reorder_workspaces {
                 self.bubble_workspace(ws_id);
             }
@@ -2854,6 +2867,7 @@ impl AmuxApp {
                 "workspace_id": ws_id.to_string(),
                 "pane_id": pane_id.to_string(),
                 "title": bc_title,
+                "subtitle": bc_subtitle,
                 "body": bc_body,
                 "source": source_str,
             }),

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -183,6 +183,9 @@ enum Command {
         /// Notification title
         #[arg(long)]
         title: Option<String>,
+        /// Notification subtitle (e.g. "Permission Required", "Task Completed")
+        #[arg(long)]
+        subtitle: Option<String>,
         /// Target workspace ID (defaults to AMUX_WORKSPACE_ID)
         #[arg(long)]
         workspace: Option<String>,
@@ -670,6 +673,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Notify {
             body,
             title,
+            subtitle,
             workspace,
             pane,
         } => {
@@ -684,6 +688,9 @@ async fn main() -> anyhow::Result<()> {
             });
             if let Some(t) = title {
                 params["title"] = serde_json::json!(t);
+            }
+            if let Some(s) = subtitle {
+                params["subtitle"] = serde_json::json!(s);
             }
             let resp = client.call("notify.send", params).await?;
             if cli.json {

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -134,6 +134,8 @@ pub struct NotifySendParams {
     pub pane_id: String,
     #[serde(default)]
     pub title: Option<String>,
+    #[serde(default)]
+    pub subtitle: Option<String>,
     pub body: String,
 }
 
@@ -150,6 +152,7 @@ pub struct NotifyListEntry {
     pub workspace_id: String,
     pub pane_id: String,
     pub title: String,
+    pub subtitle: String,
     pub body: String,
     pub source: String,
     pub read: bool,

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -72,6 +72,7 @@ pub struct Notification {
     pub pane_id: u64,
     pub surface_id: u64,
     pub title: String,
+    pub subtitle: String,
     pub body: String,
     pub source: NotificationSource,
     pub created_at: Instant,
@@ -157,12 +158,14 @@ impl NotificationStore {
     }
 
     /// Add a notification. Triggers a flash on the target pane.
+    #[allow(clippy::too_many_arguments)]
     pub fn push(
         &mut self,
         workspace_id: u64,
         pane_id: u64,
         surface_id: u64,
         title: String,
+        subtitle: String,
         body: String,
         source: NotificationSource,
     ) -> u64 {
@@ -175,6 +178,7 @@ impl NotificationStore {
             pane_id,
             surface_id,
             title,
+            subtitle,
             body,
             source,
             created_at: Instant::now(),
@@ -191,12 +195,14 @@ impl NotificationStore {
 
     /// Push a notification but immediately mark it as read (for focused-pane
     /// notifications — still triggers arrival flash but no persistent ring).
+    #[allow(clippy::too_many_arguments)]
     pub fn push_read(
         &mut self,
         workspace_id: u64,
         pane_id: u64,
         surface_id: u64,
         title: String,
+        subtitle: String,
         body: String,
         source: NotificationSource,
     ) -> u64 {
@@ -209,6 +215,7 @@ impl NotificationStore {
             pane_id,
             surface_id,
             title,
+            subtitle,
             body,
             source,
             created_at: Instant::now(),
@@ -448,6 +455,7 @@ mod tests {
             10,
             100,
             "Test".into(),
+            String::new(),
             "body".into(),
             NotificationSource::Bell,
         );
@@ -465,6 +473,7 @@ mod tests {
             10,
             100,
             "Test".into(),
+            String::new(),
             "body".into(),
             NotificationSource::Toast,
         );
@@ -478,12 +487,21 @@ mod tests {
     #[test]
     fn mark_pane_read_clears_unread() {
         let mut store = NotificationStore::new();
-        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
+        store.push(
+            1,
+            10,
+            100,
+            "A".into(),
+            String::new(),
+            "a".into(),
+            NotificationSource::Bell,
+        );
         store.push(
             1,
             10,
             101,
             "B".into(),
+            String::new(),
             "b".into(),
             NotificationSource::Toast,
         );
@@ -502,8 +520,24 @@ mod tests {
     #[test]
     fn mark_all_read() {
         let mut store = NotificationStore::new();
-        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
-        store.push(2, 20, 200, "B".into(), "b".into(), NotificationSource::Cli);
+        store.push(
+            1,
+            10,
+            100,
+            "A".into(),
+            String::new(),
+            "a".into(),
+            NotificationSource::Bell,
+        );
+        store.push(
+            2,
+            20,
+            200,
+            "B".into(),
+            String::new(),
+            "b".into(),
+            NotificationSource::Cli,
+        );
         store.mark_all_read();
         assert_eq!(store.pane_unread(10), 0);
         assert_eq!(store.pane_unread(20), 0);
@@ -517,6 +551,7 @@ mod tests {
             10,
             100,
             "First".into(),
+            String::new(),
             "a".into(),
             NotificationSource::Bell,
         );
@@ -525,6 +560,7 @@ mod tests {
             20,
             200,
             "Second".into(),
+            String::new(),
             "b".into(),
             NotificationSource::Toast,
         );
@@ -542,8 +578,24 @@ mod tests {
     #[test]
     fn has_unread_excluding_focused() {
         let mut store = NotificationStore::new();
-        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
-        store.push(1, 20, 200, "B".into(), "b".into(), NotificationSource::Bell);
+        store.push(
+            1,
+            10,
+            100,
+            "A".into(),
+            String::new(),
+            "a".into(),
+            NotificationSource::Bell,
+        );
+        store.push(
+            1,
+            20,
+            200,
+            "B".into(),
+            String::new(),
+            "b".into(),
+            NotificationSource::Bell,
+        );
 
         assert!(store.has_unread_excluding(&[10, 20], 10));
         assert!(store.has_unread_excluding(&[10, 20], 20));
@@ -553,13 +605,30 @@ mod tests {
     #[test]
     fn workspace_unread_count() {
         let mut store = NotificationStore::new();
-        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
-        store.push(1, 10, 101, "B".into(), "b".into(), NotificationSource::Bell);
+        store.push(
+            1,
+            10,
+            100,
+            "A".into(),
+            String::new(),
+            "a".into(),
+            NotificationSource::Bell,
+        );
+        store.push(
+            1,
+            10,
+            101,
+            "B".into(),
+            String::new(),
+            "b".into(),
+            NotificationSource::Bell,
+        );
         store.push(
             1,
             20,
             200,
             "C".into(),
+            String::new(),
             "c".into(),
             NotificationSource::Toast,
         );
@@ -579,8 +648,24 @@ mod tests {
     #[test]
     fn remove_pane_cleanup() {
         let mut store = NotificationStore::new();
-        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
-        store.push(1, 20, 200, "B".into(), "b".into(), NotificationSource::Bell);
+        store.push(
+            1,
+            10,
+            100,
+            "A".into(),
+            String::new(),
+            "a".into(),
+            NotificationSource::Bell,
+        );
+        store.push(
+            1,
+            20,
+            200,
+            "B".into(),
+            String::new(),
+            "b".into(),
+            NotificationSource::Bell,
+        );
         store.remove_pane(10);
         assert!(store.pane_state(10).is_none());
         assert_eq!(store.all_notifications().len(), 1);
@@ -590,7 +675,15 @@ mod tests {
     #[test]
     fn remove_notification_decrements_unread() {
         let mut store = NotificationStore::new();
-        let id = store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
+        let id = store.push(
+            1,
+            10,
+            100,
+            "A".into(),
+            String::new(),
+            "a".into(),
+            NotificationSource::Bell,
+        );
         assert_eq!(store.pane_unread(10), 1);
         store.remove_notification(id);
         assert_eq!(store.pane_unread(10), 0);
@@ -639,8 +732,24 @@ mod tests {
     #[test]
     fn clear_all_notifications() {
         let mut store = NotificationStore::new();
-        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
-        store.push(2, 20, 200, "B".into(), "b".into(), NotificationSource::Cli);
+        store.push(
+            1,
+            10,
+            100,
+            "A".into(),
+            String::new(),
+            "a".into(),
+            NotificationSource::Bell,
+        );
+        store.push(
+            2,
+            20,
+            200,
+            "B".into(),
+            String::new(),
+            "b".into(),
+            NotificationSource::Cli,
+        );
         store.clear_all();
         assert_eq!(store.all_notifications().len(), 0);
         assert_eq!(store.pane_unread(10), 0);
@@ -651,10 +760,34 @@ mod tests {
     fn mark_workspace_read_only_affects_given_panes() {
         let mut store = NotificationStore::new();
         // Workspace 1 panes: 10, 11
-        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
-        store.push(1, 11, 101, "B".into(), "b".into(), NotificationSource::Bell);
+        store.push(
+            1,
+            10,
+            100,
+            "A".into(),
+            String::new(),
+            "a".into(),
+            NotificationSource::Bell,
+        );
+        store.push(
+            1,
+            11,
+            101,
+            "B".into(),
+            String::new(),
+            "b".into(),
+            NotificationSource::Bell,
+        );
         // Workspace 2 pane: 20
-        store.push(2, 20, 200, "C".into(), "c".into(), NotificationSource::Bell);
+        store.push(
+            2,
+            20,
+            200,
+            "C".into(),
+            String::new(),
+            "c".into(),
+            NotificationSource::Bell,
+        );
 
         store.mark_workspace_read(&[10, 11]);
         assert_eq!(store.pane_unread(10), 0);
@@ -670,6 +803,7 @@ mod tests {
             10,
             100,
             "First".into(),
+            String::new(),
             "a".into(),
             NotificationSource::Bell,
         );
@@ -678,6 +812,7 @@ mod tests {
             20,
             200,
             "Other".into(),
+            String::new(),
             "b".into(),
             NotificationSource::Bell,
         );
@@ -686,6 +821,7 @@ mod tests {
             10,
             101,
             "Latest".into(),
+            String::new(),
             "c".into(),
             NotificationSource::Bell,
         );
@@ -702,9 +838,33 @@ mod tests {
     #[test]
     fn total_unread_across_panes() {
         let mut store = NotificationStore::new();
-        store.push(1, 10, 100, "A".into(), "a".into(), NotificationSource::Bell);
-        store.push(1, 10, 101, "B".into(), "b".into(), NotificationSource::Bell);
-        store.push(2, 20, 200, "C".into(), "c".into(), NotificationSource::Cli);
+        store.push(
+            1,
+            10,
+            100,
+            "A".into(),
+            String::new(),
+            "a".into(),
+            NotificationSource::Bell,
+        );
+        store.push(
+            1,
+            10,
+            101,
+            "B".into(),
+            String::new(),
+            "b".into(),
+            NotificationSource::Bell,
+        );
+        store.push(
+            2,
+            20,
+            200,
+            "C".into(),
+            String::new(),
+            "c".into(),
+            NotificationSource::Cli,
+        );
         assert_eq!(store.total_unread(), 3);
 
         store.mark_pane_read(10);

--- a/crates/amux-notify/src/lib.rs
+++ b/crates/amux-notify/src/lib.rs
@@ -455,13 +455,14 @@ mod tests {
             10,
             100,
             "Test".into(),
-            String::new(),
+            "Permission Required".into(),
             "body".into(),
             NotificationSource::Bell,
         );
         assert_eq!(id, 1);
         assert_eq!(store.pane_unread(10), 1);
         assert_eq!(store.all_notifications().len(), 1);
+        assert_eq!(store.all_notifications()[0].subtitle, "Permission Required");
         assert!(!store.all_notifications()[0].read);
     }
 
@@ -473,12 +474,13 @@ mod tests {
             10,
             100,
             "Test".into(),
-            String::new(),
+            "Task Completed".into(),
             "body".into(),
             NotificationSource::Toast,
         );
         assert_eq!(store.pane_unread(10), 0);
         assert_eq!(store.all_notifications().len(), 1);
+        assert_eq!(store.all_notifications()[0].subtitle, "Task Completed");
         assert!(store.all_notifications()[0].read);
         // But flash should still be set
         assert!(store.pane_state(10).unwrap().flash_started_at.is_some());

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -472,4 +472,20 @@ mod tests {
         // excess=6, no newline found, returns text[6..] = "ghijklmnop"
         assert_eq!(result, "ghijklmnop");
     }
+
+    #[test]
+    fn deserialize_notification_without_subtitle_defaults_empty() {
+        let json = r#"{
+            "id": 1,
+            "workspace_id": 1,
+            "pane_id": 10,
+            "surface_id": 100,
+            "title": "T",
+            "body": "B",
+            "source": "cli",
+            "read": false
+        }"#;
+        let n: SavedNotification = serde_json::from_str(json).unwrap();
+        assert_eq!(n.subtitle, "");
+    }
 }

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -136,6 +136,8 @@ pub struct SavedNotification {
     pub pane_id: u64,
     pub surface_id: u64,
     pub title: String,
+    #[serde(default)]
+    pub subtitle: String,
     pub body: String,
     pub source: String,
     pub read: bool,


### PR DESCRIPTION
## Summary

- Adds `subtitle` field to the notification pipeline end-to-end: data model, store, IPC protocol, session persistence, CLI
- Backward compatible — `#[serde(default)]` on `SavedNotification.subtitle` handles older session files
- CLI: `amux notify --title "Claude Code" --subtitle "Permission Required" "Edit file.rs"`

## Files changed

| Crate | Change |
|-------|--------|
| `amux-notify` | `Notification.subtitle`, `push()`/`push_read()` gain subtitle param |
| `amux-session` | `SavedNotification.subtitle` with serde default |
| `amux-ipc` | `NotifySendParams.subtitle`, `NotifyListEntry.subtitle` |
| `amux-app/main.rs` | `deliver_notification()` threads subtitle, session save/restore |
| `amux-app/ipc_dispatch.rs` | `notify.send`/`notify.list` pass subtitle |
| `amux-cli` | `--subtitle` flag on `amux notify` command |

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace` passes (all 13 notification tests updated)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for notification subtitles—users can now specify an optional subtitle when creating notifications via the CLI using the new `--subtitle` flag for enhanced notification context
  * Notification list responses now include subtitle information alongside title and body for each notification
  * Subtitles are automatically persisted and restored across sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->