### PR TITLE
Fix copy/paste: route Edit menu through MenuAction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "amux-term",
  "anyhow",
  "arboard",
+ "chrono",
  "dirs",
  "eframe",
  "egui",
@@ -367,7 +368,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -928,6 +929,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "clang-sys"
@@ -2332,6 +2344,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -21,7 +21,8 @@ impl AmuxApp {
                     if self.copy_selection() {
                         return true;
                     }
-                    // No selection — let Ctrl+C fall through to terminal as SIGINT
+                    // No selection to copy — leave this Copy event unhandled so any
+                    // terminal Ctrl+C behavior (e.g. SIGINT) remains unaffected.
                     continue;
                 }
                 egui::Event::Cut => {

--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -14,6 +14,26 @@ impl AmuxApp {
         let events = ctx.input(|i| i.events.clone());
 
         for event in &events {
+            // Handle platform copy/cut events (egui may fire these instead of
+            // Key events for Cmd+C / Cmd+X on macOS).
+            match event {
+                egui::Event::Copy => {
+                    if self.copy_selection() {
+                        return true;
+                    }
+                    // No selection — let Ctrl+C fall through to terminal as SIGINT
+                    continue;
+                }
+                egui::Event::Cut => {
+                    // Terminal text is read-only; treat cut as copy.
+                    if self.copy_selection() {
+                        return true;
+                    }
+                    continue;
+                }
+                _ => {}
+            }
+
             if let egui::Event::Key {
                 key,
                 pressed: true,

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -596,7 +596,7 @@ impl eframe::App for AmuxApp {
                 if let Some(zoomed_id) = zoomed {
                     // Zoomed mode: render single pane fullscreen
                     let content_rect = egui::Rect::from_min_max(
-                        egui::pos2(panel_rect.min.x, panel_rect.min.y + TAB_BAR_HEIGHT),
+                        egui::pos2(panel_rect.min.x, panel_rect.min.y + TAB_CONTENT_TOP_INSET),
                         egui::pos2(panel_rect.max.x, panel_rect.max.y - TERMINAL_BOTTOM_PAD),
                     );
                     let sel_changed = self.handle_selection_mouse(ui, zoomed_id, content_rect);
@@ -632,7 +632,7 @@ impl eframe::App for AmuxApp {
                     for &(id, rect) in &layout {
                         if id == focused {
                             let content_rect = egui::Rect::from_min_max(
-                                egui::pos2(rect.min.x, rect.min.y + TAB_BAR_HEIGHT),
+                                egui::pos2(rect.min.x, rect.min.y + TAB_CONTENT_TOP_INSET),
                                 egui::pos2(rect.max.x, rect.max.y - TERMINAL_BOTTOM_PAD),
                             );
                             let sel_changed = self.handle_selection_mouse(ui, id, content_rect);

--- a/crates/amux-app/src/menu_bar.rs
+++ b/crates/amux-app/src/menu_bar.rs
@@ -28,6 +28,9 @@ pub(crate) enum MenuAction {
     ZoomIn,
     ZoomOut,
     ZoomReset,
+    Copy,
+    Paste,
+    SelectAll,
 }
 
 /// Stored menu item IDs, used to match incoming `MenuEvent`s to actions.
@@ -41,6 +44,9 @@ struct MenuItems {
     zoom_in: muda::MenuId,
     zoom_out: muda::MenuId,
     zoom_reset: muda::MenuId,
+    copy: muda::MenuId,
+    paste: muda::MenuId,
+    select_all: muda::MenuId,
 }
 
 static MENU_ITEMS: std::sync::OnceLock<MenuItems> = std::sync::OnceLock::new();
@@ -106,6 +112,15 @@ pub(crate) fn build() -> Menu {
     let zoom_out = MenuItem::new("Zoom Out", true, accel(CMD, Code::Minus));
     let zoom_reset = MenuItem::new("Actual Size", true, accel(CMD, Code::Digit0));
 
+    // Edit menu items — use custom MenuItems (not PredefinedMenuItem) so we
+    // receive the event in our handler instead of it being consumed by the OS.
+    let copy = MenuItem::new("Copy", true, accel(CMD, Code::KeyC));
+    let paste = MenuItem::new("Paste", true, accel(CMD, Code::KeyV));
+    #[cfg(target_os = "macos")]
+    let select_all = MenuItem::new("Select All", true, accel(CMD, Code::KeyA));
+    #[cfg(not(target_os = "macos"))]
+    let select_all = MenuItem::new("Select All", true, accel(CMD_SHIFT, Code::KeyA));
+
     // Store IDs for event matching
     if MENU_ITEMS
         .set(MenuItems {
@@ -118,6 +133,9 @@ pub(crate) fn build() -> Menu {
             zoom_in: zoom_in.id().clone(),
             zoom_out: zoom_out.id().clone(),
             zoom_reset: zoom_reset.id().clone(),
+            copy: copy.id().clone(),
+            paste: paste.id().clone(),
+            select_all: select_all.id().clone(),
         })
         .is_err()
     {
@@ -167,11 +185,8 @@ pub(crate) fn build() -> Menu {
     // --- Edit menu ---
     {
         let edit_menu = Submenu::new("Edit", true);
-        let _ = edit_menu.append_items(&[
-            &PredefinedMenuItem::copy(None),
-            &PredefinedMenuItem::paste(None),
-            &PredefinedMenuItem::select_all(None),
-        ]);
+        let _ =
+            edit_menu.append_items(&[&copy, &paste, &PredefinedMenuItem::separator(), &select_all]);
         let _ = menu.append(&edit_menu);
     }
 
@@ -268,6 +283,12 @@ pub(crate) fn take_pending_action() -> Option<MenuAction> {
             return Some(MenuAction::ZoomOut);
         } else if *id == items.zoom_reset {
             return Some(MenuAction::ZoomReset);
+        } else if *id == items.copy {
+            return Some(MenuAction::Copy);
+        } else if *id == items.paste {
+            return Some(MenuAction::Paste);
+        } else if *id == items.select_all {
+            return Some(MenuAction::SelectAll);
         }
         // Unknown ID (predefined OS item, etc.) — skip and keep draining.
     }

--- a/crates/amux-app/src/menu_bar.rs
+++ b/crates/amux-app/src/menu_bar.rs
@@ -114,8 +114,14 @@ pub(crate) fn build() -> Menu {
 
     // Edit menu items — use custom MenuItems (not PredefinedMenuItem) so we
     // receive the event in our handler instead of it being consumed by the OS.
+    #[cfg(target_os = "macos")]
     let copy = MenuItem::new("Copy", true, accel(CMD, Code::KeyC));
+    #[cfg(not(target_os = "macos"))]
+    let copy = MenuItem::new("Copy", true, accel(CMD_SHIFT, Code::KeyC));
+    #[cfg(target_os = "macos")]
     let paste = MenuItem::new("Paste", true, accel(CMD, Code::KeyV));
+    #[cfg(not(target_os = "macos"))]
+    let paste = MenuItem::new("Paste", true, accel(CMD_SHIFT, Code::KeyV));
     #[cfg(target_os = "macos")]
     let select_all = MenuItem::new("Select All", true, accel(CMD, Code::KeyA));
     #[cfg(not(target_os = "macos"))]

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -200,6 +200,21 @@ impl AmuxApp {
                         gpu.set_font_size(self.font_size);
                     }
                 }
+                menu_bar::MenuAction::Copy => {
+                    self.copy_selection();
+                }
+                menu_bar::MenuAction::Paste => {
+                    if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                        if let Ok(text) = clipboard.get_text() {
+                            if !text.is_empty() {
+                                self.do_paste(&text);
+                            }
+                        }
+                    }
+                }
+                menu_bar::MenuAction::SelectAll => {
+                    self.select_all_visible();
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Native Edit menu used `PredefinedMenuItem::copy/paste/select_all` which consumed Cmd+C/Cmd+V/Cmd+A at the OS level before egui saw the key events — the menu events were silently discarded
- Replace with custom `MenuItem`s that route through `MenuAction::Copy/Paste/SelectAll` to call `copy_selection()`, `do_paste()`, and `select_all_visible()`
- Handle `egui::Event::Copy/Cut` as defensive fallback for platforms where egui fires these directly
- Align selection `content_rect` to use `TAB_CONTENT_TOP_INSET` (matching render path) instead of `TAB_BAR_HEIGHT` (was 1px off)

Closes #73

## Test plan
- [ ] Select text with mouse drag → visual highlight appears
- [ ] Cmd+C copies selected text to system clipboard
- [ ] Cmd+V pastes from system clipboard into terminal
- [ ] Cmd+A selects all visible text
- [ ] Edit menu items (Copy, Paste, Select All) work via menu bar
- [ ] Ctrl+C with no selection still sends SIGINT to terminal
- [ ] Windows: Ctrl+Shift+C/V still work for copy/paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Copy, Paste, and Select All menu items with platform-specific keyboard shortcuts (Cmd on macOS, Cmd+Shift on other platforms).
  * Improved handling of copy and cut keyboard events.
  * Paste operation now reads from system clipboard for text insertion.
  * Enhanced terminal content selection accuracy for mouse interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->