### PR TITLE
libghostty-vt backend POC (#34)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wezterm-surface",
  "wezterm-term",
  "winit",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "amux-core",
  "anyhow",
  "cosmic-text",
+ "libghostty-vt",
  "portable-pty",
  "thiserror 2.0.18",
  "tracing",
@@ -2532,6 +2533,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "int-enum"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366a1634cccc76b4cfd3e7580de9b605e4d93f1edac48d786c1f867c0def495"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2763,6 +2776,23 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "libghostty-vt"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8afe5cc9ae303133220e530b28b7addbbf591160bb1564b88f7ee61387fee74"
+dependencies = [
+ "bitflags 2.11.0",
+ "int-enum",
+ "libghostty-vt-sys",
+]
+
+[[package]]
+name = "libghostty-vt-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee97068da1692162c4523d54843bdcb43fecf086a9ee412a3375817e433faca"
 
 [[package]]
 name = "libloading"
@@ -4084,6 +4114,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ repository = "https://github.com/yourusername/amux"
 wezterm-term = { git = "https://github.com/wezterm/wezterm", rev = "05343b387085842b434d267f91b6b0ec157e4331" }
 wezterm-surface = { git = "https://github.com/wezterm/wezterm", rev = "05343b387085842b434d267f91b6b0ec157e4331" }
 portable-pty = "0.9"
+libghostty-vt = "0.1"
 
 # Windowing
 winit = "0.30"

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -8,6 +8,7 @@ description = "amux main binary: GUI + event loop"
 [features]
 default = ["gpu-renderer"]
 gpu-renderer = ["dep:amux-render-gpu"]
+libghostty = ["amux-term/libghostty"]
 
 [dependencies]
 amux-core = { workspace = true }

--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -389,7 +389,7 @@ impl AmuxApp {
         let pane_id = self.focused_pane_id();
         if let Some(managed) = self.panes.get(&pane_id) {
             let surface = managed.active_surface();
-            let cursor = surface.pane.cursor();
+            let cursor = surface.pane.cursor_pos();
             let screen = surface.pane.screen();
             let (_, rows) = surface.pane.dimensions();
             let total = screen.scrollback_rows();

--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -1,5 +1,7 @@
 //! Keyboard, mouse, clipboard, copy-mode, and selection input handling.
 
+use amux_term::TerminalBackend;
+
 use crate::*;
 
 impl AmuxApp {
@@ -389,10 +391,9 @@ impl AmuxApp {
         let pane_id = self.focused_pane_id();
         if let Some(managed) = self.panes.get(&pane_id) {
             let surface = managed.active_surface();
-            let cursor = surface.pane.cursor_pos();
-            let screen = surface.pane.screen();
+            let cursor = surface.pane.cursor();
             let (_, rows) = surface.pane.dimensions();
-            let total = screen.scrollback_rows();
+            let total = surface.pane.scrollback_rows();
             let end = total.saturating_sub(surface.scroll_offset);
             let start = end.saturating_sub(rows);
             // Place copy mode cursor at terminal cursor position in phys coords
@@ -422,7 +423,7 @@ impl AmuxApp {
             Some(m) => {
                 let s = m.active_surface();
                 let (c, r) = s.pane.dimensions();
-                let t = s.pane.screen().scrollback_rows();
+                let t = s.pane.scrollback_rows();
                 (c, r, t)
             }
             None => {
@@ -532,14 +533,12 @@ impl AmuxApp {
         &self,
         pane_id: PaneId,
         anchor: (usize, usize),
-        cols: usize,
+        _cols: usize,
         line_visual: bool,
     ) -> Option<String> {
         let cm = self.copy_mode.as_ref()?;
         let managed = self.panes.get(&pane_id)?;
         let surface = managed.active_surface();
-        let screen = surface.pane.screen();
-
         let (start, end) =
             if anchor.1 < cm.cursor.1 || (anchor.1 == cm.cursor.1 && anchor.0 <= cm.cursor.0) {
                 (anchor, cm.cursor)
@@ -547,21 +546,17 @@ impl AmuxApp {
                 (cm.cursor, anchor)
             };
 
-        let lines = screen.lines_in_phys_range(start.1..end.1 + 1);
+        let rows = surface.pane.read_cells_range(start.1, end.1 + 1);
         let mut result = String::new();
 
-        for (i, line) in lines.iter().enumerate() {
+        for (i, screen_row) in rows.iter().enumerate() {
             if i > 0 {
                 result.push('\n');
             }
             let phys_row = start.1 + i;
-            for cell in line.visible_cells() {
-                let col = cell.cell_index();
-                if col >= cols {
-                    break;
-                }
+            for (col, cell) in screen_row.cells.iter().enumerate() {
                 if line_visual {
-                    result.push_str(cell.str());
+                    result.push_str(&cell.text);
                 } else {
                     // Character visual: clip to selection bounds
                     if phys_row == start.1 && col < start.0 {
@@ -570,7 +565,7 @@ impl AmuxApp {
                     if phys_row == end.1 && col > end.0 {
                         break;
                     }
-                    result.push_str(cell.str());
+                    result.push_str(&cell.text);
                 }
             }
         }
@@ -639,7 +634,7 @@ impl AmuxApp {
         };
         let surface = managed.active_surface();
         let (cols, visible_rows) = surface.pane.dimensions();
-        let total = surface.pane.screen().scrollback_rows();
+        let total = surface.pane.scrollback_rows();
         let scroll_offset = surface.scroll_offset;
         let end_row = total.saturating_sub(scroll_offset);
         let start_row = end_row.saturating_sub(visible_rows);
@@ -675,7 +670,7 @@ impl AmuxApp {
         };
         let surface = managed.active_surface();
         let (cols, visible_rows) = surface.pane.dimensions();
-        let total_rows = surface.pane.screen().scrollback_rows();
+        let total_rows = surface.pane.scrollback_rows();
         let scroll_offset = surface.scroll_offset;
 
         let primary_pressed = ui.input(|i| i.pointer.primary_pressed());

--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -2,6 +2,7 @@
 
 use amux_layout::{PaneId, SplitDirection};
 use amux_notify::NotificationSource;
+use amux_term::TerminalBackend;
 
 use crate::managed_pane::PaneSurface;
 use crate::{startup, AmuxApp};

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -419,7 +419,7 @@ impl eframe::App for AmuxApp {
                 }
                 // Detect process exit once the channel is drained
                 if surface.exited.is_none() && !surface.pane.is_alive() {
-                    let message = match surface.pane.pty_exit_status() {
+                    let message = match surface.pane.exit_status() {
                         Some(status) => {
                             if let Some(signal) = status.signal() {
                                 format!("Process killed ({signal})")

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1436,10 +1436,11 @@ impl AmuxApp {
                             }
                         });
                         if cmd_held && ctx.input(|i| i.pointer.primary_clicked()) {
-                            // Only open safe URL schemes.
-                            if url.starts_with("http://")
-                                || url.starts_with("https://")
-                                || url.starts_with("mailto:")
+                            // Only open safe URL schemes (case-insensitive).
+                            let lower = url.to_ascii_lowercase();
+                            if lower.starts_with("http://")
+                                || lower.starts_with("https://")
+                                || lower.starts_with("mailto:")
                             {
                                 let _ = open::that(url);
                             }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -32,6 +32,7 @@ use amux_term::config::AmuxTermConfig;
 use amux_term::font;
 use amux_term::osc::NotificationEvent;
 use amux_term::pane::TerminalPane;
+use amux_term::TerminalBackend;
 use managed_pane::*;
 use portable_pty::CommandBuilder;
 
@@ -1130,7 +1131,7 @@ impl AmuxApp {
             if let Some(managed) = self.panes.get(&pane_id) {
                 let surface = managed.active_surface();
                 let (_, rows) = surface.pane.dimensions();
-                let total = surface.pane.screen().scrollback_rows();
+                let total = surface.pane.scrollback_rows();
                 let end = total.saturating_sub(surface.scroll_offset);
                 let start = end.saturating_sub(rows);
                 if cm.cursor.1 >= start && cm.cursor.1 < end {
@@ -1264,7 +1265,7 @@ impl AmuxApp {
 
         if let Some(managed) = self.panes.get(&focused_id) {
             let surface = managed.active_surface();
-            let cursor = surface.pane.cursor_pos();
+            let cursor = surface.pane.cursor();
             let (dim_cols, dim_rows) = surface.pane.dimensions();
             let cols = dim_cols.max(1) as f32;
             let rows = dim_rows.max(1) as f32;
@@ -1302,7 +1303,7 @@ impl AmuxApp {
 
         if let Some(managed) = self.panes.get(&focused_id) {
             let surface = managed.active_surface();
-            let cursor = surface.pane.cursor_pos();
+            let cursor = surface.pane.cursor();
             let (dim_cols, dim_rows) = surface.pane.dimensions();
             let cols = dim_cols.max(1) as f32;
             let rows = dim_rows.max(1) as f32;
@@ -1410,44 +1411,39 @@ impl AmuxApp {
             if col >= cols || row >= rows {
                 return;
             }
-            let screen = surface.pane.screen();
-            let total = screen.scrollback_rows();
+            let total = surface.pane.scrollback_rows();
             let end = total.saturating_sub(surface.scroll_offset);
             let start = end.saturating_sub(rows);
             let phys_row = start + row;
-            let lines = screen.lines_in_phys_range(phys_row..phys_row + 1);
-            if let Some(line) = lines.first() {
-                for cell in line.visible_cells() {
-                    if cell.cell_index() == col {
-                        if let Some(link) = cell.attrs().hyperlink() {
-                            let url = link.uri().to_string();
-                            self.hovered_hyperlink = Some(url.clone());
+            let screen_rows = surface.pane.read_cells_range(phys_row, phys_row + 1);
+            if let Some(screen_row) = screen_rows.first() {
+                if let Some(cell) = screen_row.cells.get(col) {
+                    if let Some(ref url) = cell.hyperlink_url {
+                        self.hovered_hyperlink = Some(url.clone());
 
-                            // Set pointer cursor
-                            ctx.set_cursor_icon(egui::CursorIcon::PointingHand);
+                        // Set pointer cursor
+                        ctx.set_cursor_icon(egui::CursorIcon::PointingHand);
 
-                            // Cmd+click opens URL
-                            let cmd_held = ctx.input(|i| {
-                                #[cfg(target_os = "macos")]
-                                {
-                                    i.modifiers.mac_cmd || i.modifiers.command
-                                }
-                                #[cfg(not(target_os = "macos"))]
-                                {
-                                    i.modifiers.ctrl
-                                }
-                            });
-                            if cmd_held && ctx.input(|i| i.pointer.primary_clicked()) {
-                                // Only open safe URL schemes.
-                                if url.starts_with("http://")
-                                    || url.starts_with("https://")
-                                    || url.starts_with("mailto:")
-                                {
-                                    let _ = open::that(&url);
-                                }
+                        // Cmd+click opens URL
+                        let cmd_held = ctx.input(|i| {
+                            #[cfg(target_os = "macos")]
+                            {
+                                i.modifiers.mac_cmd || i.modifiers.command
+                            }
+                            #[cfg(not(target_os = "macos"))]
+                            {
+                                i.modifiers.ctrl
+                            }
+                        });
+                        if cmd_held && ctx.input(|i| i.pointer.primary_clicked()) {
+                            // Only open safe URL schemes.
+                            if url.starts_with("http://")
+                                || url.starts_with("https://")
+                                || url.starts_with("mailto:")
+                            {
+                                let _ = open::that(url);
                             }
                         }
-                        break;
                     }
                 }
             }
@@ -1625,7 +1621,7 @@ impl AmuxApp {
                     if let Some(managed) = self.panes.get_mut(&pane_id) {
                         let surface = managed.active_surface_mut();
                         let (_, rows) = surface.pane.dimensions();
-                        let total_rows = surface.pane.screen().scrollback_rows();
+                        let total_rows = surface.pane.scrollback_rows();
                         // Calculate scroll offset to center the match
                         let target_end = phys_row + rows / 2;
                         let actual_end = target_end.min(total_rows);

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -418,7 +418,7 @@ impl eframe::App for AmuxApp {
                 }
                 // Detect process exit once the channel is drained
                 if surface.exited.is_none() && !surface.pane.is_alive() {
-                    let message = match surface.pane.exit_status() {
+                    let message = match surface.pane.pty_exit_status() {
                         Some(status) => {
                             if let Some(signal) = status.signal() {
                                 format!("Process killed ({signal})")
@@ -1264,7 +1264,7 @@ impl AmuxApp {
 
         if let Some(managed) = self.panes.get(&focused_id) {
             let surface = managed.active_surface();
-            let cursor = surface.pane.cursor();
+            let cursor = surface.pane.cursor_pos();
             let (dim_cols, dim_rows) = surface.pane.dimensions();
             let cols = dim_cols.max(1) as f32;
             let rows = dim_rows.max(1) as f32;
@@ -1302,7 +1302,7 @@ impl AmuxApp {
 
         if let Some(managed) = self.panes.get(&focused_id) {
             let surface = managed.active_surface();
-            let cursor = surface.pane.cursor();
+            let cursor = surface.pane.cursor_pos();
             let (dim_cols, dim_rows) = surface.pane.dimensions();
             let cols = dim_cols.max(1) as f32;
             let rows = dim_rows.max(1) as f32;

--- a/crates/amux-app/src/managed_pane.rs
+++ b/crates/amux-app/src/managed_pane.rs
@@ -21,7 +21,8 @@
 
 use std::sync::mpsc;
 
-use amux_term::pane::TerminalPane;
+use amux_term::AnyBackend;
+use amux_term::TerminalBackend;
 
 // Re-export core model types so existing `use managed_pane::*` keeps working.
 pub(crate) use amux_core::model::{
@@ -36,7 +37,7 @@ pub(crate) use amux_core::model::{
 /// A terminal tab within a pane. Each pane can have multiple surfaces.
 pub(crate) struct PaneSurface {
     pub(crate) id: u64,
-    pub(crate) pane: TerminalPane,
+    pub(crate) pane: AnyBackend,
     pub(crate) byte_rx: mpsc::Receiver<Vec<u8>>,
     pub(crate) scroll_offset: usize,
     pub(crate) scroll_accum: f32,

--- a/crates/amux-app/src/render.rs
+++ b/crates/amux-app/src/render.rs
@@ -2,10 +2,8 @@
 
 use std::time::Duration;
 
-use amux_term::color::resolve_color;
+use amux_term::backend::{Color, CursorShape, TerminalBackend};
 use amux_term::pane::TerminalPane;
-use wezterm_surface::{CursorShape, CursorVisibility};
-use wezterm_term::color::SrgbaTuple;
 
 use crate::managed_pane::SelectionState;
 
@@ -35,14 +33,16 @@ pub(crate) fn render_pane(
         if actual_cols == 0 || actual_rows == 0 {
             return;
         }
-        let palette = pane.color_palette();
-        let cursor = pane.cursor_pos();
-        let screen = pane.screen();
         let gpu_selection = selection.map(|sel| {
             let (start, end) = sel.normalized();
             amux_render_gpu::snapshot::SelectionRange { start, end }
         });
         let seqno = pane.current_seqno();
+
+        // Build snapshot via the wezterm-specific path (with Kitty image support).
+        let palette = pane.color_palette();
+        let cursor = pane.cursor();
+        let screen = pane.screen();
         let snapshot = amux_render_gpu::TerminalSnapshot::from_screen(
             screen,
             &palette,
@@ -63,6 +63,8 @@ pub(crate) fn render_pane(
         return;
     }
 
+    // --- Software renderer path (uses TerminalBackend trait) ---
+
     let font_id = egui::FontId::monospace(font_size);
     let cell_width = ui.fonts(|f| f.glyph_width(&font_id, 'M'));
     let cell_height = ui.fonts(|f| f.row_height(&font_id));
@@ -72,13 +74,12 @@ pub(crate) fn render_pane(
         return;
     }
 
-    let palette = pane.color_palette();
-    let cursor = pane.cursor_pos();
-    let screen = pane.screen();
+    let palette = pane.palette();
+    let cursor = pane.cursor();
+    let bg_default = color_to_egui(palette.background);
 
     let painter = ui.painter();
     let origin = rect.min;
-    let bg_default = srgba_to_egui(palette.background);
 
     // Fill the full allocated rect first to avoid artifacts when terminal is smaller
     painter.rect_filled(rect, 0.0, bg_default);
@@ -89,19 +90,18 @@ pub(crate) fn render_pane(
         painter.rect_filled(rect, 0.0, dim_overlay);
     }
 
-    let total = screen.scrollback_rows();
+    let total = pane.scrollback_rows();
     let end = total.saturating_sub(scroll_offset);
     let start = end.saturating_sub(actual_rows);
-    let lines = screen.lines_in_phys_range(start..end);
+    let screen_rows = pane.read_cells_range(start, end);
 
-    for (row_idx, line) in lines.iter().enumerate() {
+    for (row_idx, screen_row) in screen_rows.iter().enumerate() {
         let y = origin.y + row_idx as f32 * cell_height;
         if y + cell_height < rect.min.y || y > rect.max.y {
             continue;
         }
 
-        for cell_ref in line.visible_cells() {
-            let col_idx = cell_ref.cell_index();
+        for (col_idx, cell) in screen_row.cells.iter().enumerate() {
             if col_idx >= actual_cols {
                 break;
             }
@@ -111,11 +111,8 @@ pub(crate) fn render_pane(
                 continue;
             }
 
-            let attrs = cell_ref.attrs();
-            let reverse = attrs.reverse();
-            let mut bg =
-                srgba_to_egui(resolve_color(&attrs.background(), &palette, false, reverse));
-            let mut fg = srgba_to_egui(resolve_color(&attrs.foreground(), &palette, true, reverse));
+            let mut fg = color_to_egui(cell.fg);
+            let mut bg = color_to_egui(cell.bg);
 
             // Selection: swap fg/bg for selected cells (reverse video)
             let stable_row = start + row_idx;
@@ -124,7 +121,7 @@ pub(crate) fn render_pane(
                     std::mem::swap(&mut fg, &mut bg);
                     // Ensure selected empty cells have visible bg
                     if bg == bg_default {
-                        bg = srgba_to_egui(palette.foreground);
+                        bg = color_to_egui(palette.foreground);
                         fg = bg_default;
                     }
                 }
@@ -155,7 +152,7 @@ pub(crate) fn render_pane(
                 );
             }
 
-            let text = cell_ref.str();
+            let text = &cell.text;
             if !text.is_empty() && text != " " {
                 painter.text(
                     egui::pos2(x, y),
@@ -171,14 +168,14 @@ pub(crate) fn render_pane(
     // Draw cursor
     if is_focused
         && scroll_offset == 0
-        && cursor.visibility == CursorVisibility::Visible
+        && cursor.visible
         && cursor.y >= 0
         && (cursor.y as usize) < actual_rows
         && cursor.x < actual_cols
     {
         let cx = origin.x + cursor.x as f32 * cell_width;
         let cy = origin.y + cursor.y as f32 * cell_height;
-        let cursor_color = srgba_to_egui(palette.cursor_bg);
+        let cursor_color = color_to_egui(palette.cursor_bg);
 
         match cursor.shape {
             CursorShape::BlinkingBar | CursorShape::SteadyBar => {
@@ -198,25 +195,22 @@ pub(crate) fn render_pane(
                     egui::pos2(cx, cy),
                     egui::vec2(cell_width, cell_height),
                 );
-                let cursor_fg = srgba_to_egui(palette.cursor_fg);
+                let cursor_fg = color_to_egui(palette.cursor_fg);
                 painter.rect_filled(cursor_rect, 0.0, cursor_color);
 
+                // Draw text under the block cursor
                 let cursor_line_idx = cursor.y as usize;
-                if cursor_line_idx < lines.len() {
-                    let line = &lines[cursor_line_idx];
-                    for cell_ref in line.visible_cells() {
-                        if cell_ref.cell_index() == cursor.x {
-                            let text = cell_ref.str();
-                            if !text.is_empty() && text != " " {
-                                painter.text(
-                                    egui::pos2(cx, cy),
-                                    egui::Align2::LEFT_TOP,
-                                    text,
-                                    font_id.clone(),
-                                    cursor_fg,
-                                );
-                            }
-                            break;
+                if cursor_line_idx < screen_rows.len() {
+                    if let Some(cell) = screen_rows[cursor_line_idx].cells.get(cursor.x) {
+                        let text = &cell.text;
+                        if !text.is_empty() && text != " " {
+                            painter.text(
+                                egui::pos2(cx, cy),
+                                egui::Align2::LEFT_TOP,
+                                text,
+                                font_id.clone(),
+                                cursor_fg,
+                            );
                         }
                     }
                 }
@@ -312,12 +306,13 @@ pub(crate) fn render_exit_overlay(
     painter.galley(egui::pos2(x2, y2), g2, egui::Color32::from_gray(160));
 }
 
-pub(crate) fn srgba_to_egui(color: SrgbaTuple) -> egui::Color32 {
+/// Convert an amux-native Color to egui Color32.
+pub(crate) fn color_to_egui(c: Color) -> egui::Color32 {
     egui::Color32::from_rgba_unmultiplied(
-        (color.0 * 255.0).round() as u8,
-        (color.1 * 255.0).round() as u8,
-        (color.2 * 255.0).round() as u8,
-        (color.3 * 255.0).round() as u8,
+        (c.0 * 255.0).round() as u8,
+        (c.1 * 255.0).round() as u8,
+        (c.2 * 255.0).round() as u8,
+        (c.3 * 255.0).round() as u8,
     )
 }
 

--- a/crates/amux-app/src/render.rs
+++ b/crates/amux-app/src/render.rs
@@ -39,40 +39,24 @@ pub(crate) fn render_pane(
         });
         let seqno = pane.current_seqno();
 
-        // Build snapshot: use wezterm-specific path (with Kitty image support)
-        // when available, otherwise fall back to trait-based path.
-        let snapshot = if let Some(wez) = pane.as_wezterm() {
-            let palette = wez.color_palette();
-            let cursor = pane.cursor();
-            let screen = wez.screen();
-            amux_render_gpu::TerminalSnapshot::from_screen(
-                screen,
-                &palette,
-                &cursor,
-                actual_cols,
-                actual_rows,
-                scroll_offset,
-                is_focused,
-                gpu_selection,
-                pane_id,
-                seqno,
-                find_highlights.to_vec(),
-                current_highlight,
-            )
-        } else {
-            amux_render_gpu::TerminalSnapshot::from_backend(
-                pane,
-                actual_cols,
-                actual_rows,
-                scroll_offset,
-                is_focused,
-                gpu_selection,
-                pane_id,
-                seqno,
-                find_highlights.to_vec(),
-                current_highlight,
-            )
-        };
+        // Build snapshot via the trait-based path (works for all backends).
+        let mut snapshot = amux_render_gpu::TerminalSnapshot::from_backend(
+            pane,
+            actual_cols,
+            actual_rows,
+            scroll_offset,
+            is_focused,
+            gpu_selection,
+            pane_id,
+            seqno,
+            find_highlights.to_vec(),
+            current_highlight,
+        );
+
+        // Add Kitty inline images for the wezterm backend.
+        if let Some(wez) = pane.as_wezterm() {
+            amux_render_gpu::snapshot::extract_kitty_images(&mut snapshot, wez.screen());
+        }
         let pixels_per_point = ui.ctx().pixels_per_point();
         let callback = gpu.paint_callback(rect, snapshot, pixels_per_point);
         ui.painter().add(egui::Shape::Callback(callback));

--- a/crates/amux-app/src/render.rs
+++ b/crates/amux-app/src/render.rs
@@ -35,8 +35,8 @@ pub(crate) fn render_pane(
         if actual_cols == 0 || actual_rows == 0 {
             return;
         }
-        let palette = pane.palette();
-        let cursor = pane.cursor();
+        let palette = pane.color_palette();
+        let cursor = pane.cursor_pos();
         let screen = pane.screen();
         let gpu_selection = selection.map(|sel| {
             let (start, end) = sel.normalized();
@@ -72,8 +72,8 @@ pub(crate) fn render_pane(
         return;
     }
 
-    let palette = pane.palette();
-    let cursor = pane.cursor();
+    let palette = pane.color_palette();
+    let cursor = pane.cursor_pos();
     let screen = pane.screen();
 
     let painter = ui.painter();

--- a/crates/amux-app/src/render.rs
+++ b/crates/amux-app/src/render.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use amux_term::backend::{Color, CursorShape, TerminalBackend};
-use amux_term::pane::TerminalPane;
+use amux_term::AnyBackend;
 
 use crate::managed_pane::SelectionState;
 
@@ -15,7 +15,7 @@ use amux_render_gpu::GpuRenderer;
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn render_pane(
     ui: &mut egui::Ui,
-    pane: &mut TerminalPane,
+    pane: &mut AnyBackend,
     rect: egui::Rect,
     is_focused: bool,
     scroll_offset: usize,
@@ -39,24 +39,40 @@ pub(crate) fn render_pane(
         });
         let seqno = pane.current_seqno();
 
-        // Build snapshot via the wezterm-specific path (with Kitty image support).
-        let palette = pane.color_palette();
-        let cursor = pane.cursor();
-        let screen = pane.screen();
-        let snapshot = amux_render_gpu::TerminalSnapshot::from_screen(
-            screen,
-            &palette,
-            &cursor,
-            actual_cols,
-            actual_rows,
-            scroll_offset,
-            is_focused,
-            gpu_selection,
-            pane_id,
-            seqno,
-            find_highlights.to_vec(),
-            current_highlight,
-        );
+        // Build snapshot: use wezterm-specific path (with Kitty image support)
+        // when available, otherwise fall back to trait-based path.
+        let snapshot = if let Some(wez) = pane.as_wezterm() {
+            let palette = wez.color_palette();
+            let cursor = pane.cursor();
+            let screen = wez.screen();
+            amux_render_gpu::TerminalSnapshot::from_screen(
+                screen,
+                &palette,
+                &cursor,
+                actual_cols,
+                actual_rows,
+                scroll_offset,
+                is_focused,
+                gpu_selection,
+                pane_id,
+                seqno,
+                find_highlights.to_vec(),
+                current_highlight,
+            )
+        } else {
+            amux_render_gpu::TerminalSnapshot::from_backend(
+                pane,
+                actual_cols,
+                actual_rows,
+                scroll_offset,
+                is_focused,
+                gpu_selection,
+                pane_id,
+                seqno,
+                find_highlights.to_vec(),
+                current_highlight,
+            )
+        };
         let pixels_per_point = ui.ctx().pixels_per_point();
         let callback = gpu.paint_callback(rect, snapshot, pixels_per_point);
         ui.painter().add(egui::Shape::Callback(callback));

--- a/crates/amux-app/src/selection.rs
+++ b/crates/amux-app/src/selection.rs
@@ -1,5 +1,5 @@
 //! Terminal text selection helpers: coordinate mapping, word boundaries,
-//! and text extraction from wezterm-term screen state.
+//! and text extraction via the TerminalBackend trait.
 
 use amux_term::backend::TerminalBackend;
 use managed_pane::WORD_DELIMITERS;

--- a/crates/amux-app/src/selection.rs
+++ b/crates/amux-app/src/selection.rs
@@ -1,7 +1,7 @@
 //! Terminal text selection helpers: coordinate mapping, word boundaries,
 //! and text extraction from wezterm-term screen state.
 
-use amux_term::pane::TerminalPane;
+use amux_term::backend::TerminalBackend;
 use managed_pane::WORD_DELIMITERS;
 
 use crate::managed_pane;
@@ -58,24 +58,18 @@ pub(crate) fn word_bounds_in_line(line_text: &str, col: usize) -> (usize, usize)
 
 /// Extract text from the terminal screen within a selection range.
 pub(crate) fn extract_selection_text(
-    pane: &TerminalPane,
+    pane: &dyn TerminalBackend,
     start: (usize, usize),
     end: (usize, usize),
-    cols: usize,
+    _cols: usize,
 ) -> String {
-    let screen = pane.screen();
-    let lines = screen.lines_in_phys_range(start.1..end.1 + 1);
+    let rows = pane.read_cells_range(start.1, end.1 + 1);
     let mut result = String::new();
 
-    for (i, line) in lines.iter().enumerate() {
+    for (i, screen_row) in rows.iter().enumerate() {
         let row = start.1 + i;
         let mut line_text = String::new();
-        for cell in line.visible_cells() {
-            let ci = cell.cell_index();
-            if ci >= cols {
-                break;
-            }
-            // Determine if this cell is in the selection
+        for (ci, cell) in screen_row.cells.iter().enumerate() {
             let in_sel = if start.1 == end.1 {
                 ci >= start.0 && ci <= end.0
             } else if row == start.1 {
@@ -86,14 +80,13 @@ pub(crate) fn extract_selection_text(
                 true
             };
             if in_sel {
-                line_text.push_str(cell.str());
+                line_text.push_str(&cell.text);
             }
         }
 
         if i > 0 {
             // Check if previous line was wrapped — if so, don't add newline
-            let prev_line = &lines[i - 1];
-            if !prev_line.last_cell_was_wrapped() {
+            if !rows[i - 1].wrapped {
                 result.push('\n');
             }
         }
@@ -104,23 +97,21 @@ pub(crate) fn extract_selection_text(
 }
 
 /// Build a flat string of a line's cell text for word boundary detection.
-pub(crate) fn line_text_string(pane: &TerminalPane, stable_row: usize, cols: usize) -> String {
-    let screen = pane.screen();
-    let lines = screen.lines_in_phys_range(stable_row..stable_row + 1);
-    if lines.is_empty() {
+pub(crate) fn line_text_string(
+    pane: &dyn TerminalBackend,
+    stable_row: usize,
+    _cols: usize,
+) -> String {
+    let rows = pane.read_cells_range(stable_row, stable_row + 1);
+    if rows.is_empty() {
         return String::new();
     }
-    let line = &lines[0];
     let mut text = String::new();
-    for cell in line.visible_cells() {
-        if cell.cell_index() >= cols {
-            break;
-        }
-        let s = cell.str();
-        if s.is_empty() {
+    for cell in &rows[0].cells {
+        if cell.text.is_empty() {
             text.push(' ');
         } else {
-            text.push_str(s);
+            text.push_str(&cell.text);
         }
     }
     text

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -27,7 +27,10 @@ pub(crate) fn run() -> anyhow::Result<()> {
     tracing::info!("IPC server: {}", ipc_addr);
 
     let theme = theme::Theme::default();
-    let mut term_config = AmuxTermConfig::default();
+    let mut term_config = AmuxTermConfig {
+        backend: app_config.backend.clone(),
+        ..Default::default()
+    };
     theme.apply_to_palette(&mut term_config.color_palette);
     let config = Arc::new(term_config);
 
@@ -474,7 +477,17 @@ pub(crate) fn spawn_surface(
         None
     };
 
-    let mut pane = TerminalPane::spawn(cols, rows, cmd, config.clone())?;
+    let mut pane: amux_term::AnyBackend = match config.backend.as_str() {
+        #[cfg(feature = "libghostty")]
+        "ghostty" => {
+            let ghostty_pane = amux_term::ghostty_pane::GhosttyPane::spawn(cols, rows, cmd)?;
+            amux_term::AnyBackend::Ghostty(ghostty_pane)
+        }
+        _ => {
+            let wez_pane = TerminalPane::spawn(cols, rows, cmd, config.clone())?;
+            amux_term::AnyBackend::Wezterm(wez_pane)
+        }
+    };
 
     // Inject scrollback text before starting the reader thread.
     // feed_bytes writes directly to the terminal state machine, not through the PTY.

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -481,11 +481,11 @@ pub(crate) fn spawn_surface(
         #[cfg(feature = "libghostty")]
         "ghostty" => {
             let ghostty_pane = amux_term::ghostty_pane::GhosttyPane::spawn(cols, rows, cmd)?;
-            amux_term::AnyBackend::Ghostty(ghostty_pane)
+            amux_term::AnyBackend::Ghostty(Box::new(ghostty_pane))
         }
         _ => {
             let wez_pane = TerminalPane::spawn(cols, rows, cmd, config.clone())?;
-            amux_term::AnyBackend::Wezterm(wez_pane)
+            amux_term::AnyBackend::Wezterm(Box::new(wez_pane))
         }
     };
 

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -355,7 +355,7 @@ impl AmuxApp {
             let (_, rows) = surface.pane.dimensions();
             let page_size = rows.saturating_sub(1).max(1);
             let lines = pages * page_size as isize;
-            let total = surface.pane.screen().scrollback_rows();
+            let total = surface.pane.scrollback_rows();
             let max_offset = total.saturating_sub(rows);
             let new_offset = surface.scroll_offset as isize - lines;
             surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
@@ -367,7 +367,7 @@ impl AmuxApp {
         if let Some(managed) = self.panes.get_mut(&pane_id) {
             let surface = managed.active_surface_mut();
             let (_, rows) = surface.pane.dimensions();
-            let total = surface.pane.screen().scrollback_rows();
+            let total = surface.pane.scrollback_rows();
             let max_offset = total.saturating_sub(rows);
             let new_offset = surface.scroll_offset as isize - lines;
             surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -12,6 +12,9 @@ pub struct AppConfig {
     /// Font family for terminal text (e.g. "JetBrains Mono", "Menlo").
     /// Resolved against system-installed fonts by cosmic-text.
     pub font_family: String,
+    /// Terminal backend engine: "wezterm" (default) or "ghostty".
+    /// The "ghostty" backend requires the `libghostty` feature.
+    pub backend: String,
     pub notifications: NotificationConfig,
 }
 
@@ -20,6 +23,7 @@ impl Default for AppConfig {
         Self {
             font_size: DEFAULT_FONT_SIZE,
             font_family: DEFAULT_FONT_FAMILY.to_owned(),
+            backend: "wezterm".to_owned(),
             notifications: NotificationConfig::default(),
         }
     }

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -1,9 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
+use amux_term::backend::CursorShape;
 use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, SwashCache};
 use egui_wgpu::wgpu;
 use egui_wgpu::{CallbackResources, CallbackTrait, ScreenDescriptor};
-use wezterm_surface::{CursorShape, CursorVisibility};
 
 use crate::atlas::GlyphAtlas;
 use crate::pipeline::{
@@ -81,7 +81,7 @@ pub struct PaneRenderState {
     seqno: usize,
     cursor_x: usize,
     cursor_y: i64,
-    cursor_visibility: CursorVisibility,
+    cursor_visible: bool,
     cursor_shape: CursorShape,
     scroll_offset: usize,
     is_focused: bool,
@@ -133,7 +133,7 @@ impl PaneRenderState {
             seqno: 0,
             cursor_x: 0,
             cursor_y: 0,
-            cursor_visibility: CursorVisibility::Visible,
+            cursor_visible: true,
             cursor_shape: CursorShape::Default,
             scroll_offset: 0,
             is_focused: false,
@@ -167,10 +167,10 @@ impl PaneRenderState {
     ) -> bool {
         !self.initialized
             || self.seqno != snap.seqno
-            || self.cursor_x != snap.cursor.x
-            || self.cursor_y != snap.cursor.y
-            || self.cursor_visibility != snap.cursor.visibility
-            || self.cursor_shape != snap.cursor.shape
+            || self.cursor_x != snap.cursor_x
+            || self.cursor_y != snap.cursor_y
+            || self.cursor_visible != snap.cursor_visible
+            || self.cursor_shape != snap.cursor_shape
             || self.scroll_offset != snap.scroll_offset
             || self.is_focused != snap.is_focused
             || self.rect_x != rect.x
@@ -198,10 +198,10 @@ impl PaneRenderState {
     ) {
         self.initialized = true;
         self.seqno = snap.seqno;
-        self.cursor_x = snap.cursor.x;
-        self.cursor_y = snap.cursor.y;
-        self.cursor_visibility = snap.cursor.visibility;
-        self.cursor_shape = snap.cursor.shape;
+        self.cursor_x = snap.cursor_x;
+        self.cursor_y = snap.cursor_y;
+        self.cursor_visible = snap.cursor_visible;
+        self.cursor_shape = snap.cursor_shape;
         self.scroll_offset = snap.scroll_offset;
         self.is_focused = snap.is_focused;
         self.selection_range = snap.selection_range;
@@ -588,19 +588,18 @@ impl CallbackTrait for TerminalPaintCallback {
         };
 
         // --- Cursor ---
-        let cursor = &snap.cursor;
         if snap.is_focused
             && snap.scroll_offset == 0
-            && cursor.visibility == CursorVisibility::Visible
-            && cursor.y >= 0
-            && (cursor.y as usize) < snap.rows
-            && cursor.x < snap.cols
+            && snap.cursor_visible
+            && snap.cursor_y >= 0
+            && (snap.cursor_y as usize) < snap.rows
+            && snap.cursor_x < snap.cols
         {
-            let cx = self.phys_rect.x + cursor.x as f32 * self.cell_width;
-            let cy = self.phys_rect.y + cursor.y as f32 * self.cell_height;
+            let cx = self.phys_rect.x + snap.cursor_x as f32 * self.cell_width;
+            let cy = self.phys_rect.y + snap.cursor_y as f32 * self.cell_height;
             let cursor_bg = maybe_linearize(snap.cursor_bg, linearize);
 
-            match cursor.shape {
+            match snap.cursor_shape {
                 CursorShape::BlinkingBar | CursorShape::SteadyBar => {
                     bg_instances.push(CellBgInstance {
                         pos: [cx, cy],

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -395,6 +395,56 @@ impl TerminalSnapshot {
     }
 }
 
+/// Extract Kitty inline images from a wezterm screen and add them to a snapshot.
+///
+/// Call this after `from_backend()` to add Kitty image support for the wezterm backend.
+/// The `from_screen()` constructor already includes image extraction inline.
+pub fn extract_kitty_images(
+    snapshot: &mut TerminalSnapshot,
+    screen: &wezterm_term::screen::Screen,
+) {
+    let total = screen.scrollback_rows();
+    let end = total.saturating_sub(snapshot.scroll_offset);
+    let start = end.saturating_sub(snapshot.rows);
+    let lines = screen.lines_in_phys_range(start..end);
+
+    let mut images = Vec::new();
+    let mut seen_images: HashMap<[u8; 32], Arc<ImageData>> = HashMap::new();
+
+    for (row_idx, line) in lines.iter().enumerate() {
+        for cell_ref in line.visible_cells() {
+            let col_idx = cell_ref.cell_index();
+            if col_idx >= snapshot.cols {
+                break;
+            }
+
+            if let Some(image_cells) = cell_ref.attrs().images() {
+                for image_cell in &image_cells {
+                    let image_data = image_cell.image_data();
+                    let hash = image_data.hash();
+                    seen_images
+                        .entry(hash)
+                        .or_insert_with(|| Arc::clone(image_data));
+
+                    let tl = image_cell.top_left();
+                    let br = image_cell.bottom_right();
+                    images.push(ImagePlacement {
+                        col: col_idx,
+                        row: row_idx,
+                        uv_min: [tl.x.into_inner(), tl.y.into_inner()],
+                        uv_max: [br.x.into_inner(), br.y.into_inner()],
+                        image_hash: hash,
+                        z_index: image_cell.z_index(),
+                    });
+                }
+            }
+        }
+    }
+
+    snapshot.images = images;
+    snapshot.decoded_images = decode_images(seen_images);
+}
+
 /// Decode image data from wezterm-term into raw RGBA.
 fn decode_images(seen: HashMap<[u8; 32], Arc<ImageData>>) -> Vec<DecodedImage> {
     let mut result = Vec::with_capacity(seen.len());

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -175,7 +175,8 @@ impl TerminalSnapshot {
                 }
 
                 // Capture text under cursor for block cursor rendering
-                if row_idx == cursor.y as usize
+                if cursor.y >= 0
+                    && row_idx == cursor.y as usize
                     && col_idx == cursor.x
                     && !cell.text.is_empty()
                     && cell.text != " "
@@ -310,7 +311,7 @@ impl TerminalSnapshot {
                 }
 
                 // Capture text under cursor for block cursor rendering
-                if row_idx == cursor.y as usize && col_idx == cursor.x {
+                if cursor.y >= 0 && row_idx == cursor.y as usize && col_idx == cursor.x {
                     let text = cell_ref.str();
                     if !text.is_empty() && text != " " {
                         cursor_text = text.to_string();

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use amux_term::backend::{Color, CursorPos, CursorShape, TerminalBackend};
 use amux_term::color::{resolve_color, srgba_to_f32};
 use wezterm_term::color::{ColorPalette, SrgbaTuple};
 use wezterm_term::image::{ImageData, ImageDataType};
-use wezterm_term::CursorPosition;
 
 /// Pre-extracted terminal state for GPU rendering.
 ///
@@ -16,7 +16,11 @@ pub struct TerminalSnapshot {
     pub cols: usize,
     pub rows: usize,
     pub cells: Vec<CellData>,
-    pub cursor: CursorPosition,
+    // Cursor fields (amux-native types, no wezterm dependency)
+    pub cursor_x: usize,
+    pub cursor_y: i64,
+    pub cursor_visible: bool,
+    pub cursor_shape: CursorShape,
     pub default_bg: [f32; 4],
     pub cursor_bg: [f32; 4],
     pub cursor_fg: [f32; 4],
@@ -96,16 +100,148 @@ impl SelectionRange {
     }
 }
 
+fn color_to_f32(c: Color) -> [f32; 4] {
+    [c.0, c.1, c.2, c.3]
+}
+
 impl TerminalSnapshot {
-    /// Extract a snapshot from the terminal screen.
+    /// Build a snapshot from a `TerminalBackend` using amux-native types.
     ///
-    /// `scroll_offset` is the number of lines scrolled back from the bottom.
-    /// `selection` is an optional normalized selection range for highlight rendering.
+    /// Does NOT extract Kitty images — those require wezterm-specific screen
+    /// access and must be added separately for the wezterm backend.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_backend(
+        backend: &dyn TerminalBackend,
+        cols: usize,
+        rows: usize,
+        scroll_offset: usize,
+        is_focused: bool,
+        selection: Option<SelectionRange>,
+        pane_id: u64,
+        seqno: usize,
+        highlight_ranges: Vec<(usize, usize, usize)>,
+        current_highlight: Option<usize>,
+    ) -> Self {
+        let palette = backend.palette();
+        let cursor = backend.cursor();
+        let selection_range = selection.as_ref().map(|s| (s.start, s.end));
+        let default_bg = color_to_f32(palette.background);
+        let cursor_bg = color_to_f32(palette.cursor_bg);
+        let cursor_fg = color_to_f32(palette.cursor_fg);
+
+        let total = backend.scrollback_rows();
+        let end = total.saturating_sub(scroll_offset);
+        let start = end.saturating_sub(rows);
+        let screen_rows = backend.read_cells_range(start, end);
+
+        let mut cells = Vec::with_capacity(cols * rows);
+        let mut cursor_text = String::new();
+        let mut cursor_text_bold = false;
+        let mut cursor_text_italic = false;
+
+        for (row_idx, screen_row) in screen_rows.iter().enumerate() {
+            for (col_idx, cell) in screen_row.cells.iter().enumerate() {
+                if col_idx >= cols {
+                    break;
+                }
+
+                let mut fg = color_to_f32(cell.fg);
+                let mut bg = color_to_f32(cell.bg);
+
+                // Apply selection highlighting (swap fg/bg)
+                let stable_row = start + row_idx;
+                if let Some(ref sel) = selection {
+                    if sel.contains(col_idx, stable_row) {
+                        std::mem::swap(&mut fg, &mut bg);
+                        if bg == default_bg {
+                            fg = color_to_f32(palette.background);
+                            bg = color_to_f32(palette.foreground);
+                        }
+                    }
+                }
+
+                // Apply find/search highlighting
+                for (i, &(h_row, h_start, h_end)) in highlight_ranges.iter().enumerate() {
+                    if h_row == stable_row && col_idx >= h_start && col_idx < h_end {
+                        if current_highlight == Some(i) {
+                            bg = [1.0, 0.6, 0.0, 1.0];
+                            fg = [0.0, 0.0, 0.0, 1.0];
+                        } else {
+                            bg = [1.0, 1.0, 0.0, 0.7];
+                            fg = [0.0, 0.0, 0.0, 1.0];
+                        }
+                        break;
+                    }
+                }
+
+                // Capture text under cursor for block cursor rendering
+                if row_idx == cursor.y as usize
+                    && col_idx == cursor.x
+                    && !cell.text.is_empty()
+                    && cell.text != " "
+                {
+                    cursor_text = cell.text.clone();
+                    cursor_text_bold = cell.bold;
+                    cursor_text_italic = cell.italic;
+                }
+
+                cells.push(CellData {
+                    col: col_idx,
+                    row: row_idx,
+                    text: cell.text.clone(),
+                    fg,
+                    bg,
+                    bold: cell.bold,
+                    italic: cell.italic,
+                    hyperlink_url: cell.hyperlink_url.clone(),
+                });
+            }
+        }
+
+        // Dim background colors for unfocused panes.
+        let dim_factor = if is_focused { 1.0 } else { 0.6 };
+        let dimmed_bg = dim_color(default_bg, dim_factor);
+        if !is_focused {
+            for cell in &mut cells {
+                cell.bg = dim_color(cell.bg, dim_factor);
+            }
+        }
+
+        Self {
+            pane_id,
+            seqno,
+            cols,
+            rows,
+            cells,
+            cursor_x: cursor.x,
+            cursor_y: cursor.y,
+            cursor_visible: cursor.visible,
+            cursor_shape: cursor.shape,
+            default_bg: dimmed_bg,
+            cursor_bg,
+            cursor_fg,
+            is_focused,
+            scroll_offset,
+            cursor_text,
+            cursor_text_bold,
+            cursor_text_italic,
+            selection_range,
+            highlight_ranges,
+            current_highlight,
+            images: Vec::new(),
+            decoded_images: Vec::new(),
+        }
+    }
+
+    /// Extract a snapshot from the wezterm terminal screen.
+    ///
+    /// This is the legacy path that uses wezterm-specific types directly.
+    /// Includes Kitty image extraction.
     #[allow(clippy::too_many_arguments)]
     pub fn from_screen(
         screen: &wezterm_term::screen::Screen,
         palette: &ColorPalette,
-        cursor: &CursorPosition,
+        cursor: &CursorPos,
         cols: usize,
         rows: usize,
         scroll_offset: usize,
@@ -163,11 +299,9 @@ impl TerminalSnapshot {
                 for (i, &(h_row, h_start, h_end)) in highlight_ranges.iter().enumerate() {
                     if h_row == stable_row && col_idx >= h_start && col_idx < h_end {
                         if current_highlight == Some(i) {
-                            // Current match: bright orange bg
                             bg = SrgbaTuple(1.0, 0.6, 0.0, 1.0);
                             fg = SrgbaTuple(0.0, 0.0, 0.0, 1.0);
                         } else {
-                            // Other matches: yellow bg
                             bg = SrgbaTuple(1.0, 1.0, 0.0, 0.7);
                             fg = SrgbaTuple(0.0, 0.0, 0.0, 1.0);
                         }
@@ -240,7 +374,10 @@ impl TerminalSnapshot {
             cols,
             rows,
             cells,
-            cursor: *cursor,
+            cursor_x: cursor.x,
+            cursor_y: cursor.y,
+            cursor_visible: cursor.visible,
+            cursor_shape: cursor.shape,
             default_bg: dimmed_bg,
             cursor_bg,
             cursor_fg,

--- a/crates/amux-term/Cargo.toml
+++ b/crates/amux-term/Cargo.toml
@@ -22,5 +22,9 @@ anyhow = "1"
 thiserror = { workspace = true }
 libghostty-vt = { workspace = true, optional = true }
 
+[[example]]
+name = "ghostty_smoke"
+required-features = ["libghostty"]
+
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/crates/amux-term/Cargo.toml
+++ b/crates/amux-term/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 license.workspace = true
 description = "Terminal pane abstraction wrapping wezterm-term + portable-pty"
 
+[features]
+default = []
+libghostty = ["dep:libghostty-vt"]
+
 [dependencies]
 amux-core = { workspace = true }
 wezterm-term = { workspace = true }
@@ -16,6 +20,7 @@ cosmic-text = { workspace = true }
 tracing = { workspace = true }
 anyhow = "1"
 thiserror = { workspace = true }
+libghostty-vt = { workspace = true, optional = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/crates/amux-term/Cargo.toml
+++ b/crates/amux-term/Cargo.toml
@@ -8,6 +8,7 @@ description = "Terminal pane abstraction wrapping wezterm-term + portable-pty"
 [dependencies]
 amux-core = { workspace = true }
 wezterm-term = { workspace = true }
+wezterm-surface = { workspace = true }
 portable-pty = { workspace = true }
 winit = { workspace = true }
 url = { workspace = true }

--- a/crates/amux-term/Cargo.toml
+++ b/crates/amux-term/Cargo.toml
@@ -26,5 +26,9 @@ libghostty-vt = { workspace = true, optional = true }
 name = "ghostty_smoke"
 required-features = ["libghostty"]
 
+[[example]]
+name = "backend_compare"
+required-features = ["libghostty"]
+
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/crates/amux-term/examples/backend_compare.rs
+++ b/crates/amux-term/examples/backend_compare.rs
@@ -19,9 +19,8 @@ use portable_pty::CommandBuilder;
 fn run_backend(name: &str, pane: &mut dyn TerminalBackend) {
     // Let the shell run
     for _ in 0..30 {
-        match pane.advance() {
-            AdvanceResult::Eof => break,
-            _ => {}
+        if let AdvanceResult::Eof = pane.advance() {
+            break;
         }
         thread::sleep(Duration::from_millis(50));
     }
@@ -63,6 +62,25 @@ fn run_backend(name: &str, pane: &mut dyn TerminalBackend) {
             row.wrapped,
         );
     }
+
+    // Line-spec reading
+    let last2 = pane.read_screen_lines("-2", false);
+    println!("  read_screen_lines(\"-2\"):");
+    for line in last2.lines() {
+        println!("    {line:?}");
+    }
+
+    // Search
+    let hits = pane.search_scrollback("plain");
+    println!("  search_scrollback(\"plain\"): {hits:?}");
+
+    // Scrollback text
+    let scrollback = pane.read_scrollback_text(100);
+    println!(
+        "  read_scrollback_text(100): {} chars, {} lines",
+        scrollback.len(),
+        scrollback.lines().count()
+    );
 
     if let Some(exit) = pane.exit_status() {
         println!(

--- a/crates/amux-term/examples/backend_compare.rs
+++ b/crates/amux-term/examples/backend_compare.rs
@@ -1,0 +1,73 @@
+//! Side-by-side comparison: TerminalPane (wezterm) vs GhosttyPane (libghostty).
+//!
+//! Runs the same command through both backends and compares what the
+//! TerminalBackend trait reports. Validates the abstraction is sound.
+//!
+//! Run with:
+//!   cargo run -p amux-term --features libghostty --example backend_compare
+
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use amux_term::backend::TerminalBackend;
+use amux_term::config::AmuxTermConfig;
+use amux_term::ghostty_pane::GhosttyPane;
+use amux_term::pane::{AdvanceResult, TerminalPane};
+use portable_pty::CommandBuilder;
+
+fn run_backend(name: &str, pane: &mut dyn TerminalBackend) {
+    // Let the shell run
+    for _ in 0..30 {
+        match pane.advance() {
+            AdvanceResult::Eof => break,
+            _ => {}
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    println!("--- {name} ---");
+    println!("  Dimensions: {:?}", pane.dimensions());
+    println!("  Cursor: {:?}", pane.cursor());
+    println!("  Alt screen: {}", pane.is_alt_screen_active());
+    println!("  Bracketed paste: {}", pane.bracketed_paste_enabled());
+    println!("  Scrollback rows: {}", pane.scrollback_rows());
+    println!("  Alive: {}", pane.is_alive());
+
+    let text = pane.read_screen_text();
+    println!("  Screen text ({} chars):", text.len());
+    for line in text.lines() {
+        println!("    {line:?}");
+    }
+
+    if let Some(exit) = pane.exit_status() {
+        println!(
+            "  Exit: code={} success={}",
+            exit.exit_code(),
+            exit.success()
+        );
+    }
+    println!();
+}
+
+fn main() {
+    let script = "echo 'ALPHA'; echo 'BRAVO'; echo 'CHARLIE'; exit 0";
+
+    println!("=== Backend comparison ===");
+    println!("Command: bash -c {script:?}\n");
+
+    // --- wezterm-term backend ---
+    let mut cmd1 = CommandBuilder::new("bash");
+    cmd1.args(["--norc", "--noprofile", "-c", script]);
+    let config = Arc::new(AmuxTermConfig::default());
+    let mut wezterm_pane = TerminalPane::spawn(80, 24, cmd1, config).expect("wezterm spawn failed");
+    run_backend("wezterm-term (TerminalPane)", &mut wezterm_pane);
+
+    // --- libghostty-vt backend ---
+    let mut cmd2 = CommandBuilder::new("bash");
+    cmd2.args(["--norc", "--noprofile", "-c", script]);
+    let mut ghostty_pane = GhosttyPane::spawn(80, 24, cmd2).expect("ghostty spawn failed");
+    run_backend("libghostty-vt (GhosttyPane)", &mut ghostty_pane);
+
+    println!("=== Both backends exercised through TerminalBackend trait ===");
+}

--- a/crates/amux-term/examples/backend_compare.rs
+++ b/crates/amux-term/examples/backend_compare.rs
@@ -29,15 +29,39 @@ fn run_backend(name: &str, pane: &mut dyn TerminalBackend) {
     println!("--- {name} ---");
     println!("  Dimensions: {:?}", pane.dimensions());
     println!("  Cursor: {:?}", pane.cursor());
-    println!("  Alt screen: {}", pane.is_alt_screen_active());
-    println!("  Bracketed paste: {}", pane.bracketed_paste_enabled());
-    println!("  Scrollback rows: {}", pane.scrollback_rows());
     println!("  Alive: {}", pane.is_alive());
 
+    // Plain text
     let text = pane.read_screen_text();
     println!("  Screen text ({} chars):", text.len());
     for line in text.lines() {
         println!("    {line:?}");
+    }
+
+    // Cell-level access (what the GPU renderer uses)
+    let rows = pane.read_screen_cells(0);
+    let non_empty: Vec<_> = rows
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.cells.iter().any(|c| !c.text.is_empty() && c.text != " "))
+        .collect();
+    println!(
+        "  Screen cells: {} rows ({} non-empty)",
+        rows.len(),
+        non_empty.len()
+    );
+    for (i, row) in &non_empty {
+        let line_text: String = row.cells.iter().map(|c| c.text.as_str()).collect();
+        let has_bold = row.cells.iter().any(|c| c.bold);
+        let has_color = row
+            .cells
+            .iter()
+            .any(|c| c.fg.0 != 1.0 || c.fg.1 != 1.0 || c.fg.2 != 1.0);
+        println!(
+            "    row {i}: {:?} bold={has_bold} color={has_color} wrapped={}",
+            line_text.trim_end(),
+            row.wrapped,
+        );
     }
 
     if let Some(exit) = pane.exit_status() {
@@ -51,10 +75,16 @@ fn run_backend(name: &str, pane: &mut dyn TerminalBackend) {
 }
 
 fn main() {
-    let script = "echo 'ALPHA'; echo 'BRAVO'; echo 'CHARLIE'; exit 0";
+    // Use ANSI color codes to test attribute extraction
+    let script = concat!(
+        "printf '\\033[1mBOLD\\033[0m \\033[3mITALIC\\033[0m \\033[31mRED\\033[0m\\n'; ",
+        "printf 'plain text\\n'; ",
+        "printf '\\033[4munderlined\\033[0m\\n'; ",
+        "exit 0"
+    );
 
-    println!("=== Backend comparison ===");
-    println!("Command: bash -c {script:?}\n");
+    println!("=== Backend comparison (with attributes) ===");
+    println!("Command: bash -c <script with ANSI colors>\n");
 
     // --- wezterm-term backend ---
     let mut cmd1 = CommandBuilder::new("bash");

--- a/crates/amux-term/examples/ghostty_smoke.rs
+++ b/crates/amux-term/examples/ghostty_smoke.rs
@@ -1,7 +1,6 @@
 //! Smoke test for the GhosttyPane backend.
 //!
-//! Spawns a shell, sends `echo hello && exit`, reads output, and prints
-//! what the TerminalBackend trait reports.
+//! Spawns a shell, runs commands, and exercises the TerminalBackend trait.
 //!
 //! Run with:
 //!   cargo run -p amux-term --features libghostty --example ghostty_smoke
@@ -21,54 +20,55 @@ fn main() {
         "--norc",
         "--noprofile",
         "-c",
-        "echo 'hello from ghostty'; sleep 0.2; exit 42",
+        "echo 'hello from ghostty'; echo 'line two'; sleep 0.2; exit 42",
     ]);
 
     let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
     println!("Spawned. PID: {:?}", pane.child_pid());
     println!("Dimensions: {:?}", pane.dimensions());
-    println!("Title: {:?}", pane.title());
 
-    // Give the shell time to run
-    for i in 0..20 {
+    // Let the shell run
+    for _ in 0..20 {
         match pane.advance() {
-            amux_term::pane::AdvanceResult::Read(n) => {
-                println!("[tick {i}] Read {n} bytes");
-            }
+            amux_term::pane::AdvanceResult::Read(_) => {}
             amux_term::pane::AdvanceResult::WouldBlock => {}
-            amux_term::pane::AdvanceResult::Eof => {
-                println!("[tick {i}] EOF");
-                break;
-            }
+            amux_term::pane::AdvanceResult::Eof => break,
         }
         thread::sleep(Duration::from_millis(50));
     }
 
-    println!("\n--- State after run ---");
+    println!("\n--- Screen text ---");
+    let text = pane.read_screen_text();
+    if text.is_empty() {
+        println!("(empty)");
+    } else {
+        for (i, line) in text.lines().enumerate() {
+            println!("  {i}: {line:?}");
+        }
+    }
+
+    println!("\n--- State ---");
     println!("Title: {:?}", pane.title());
     println!("Cursor: {:?}", pane.cursor());
     println!("Alt screen: {}", pane.is_alt_screen_active());
     println!("Bracketed paste: {}", pane.bracketed_paste_enabled());
     println!("Scrollback rows: {}", pane.scrollback_rows());
     println!("Alive: {}", pane.is_alive());
-    println!("Seqno: {}", pane.current_seqno());
 
     let palette = pane.palette();
     println!(
-        "Palette fg: ({:.2}, {:.2}, {:.2})",
-        palette.foreground.0, palette.foreground.1, palette.foreground.2
+        "Palette: fg=({:.2},{:.2},{:.2}) bg=({:.2},{:.2},{:.2}) {} colors",
+        palette.foreground.0,
+        palette.foreground.1,
+        palette.foreground.2,
+        palette.background.0,
+        palette.background.1,
+        palette.background.2,
+        palette.colors.len()
     );
-    println!(
-        "Palette bg: ({:.2}, {:.2}, {:.2})",
-        palette.background.0, palette.background.1, palette.background.2
-    );
-    println!("Palette colors: {} entries", palette.colors.len());
 
     if let Some(exit) = pane.exit_status() {
-        println!("Exit code: {}", exit.exit_code());
-        println!("Success: {}", exit.success());
-    } else {
-        println!("(process still running)");
+        println!("Exit: code={} success={}", exit.exit_code(), exit.success());
     }
 
     println!("\n=== Done ===");

--- a/crates/amux-term/examples/ghostty_smoke.rs
+++ b/crates/amux-term/examples/ghostty_smoke.rs
@@ -1,0 +1,75 @@
+//! Smoke test for the GhosttyPane backend.
+//!
+//! Spawns a shell, sends `echo hello && exit`, reads output, and prints
+//! what the TerminalBackend trait reports.
+//!
+//! Run with:
+//!   cargo run -p amux-term --features libghostty --example ghostty_smoke
+
+use std::thread;
+use std::time::Duration;
+
+use amux_term::backend::TerminalBackend;
+use amux_term::ghostty_pane::GhosttyPane;
+use portable_pty::CommandBuilder;
+
+fn main() {
+    println!("=== GhosttyPane smoke test ===\n");
+
+    let mut cmd = CommandBuilder::new("bash");
+    cmd.args([
+        "--norc",
+        "--noprofile",
+        "-c",
+        "echo 'hello from ghostty'; sleep 0.2; exit 42",
+    ]);
+
+    let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
+    println!("Spawned. PID: {:?}", pane.child_pid());
+    println!("Dimensions: {:?}", pane.dimensions());
+    println!("Title: {:?}", pane.title());
+
+    // Give the shell time to run
+    for i in 0..20 {
+        match pane.advance() {
+            amux_term::pane::AdvanceResult::Read(n) => {
+                println!("[tick {i}] Read {n} bytes");
+            }
+            amux_term::pane::AdvanceResult::WouldBlock => {}
+            amux_term::pane::AdvanceResult::Eof => {
+                println!("[tick {i}] EOF");
+                break;
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    println!("\n--- State after run ---");
+    println!("Title: {:?}", pane.title());
+    println!("Cursor: {:?}", pane.cursor());
+    println!("Alt screen: {}", pane.is_alt_screen_active());
+    println!("Bracketed paste: {}", pane.bracketed_paste_enabled());
+    println!("Scrollback rows: {}", pane.scrollback_rows());
+    println!("Alive: {}", pane.is_alive());
+    println!("Seqno: {}", pane.current_seqno());
+
+    let palette = pane.palette();
+    println!(
+        "Palette fg: ({:.2}, {:.2}, {:.2})",
+        palette.foreground.0, palette.foreground.1, palette.foreground.2
+    );
+    println!(
+        "Palette bg: ({:.2}, {:.2}, {:.2})",
+        palette.background.0, palette.background.1, palette.background.2
+    );
+    println!("Palette colors: {} entries", palette.colors.len());
+
+    if let Some(exit) = pane.exit_status() {
+        println!("Exit code: {}", exit.exit_code());
+        println!("Success: {}", exit.success());
+    } else {
+        println!("(process still running)");
+    }
+
+    println!("\n=== Done ===");
+}

--- a/crates/amux-term/src/any_backend.rs
+++ b/crates/amux-term/src/any_backend.rs
@@ -1,0 +1,176 @@
+//! `AnyBackend` enum — runtime-switchable terminal backend.
+//!
+//! Uses an enum instead of `Box<dyn TerminalBackend>` to avoid lifetime
+//! gymnastics (GhosttyPane has lifetime params), Send divergence, and to
+//! allow pattern-matching for backend-specific features (e.g., Kitty images
+//! on wezterm).
+
+use std::io::Read;
+
+use url::Url;
+
+use crate::backend::{CursorPos, Palette, ProcessExit, ScreenRow, StableRow, TerminalBackend};
+#[cfg(feature = "libghostty")]
+use crate::ghostty_pane::GhosttyPane;
+use crate::osc::NotificationEvent;
+use crate::pane::{AdvanceResult, SequenceNo, TermError, TerminalPane};
+
+/// Runtime-selectable terminal backend.
+pub enum AnyBackend {
+    Wezterm(TerminalPane),
+    #[cfg(feature = "libghostty")]
+    Ghostty(GhosttyPane<'static, 'static>),
+}
+
+impl AnyBackend {
+    /// Returns a reference to the inner `TerminalPane` if this is a wezterm backend.
+    pub fn as_wezterm(&self) -> Option<&TerminalPane> {
+        match self {
+            Self::Wezterm(p) => Some(p),
+            #[cfg(feature = "libghostty")]
+            _ => None,
+        }
+    }
+
+    /// Returns a mutable reference to the inner `TerminalPane` if this is a wezterm backend.
+    pub fn as_wezterm_mut(&mut self) -> Option<&mut TerminalPane> {
+        match self {
+            Self::Wezterm(p) => Some(p),
+            #[cfg(feature = "libghostty")]
+            _ => None,
+        }
+    }
+}
+
+/// Delegate all `TerminalBackend` methods to the inner variant.
+macro_rules! delegate {
+    ($self:ident, $method:ident $(, $arg:ident : $ty:ty )* $(,)? ) => {
+        match $self {
+            AnyBackend::Wezterm(inner) => inner.$method( $( $arg ),* ),
+            #[cfg(feature = "libghostty")]
+            AnyBackend::Ghostty(inner) => inner.$method( $( $arg ),* ),
+        }
+    };
+}
+
+impl TerminalBackend for AnyBackend {
+    fn advance(&mut self) -> AdvanceResult {
+        delegate!(self, advance)
+    }
+
+    fn resize(&mut self, cols: u16, rows: u16) -> Result<(), TermError> {
+        delegate!(self, resize, cols: u16, rows: u16)
+    }
+
+    fn write_bytes(&mut self, data: &[u8]) -> Result<(), TermError> {
+        delegate!(self, write_bytes, data: &[u8])
+    }
+
+    fn feed_bytes(&mut self, data: &[u8]) {
+        delegate!(self, feed_bytes, data: &[u8])
+    }
+
+    fn take_reader(&mut self) -> Option<Box<dyn Read + Send>> {
+        delegate!(self, take_reader)
+    }
+
+    fn title(&self) -> &str {
+        delegate!(self, title)
+    }
+
+    fn working_dir(&self) -> Option<&Url> {
+        delegate!(self, working_dir)
+    }
+
+    fn dimensions(&self) -> (usize, usize) {
+        delegate!(self, dimensions)
+    }
+
+    fn cursor(&self) -> CursorPos {
+        delegate!(self, cursor)
+    }
+
+    fn palette(&self) -> Palette {
+        delegate!(self, palette)
+    }
+
+    fn is_alt_screen_active(&self) -> bool {
+        delegate!(self, is_alt_screen_active)
+    }
+
+    fn bracketed_paste_enabled(&self) -> bool {
+        delegate!(self, bracketed_paste_enabled)
+    }
+
+    fn child_pid(&self) -> Option<u32> {
+        delegate!(self, child_pid)
+    }
+
+    fn is_alive(&mut self) -> bool {
+        delegate!(self, is_alive)
+    }
+
+    fn exit_status(&mut self) -> Option<ProcessExit> {
+        delegate!(self, exit_status)
+    }
+
+    fn changed_lines(&self) -> Vec<StableRow> {
+        delegate!(self, changed_lines)
+    }
+
+    fn mark_rendered(&mut self) {
+        delegate!(self, mark_rendered)
+    }
+
+    fn current_seqno(&self) -> SequenceNo {
+        delegate!(self, current_seqno)
+    }
+
+    fn rendered_seqno(&self) -> SequenceNo {
+        delegate!(self, rendered_seqno)
+    }
+
+    fn scrollback_rows(&self) -> usize {
+        delegate!(self, scrollback_rows)
+    }
+
+    fn read_screen_lines(&self, line_spec: &str, ansi: bool) -> String {
+        delegate!(self, read_screen_lines, line_spec: &str, ansi: bool)
+    }
+
+    fn read_screen_text(&self) -> String {
+        delegate!(self, read_screen_text)
+    }
+
+    fn read_scrollback_text(&self, max_lines: usize) -> String {
+        delegate!(self, read_scrollback_text, max_lines: usize)
+    }
+
+    fn read_scrollback_text_range(&self, start: usize, end: usize) -> String {
+        delegate!(self, read_scrollback_text_range, start: usize, end: usize)
+    }
+
+    fn search_scrollback(&self, query: &str) -> Vec<(usize, usize, usize)> {
+        delegate!(self, search_scrollback, query: &str)
+    }
+
+    fn read_screen_cells(&self, scroll_offset: usize) -> Vec<ScreenRow> {
+        delegate!(self, read_screen_cells, scroll_offset: usize)
+    }
+
+    fn read_cells_range(&self, start_row: usize, end_row: usize) -> Vec<ScreenRow> {
+        delegate!(self, read_cells_range, start_row: usize, end_row: usize)
+    }
+
+    fn erase_scrollback(&mut self) {
+        delegate!(self, erase_scrollback)
+    }
+
+    fn focus_changed(&mut self, focused: bool) {
+        delegate!(self, focus_changed, focused: bool)
+    }
+
+    fn drain_notifications(&self) -> Vec<NotificationEvent> {
+        delegate!(self, drain_notifications)
+    }
+}

--- a/crates/amux-term/src/any_backend.rs
+++ b/crates/amux-term/src/any_backend.rs
@@ -16,10 +16,13 @@ use crate::osc::NotificationEvent;
 use crate::pane::{AdvanceResult, SequenceNo, TermError, TerminalPane};
 
 /// Runtime-selectable terminal backend.
+///
+/// Both variants are boxed to keep enum size small and avoid
+/// clippy::large_enum_variant.
 pub enum AnyBackend {
-    Wezterm(TerminalPane),
+    Wezterm(Box<TerminalPane>),
     #[cfg(feature = "libghostty")]
-    Ghostty(GhosttyPane<'static, 'static>),
+    Ghostty(Box<GhosttyPane<'static, 'static>>),
 }
 
 impl AnyBackend {

--- a/crates/amux-term/src/backend.rs
+++ b/crates/amux-term/src/backend.rs
@@ -300,6 +300,11 @@ pub trait TerminalBackend {
     /// Read an arbitrary range of physical rows as structured cells.
     /// `start_row` and `end_row` are 0-based physical row indices (end exclusive).
     /// Used for selection text extraction, hyperlink detection, etc.
+    ///
+    /// **Note:** Not all backends can access scrollback history. The ghostty
+    /// backend returns only viewport rows that overlap the requested range,
+    /// and returns empty for rows in scrollback history. Callers should
+    /// handle receiving fewer rows than requested.
     fn read_cells_range(&self, start_row: usize, end_row: usize) -> Vec<ScreenRow>;
 
     // --- Terminal control ---

--- a/crates/amux-term/src/backend.rs
+++ b/crates/amux-term/src/backend.rs
@@ -1,0 +1,119 @@
+use std::io::Read;
+
+use url::Url;
+use wezterm_term::color::ColorPalette;
+use wezterm_term::{CursorPosition, StableRowIndex};
+
+use crate::osc::NotificationEvent;
+use crate::pane::{AdvanceResult, SequenceNo, TermError};
+
+/// Trait abstracting the terminal backend (wezterm-term, libghostty, etc.).
+///
+/// Covers lifecycle, state queries, process management, change tracking,
+/// text reading, and terminal control. Does NOT include raw screen access
+/// (`screen()`) — that is backend-specific and accessed via the concrete type
+/// for GPU rendering and cell-level iteration.
+///
+/// Step 1 of the libghostty POC: the trait uses wezterm-term types (CursorPosition,
+/// ColorPalette, StableRowIndex). Step 2 will introduce amux-native equivalents.
+pub trait TerminalBackend {
+    // --- Lifecycle ---
+
+    /// Read available bytes from the PTY and feed them to the terminal.
+    fn advance(&mut self) -> AdvanceResult;
+
+    /// Resize the terminal and PTY.
+    fn resize(&mut self, cols: u16, rows: u16) -> Result<(), TermError>;
+
+    /// Write bytes to the PTY (simulate keyboard input).
+    fn write_bytes(&mut self, data: &[u8]) -> Result<(), TermError>;
+
+    /// Feed raw bytes directly into the terminal state machine.
+    fn feed_bytes(&mut self, data: &[u8]);
+
+    /// Take the PTY reader for use in a background thread.
+    /// After this, `advance()` returns `Eof`; use `feed_bytes()` instead.
+    fn take_reader(&mut self) -> Option<Box<dyn Read + Send>>;
+
+    // --- State queries ---
+
+    /// Window title (set by OSC 0/2).
+    fn title(&self) -> &str;
+
+    /// Working directory (set by OSC 7).
+    fn working_dir(&self) -> Option<&Url>;
+
+    /// Terminal dimensions as (cols, rows).
+    fn dimensions(&self) -> (usize, usize);
+
+    /// Current cursor position.
+    fn cursor(&self) -> CursorPosition;
+
+    /// Current color palette.
+    fn palette(&self) -> ColorPalette;
+
+    /// Whether the alternate screen buffer is active.
+    fn is_alt_screen_active(&self) -> bool;
+
+    /// Whether bracketed paste mode is enabled (DECSET 2004).
+    fn bracketed_paste_enabled(&self) -> bool;
+
+    // --- Process management ---
+
+    /// Child process ID, if available.
+    fn child_pid(&self) -> Option<u32>;
+
+    /// Whether the child process is still running.
+    fn is_alive(&mut self) -> bool;
+
+    /// Child exit status, if it has exited.
+    fn exit_status(&mut self) -> Option<portable_pty::ExitStatus>;
+
+    // --- Change tracking ---
+
+    /// Stable row indices of lines changed since last `mark_rendered()`.
+    fn changed_lines(&self) -> Vec<StableRowIndex>;
+
+    /// Mark the current state as rendered.
+    fn mark_rendered(&mut self);
+
+    /// Current sequence number.
+    fn current_seqno(&self) -> SequenceNo;
+
+    /// Last-rendered sequence number.
+    fn rendered_seqno(&self) -> SequenceNo;
+
+    // --- Text reading ---
+
+    /// Total rows in scrollback + visible screen.
+    fn scrollback_rows(&self) -> usize;
+
+    /// Read lines by spec: "1-50", "-20" (last 20), or "5" (single line).
+    fn read_screen_lines(&self, line_spec: &str, ansi: bool) -> String;
+
+    /// Read visible screen content as plain text.
+    fn read_screen_text(&self) -> String;
+
+    /// Read scrollback with ANSI formatting, up to `max_lines`.
+    fn read_scrollback_text(&self, max_lines: usize) -> String;
+
+    /// Read a range of physical rows with ANSI formatting.
+    fn read_scrollback_text_range(&self, start: usize, end: usize) -> String;
+
+    /// Search scrollback for case-insensitive matches.
+    /// Returns `(phys_row, start_col, end_col)` tuples.
+    fn search_scrollback(&self, query: &str) -> Vec<(usize, usize, usize)>;
+
+    // --- Terminal control ---
+
+    /// Erase scrollback buffer, keeping visible screen.
+    fn erase_scrollback(&mut self);
+
+    /// Notify terminal of focus change (DECSET 1004).
+    fn focus_changed(&mut self, focused: bool);
+
+    // --- Notifications ---
+
+    /// Drain pending notification events from the alert handler.
+    fn drain_notifications(&self) -> Vec<NotificationEvent>;
+}

--- a/crates/amux-term/src/backend.rs
+++ b/crates/amux-term/src/backend.rs
@@ -9,7 +9,7 @@ use crate::pane::{AdvanceResult, SequenceNo, TermError};
 // These replace wezterm-term/portable-pty types in the trait so backends
 // don't need to produce wezterm-specific types.
 
-/// RGBA color as linear f32 values in [0.0, 1.0].
+/// RGBA color as sRGB f32 values in [0.0, 1.0].
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Color(pub f32, pub f32, pub f32, pub f32);
 
@@ -71,14 +71,14 @@ impl Default for Palette {
 }
 
 /// Process exit status.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct ProcessExit {
     code: i32,
-    signal: Option<u32>,
+    signal: Option<String>,
 }
 
 impl ProcessExit {
-    pub fn new(code: i32, signal: Option<u32>) -> Self {
+    pub fn new(code: i32, signal: Option<String>) -> Self {
         Self { code, signal }
     }
 
@@ -92,9 +92,9 @@ impl ProcessExit {
         self.code
     }
 
-    /// Signal that killed the process, if any.
-    pub fn signal(&self) -> Option<u32> {
-        self.signal
+    /// Signal name that killed the process, if any (e.g. "SIGTERM").
+    pub fn signal(&self) -> Option<&str> {
+        self.signal.as_deref()
     }
 }
 
@@ -186,7 +186,7 @@ impl From<portable_pty::ExitStatus> for ProcessExit {
     fn from(s: portable_pty::ExitStatus) -> Self {
         Self {
             code: s.exit_code() as i32,
-            signal: s.signal().map(|_| 0), // portable-pty gives signal name, not number
+            signal: s.signal().map(|name| name.to_string()),
         }
     }
 }

--- a/crates/amux-term/src/backend.rs
+++ b/crates/amux-term/src/backend.rs
@@ -297,6 +297,11 @@ pub trait TerminalBackend {
     /// Returns rows in display order. Colors are palette-resolved.
     fn read_screen_cells(&self, scroll_offset: usize) -> Vec<ScreenRow>;
 
+    /// Read an arbitrary range of physical rows as structured cells.
+    /// `start_row` and `end_row` are 0-based physical row indices (end exclusive).
+    /// Used for selection text extraction, hyperlink detection, etc.
+    fn read_cells_range(&self, start_row: usize, end_row: usize) -> Vec<ScreenRow>;
+
     // --- Terminal control ---
 
     /// Erase scrollback buffer, keeping visible screen.

--- a/crates/amux-term/src/backend.rs
+++ b/crates/amux-term/src/backend.rs
@@ -1,11 +1,170 @@
 use std::io::Read;
 
 use url::Url;
-use wezterm_term::color::ColorPalette;
-use wezterm_term::{CursorPosition, StableRowIndex};
 
 use crate::osc::NotificationEvent;
 use crate::pane::{AdvanceResult, SequenceNo, TermError};
+
+// --- Amux-native types ---
+// These replace wezterm-term/portable-pty types in the trait so backends
+// don't need to produce wezterm-specific types.
+
+/// RGBA color as linear f32 values in [0.0, 1.0].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Color(pub f32, pub f32, pub f32, pub f32);
+
+impl Color {
+    pub const BLACK: Self = Self(0.0, 0.0, 0.0, 1.0);
+    pub const WHITE: Self = Self(1.0, 1.0, 1.0, 1.0);
+    pub const TRANSPARENT: Self = Self(0.0, 0.0, 0.0, 0.0);
+}
+
+/// Terminal cursor position.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CursorPos {
+    pub x: usize,
+    pub y: i64,
+    pub shape: CursorShape,
+    pub visible: bool,
+}
+
+/// Cursor rendering shape.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CursorShape {
+    #[default]
+    Default,
+    BlinkingBlock,
+    SteadyBlock,
+    BlinkingUnderline,
+    SteadyUnderline,
+    BlinkingBar,
+    SteadyBar,
+}
+
+/// Terminal color palette — the semantic colors a backend exposes.
+#[derive(Clone, Debug)]
+pub struct Palette {
+    pub foreground: Color,
+    pub background: Color,
+    pub cursor_fg: Color,
+    pub cursor_bg: Color,
+    pub cursor_border: Color,
+    pub selection_fg: Color,
+    pub selection_bg: Color,
+    /// 256-entry xterm color table (ANSI 0-15 + 216 cube + 24 grayscale).
+    pub colors: Vec<Color>,
+}
+
+impl Default for Palette {
+    fn default() -> Self {
+        Self {
+            foreground: Color::WHITE,
+            background: Color::BLACK,
+            cursor_fg: Color::BLACK,
+            cursor_bg: Color::WHITE,
+            cursor_border: Color::WHITE,
+            selection_fg: Color::BLACK,
+            selection_bg: Color(0.4, 0.6, 1.0, 1.0),
+            colors: Vec::new(),
+        }
+    }
+}
+
+/// Process exit status.
+#[derive(Clone, Copy, Debug)]
+pub struct ProcessExit {
+    code: i32,
+    signal: Option<u32>,
+}
+
+impl ProcessExit {
+    pub fn new(code: i32, signal: Option<u32>) -> Self {
+        Self { code, signal }
+    }
+
+    /// True if the process exited with code 0 and no signal.
+    pub fn success(&self) -> bool {
+        self.signal.is_none() && self.code == 0
+    }
+
+    /// Exit code (0 = success).
+    pub fn exit_code(&self) -> i32 {
+        self.code
+    }
+
+    /// Signal that killed the process, if any.
+    pub fn signal(&self) -> Option<u32> {
+        self.signal
+    }
+}
+
+/// Stable row index — identifies a row across scrollback changes.
+pub type StableRow = i64;
+
+// --- Conversions from wezterm-term / portable-pty types ---
+
+impl From<wezterm_term::color::SrgbaTuple> for Color {
+    fn from(c: wezterm_term::color::SrgbaTuple) -> Self {
+        Self(c.0, c.1, c.2, c.3)
+    }
+}
+
+impl From<Color> for wezterm_term::color::SrgbaTuple {
+    fn from(c: Color) -> Self {
+        Self(c.0, c.1, c.2, c.3)
+    }
+}
+
+impl From<wezterm_term::CursorPosition> for CursorPos {
+    fn from(c: wezterm_term::CursorPosition) -> Self {
+        Self {
+            x: c.x,
+            y: c.y,
+            shape: c.shape.into(),
+            visible: c.visibility == wezterm_surface::CursorVisibility::Visible,
+        }
+    }
+}
+
+impl From<wezterm_surface::CursorShape> for CursorShape {
+    fn from(s: wezterm_surface::CursorShape) -> Self {
+        match s {
+            wezterm_surface::CursorShape::Default => Self::Default,
+            wezterm_surface::CursorShape::BlinkingBlock => Self::BlinkingBlock,
+            wezterm_surface::CursorShape::SteadyBlock => Self::SteadyBlock,
+            wezterm_surface::CursorShape::BlinkingUnderline => Self::BlinkingUnderline,
+            wezterm_surface::CursorShape::SteadyUnderline => Self::SteadyUnderline,
+            wezterm_surface::CursorShape::BlinkingBar => Self::BlinkingBar,
+            wezterm_surface::CursorShape::SteadyBar => Self::SteadyBar,
+        }
+    }
+}
+
+impl From<wezterm_term::color::ColorPalette> for Palette {
+    fn from(p: wezterm_term::color::ColorPalette) -> Self {
+        Self {
+            foreground: p.foreground.into(),
+            background: p.background.into(),
+            cursor_fg: p.cursor_fg.into(),
+            cursor_bg: p.cursor_bg.into(),
+            cursor_border: p.cursor_border.into(),
+            selection_fg: p.selection_fg.into(),
+            selection_bg: p.selection_bg.into(),
+            colors: p.colors.0.iter().map(|&c| Color::from(c)).collect(),
+        }
+    }
+}
+
+impl From<portable_pty::ExitStatus> for ProcessExit {
+    fn from(s: portable_pty::ExitStatus) -> Self {
+        Self {
+            code: if s.success() { 0 } else { 1 },
+            signal: None,
+        }
+    }
+}
+
+// --- The trait ---
 
 /// Trait abstracting the terminal backend (wezterm-term, libghostty, etc.).
 ///
@@ -14,8 +173,8 @@ use crate::pane::{AdvanceResult, SequenceNo, TermError};
 /// (`screen()`) — that is backend-specific and accessed via the concrete type
 /// for GPU rendering and cell-level iteration.
 ///
-/// Step 1 of the libghostty POC: the trait uses wezterm-term types (CursorPosition,
-/// ColorPalette, StableRowIndex). Step 2 will introduce amux-native equivalents.
+/// Uses amux-native types (CursorPos, Palette, etc.) so backends don't need
+/// to produce wezterm-specific types.
 pub trait TerminalBackend {
     // --- Lifecycle ---
 
@@ -46,11 +205,11 @@ pub trait TerminalBackend {
     /// Terminal dimensions as (cols, rows).
     fn dimensions(&self) -> (usize, usize);
 
-    /// Current cursor position.
-    fn cursor(&self) -> CursorPosition;
+    /// Current cursor position, shape, and visibility.
+    fn cursor(&self) -> CursorPos;
 
     /// Current color palette.
-    fn palette(&self) -> ColorPalette;
+    fn palette(&self) -> Palette;
 
     /// Whether the alternate screen buffer is active.
     fn is_alt_screen_active(&self) -> bool;
@@ -67,12 +226,12 @@ pub trait TerminalBackend {
     fn is_alive(&mut self) -> bool;
 
     /// Child exit status, if it has exited.
-    fn exit_status(&mut self) -> Option<portable_pty::ExitStatus>;
+    fn exit_status(&mut self) -> Option<ProcessExit>;
 
     // --- Change tracking ---
 
     /// Stable row indices of lines changed since last `mark_rendered()`.
-    fn changed_lines(&self) -> Vec<StableRowIndex>;
+    fn changed_lines(&self) -> Vec<StableRow>;
 
     /// Mark the current state as rendered.
     fn mark_rendered(&mut self);

--- a/crates/amux-term/src/backend.rs
+++ b/crates/amux-term/src/backend.rs
@@ -158,8 +158,8 @@ impl From<wezterm_term::color::ColorPalette> for Palette {
 impl From<portable_pty::ExitStatus> for ProcessExit {
     fn from(s: portable_pty::ExitStatus) -> Self {
         Self {
-            code: if s.success() { 0 } else { 1 },
-            signal: None,
+            code: s.exit_code() as i32,
+            signal: s.signal().map(|_| 0), // portable-pty gives signal name, not number
         }
     }
 }

--- a/crates/amux-term/src/backend.rs
+++ b/crates/amux-term/src/backend.rs
@@ -101,6 +101,33 @@ impl ProcessExit {
 /// Stable row index — identifies a row across scrollback changes.
 pub type StableRow = i64;
 
+// --- Screen cell types for rendering ---
+
+/// A single cell's data, backend-agnostic.
+#[derive(Clone, Debug)]
+pub struct ScreenCell {
+    /// Grapheme cluster (usually one char, can be multi-codepoint).
+    pub text: String,
+    /// Resolved foreground color (already palette-resolved).
+    pub fg: Color,
+    /// Resolved background color.
+    pub bg: Color,
+    pub bold: bool,
+    pub italic: bool,
+    pub underline: bool,
+    pub strikethrough: bool,
+    pub reverse: bool,
+    pub hyperlink_url: Option<String>,
+}
+
+/// A row of cells for rendering.
+#[derive(Clone, Debug)]
+pub struct ScreenRow {
+    pub cells: Vec<ScreenCell>,
+    /// Whether this line wraps to the next.
+    pub wrapped: bool,
+}
+
 // --- Conversions from wezterm-term / portable-pty types ---
 
 impl From<wezterm_term::color::SrgbaTuple> for Color {
@@ -262,6 +289,13 @@ pub trait TerminalBackend {
     /// Search scrollback for case-insensitive matches.
     /// Returns `(phys_row, start_col, end_col)` tuples.
     fn search_scrollback(&self, query: &str) -> Vec<(usize, usize, usize)>;
+
+    // --- Cell-level screen access (for rendering) ---
+
+    /// Read visible screen as structured rows/cells with resolved colors.
+    /// `scroll_offset` is lines scrolled back from the bottom (0 = latest).
+    /// Returns rows in display order. Colors are palette-resolved.
+    fn read_screen_cells(&self, scroll_offset: usize) -> Vec<ScreenRow>;
 
     // --- Terminal control ---
 

--- a/crates/amux-term/src/config.rs
+++ b/crates/amux-term/src/config.rs
@@ -15,6 +15,8 @@ pub struct AmuxTermConfig {
     pub scrollback_lines: usize,
     pub color_palette: ColorPalette,
     pub enable_kitty_keyboard: bool,
+    /// Terminal backend engine: "wezterm" (default) or "ghostty".
+    pub backend: String,
 }
 
 /// Build a color palette using standard xterm ANSI colors (0-15).
@@ -64,6 +66,7 @@ impl Default for AmuxTermConfig {
             scrollback_lines: 10_000,
             color_palette: default_palette(),
             enable_kitty_keyboard: true,
+            backend: "wezterm".to_owned(),
         }
     }
 }

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -11,7 +11,7 @@ use std::sync::{mpsc, Arc, Mutex};
 
 use libghostty_vt::render::{CellIterator, CursorVisualStyle, Dirty, RenderState, RowIterator};
 use libghostty_vt::style::RgbColor;
-use libghostty_vt::terminal::{Mode, Options as TerminalOptions, Terminal};
+use libghostty_vt::terminal::{Mode, Options as TerminalOptions, Point, PointCoordinate, Terminal};
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use url::Url;
 
@@ -95,10 +95,27 @@ where
             })
             .map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("{e}")))?;
 
+        // Register bell callback for notifications.
+        let (tx, rx) = mpsc::channel();
+        let bell_tx = tx.clone();
+        terminal
+            .on_bell(move |_term| {
+                let _ = bell_tx.send(NotificationEvent::Bell);
+            })
+            .map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("{e}")))?;
+
+        // Register title change callback.
+        let title_tx = tx;
+        terminal
+            .on_title_changed(move |term| {
+                if let Ok(title) = term.title() {
+                    let _ = title_tx.send(NotificationEvent::TitleChanged(title.to_string()));
+                }
+            })
+            .map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("{e}")))?;
+
         let render_state =
             RenderState::new().map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("{e}")))?;
-
-        let (_tx, rx) = mpsc::channel();
 
         Ok(Self {
             terminal,
@@ -152,6 +169,44 @@ where
                     .or_else(|| Url::parse(&format!("file://{pwd}")).ok());
             }
         }
+    }
+
+    /// Read a single row of text via grid_ref point queries.
+    /// Returns the text content of the row, trimmed at the right.
+    fn read_row_text(&self, row: u32, cols: u16) -> String {
+        let mut line = String::new();
+        let mut char_buf = ['\0'; 16];
+        for col in 0..cols {
+            let coord: PointCoordinate =
+                libghostty_vt::ffi::GhosttyPointCoordinate { x: col, y: row }.into();
+            if let Ok(grid_ref) = self.terminal.grid_ref(Point::Screen(coord)) {
+                if let Ok(n) = grid_ref.graphemes(&mut char_buf) {
+                    for &ch in &char_buf[..n] {
+                        line.push(ch);
+                    }
+                } else {
+                    line.push(' ');
+                }
+            } else {
+                line.push(' ');
+            }
+        }
+        line.trim_end().to_string()
+    }
+
+    /// Read a range of rows as text lines using grid_ref.
+    /// `start` and `end` are 0-based row indices (end exclusive).
+    fn read_rows_text(&self, start: u32, end: u32) -> String {
+        let cols = self.terminal.cols().unwrap_or(80);
+        let mut lines = Vec::new();
+        for row in start..end {
+            lines.push(self.read_row_text(row, cols));
+        }
+        // Trim trailing empty lines
+        while lines.last().is_some_and(|l| l.is_empty()) {
+            lines.pop();
+        }
+        lines.join("\n")
     }
 
     /// Read screen text using the render state snapshot iterators.
@@ -335,28 +390,106 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         self.terminal.total_rows().unwrap_or(0)
     }
 
-    fn read_screen_lines(&self, _line_spec: &str, _ansi: bool) -> String {
-        // TODO: parse line_spec and handle ANSI formatting.
-        // For now, return visible screen text.
-        self.read_text_from_snapshot()
+    fn read_screen_lines(&self, line_spec: &str, _ansi: bool) -> String {
+        // ANSI formatting not yet supported — returns plain text regardless.
+        let total = self.terminal.total_rows().unwrap_or(0) as u32;
+        if total == 0 {
+            return String::new();
+        }
+
+        let (start, end) = if let Some(rest) = line_spec.strip_prefix('-') {
+            // "-N" means last N lines
+            let n: u32 = rest.parse().unwrap_or(total);
+            (total.saturating_sub(n), total)
+        } else if let Some((a, b)) = line_spec.split_once('-') {
+            // "A-B" means lines A through B (1-based)
+            let a: u32 = a.parse().unwrap_or(1);
+            let b: u32 = b.parse().unwrap_or(total);
+            let s = a.saturating_sub(1).min(total);
+            let e = b.min(total);
+            if s >= e {
+                (0, 0)
+            } else {
+                (s, e)
+            }
+        } else {
+            // Single line number (1-based)
+            let n: u32 = line_spec.parse().unwrap_or(1);
+            let idx = n.saturating_sub(1).min(total.saturating_sub(1));
+            (idx, (idx + 1).min(total))
+        };
+
+        self.read_rows_text(start, end)
     }
 
     fn read_screen_text(&self) -> String {
         self.read_text_from_snapshot()
     }
 
-    fn read_scrollback_text(&self, _max_lines: usize) -> String {
-        // libghostty's RenderState iterates the viewport, not full scrollback.
-        // For scrollback, we'd use terminal.grid_ref() point-by-point.
-        self.read_text_from_snapshot()
+    fn read_scrollback_text(&self, max_lines: usize) -> String {
+        let total = self.terminal.total_rows().unwrap_or(0) as u32;
+        let start = total.saturating_sub(max_lines as u32);
+        self.read_rows_text(start, total)
     }
 
-    fn read_scrollback_text_range(&self, _start: usize, _end: usize) -> String {
-        String::new()
+    fn read_scrollback_text_range(&self, start: usize, end: usize) -> String {
+        self.read_rows_text(start as u32, end as u32)
     }
 
-    fn search_scrollback(&self, _query: &str) -> Vec<(usize, usize, usize)> {
-        Vec::new()
+    fn search_scrollback(&self, query: &str) -> Vec<(usize, usize, usize)> {
+        if query.is_empty() {
+            return Vec::new();
+        }
+        let query_lower = query.to_lowercase();
+        let cols = self.terminal.cols().unwrap_or(80);
+        let total = self.terminal.total_rows().unwrap_or(0) as u32;
+
+        let mut matches = Vec::new();
+        let mut char_buf = ['\0'; 16];
+
+        for row in 0..total {
+            let mut line_text = String::new();
+            let mut col_offsets: Vec<usize> = Vec::new();
+
+            for col in 0..cols {
+                let coord: PointCoordinate =
+                    libghostty_vt::ffi::GhosttyPointCoordinate { x: col, y: row }.into();
+                if let Ok(grid_ref) = self.terminal.grid_ref(Point::Screen(coord)) {
+                    if let Ok(n) = grid_ref.graphemes(&mut char_buf) {
+                        for &ch in &char_buf[..n] {
+                            let mut buf = [0u8; 4];
+                            let s = ch.encode_utf8(&mut buf);
+                            for _ in s.bytes() {
+                                col_offsets.push(col as usize);
+                            }
+                            line_text.push(ch);
+                        }
+                    } else {
+                        col_offsets.push(col as usize);
+                        line_text.push(' ');
+                    }
+                } else {
+                    col_offsets.push(col as usize);
+                    line_text.push(' ');
+                }
+            }
+
+            let line_lower = line_text.to_lowercase();
+            let mut search_start = 0;
+            while let Some(byte_pos) = line_lower[search_start..].find(&query_lower) {
+                let abs_pos = search_start + byte_pos;
+                let end_pos = abs_pos + query_lower.len();
+                let start_col = col_offsets.get(abs_pos).copied().unwrap_or(0);
+                let end_col = col_offsets
+                    .get(end_pos.saturating_sub(1))
+                    .copied()
+                    .unwrap_or(start_col)
+                    + 1;
+                matches.push((row as usize, start_col, end_col));
+                search_start = abs_pos + 1;
+            }
+        }
+        matches
     }
 
     fn read_screen_cells(&self, _scroll_offset: usize) -> Vec<ScreenRow> {

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -5,10 +5,11 @@
 //!
 //! Enabled with `--features libghostty`.
 
+use std::cell::RefCell;
 use std::io::{Read, Write};
 use std::sync::{mpsc, Arc, Mutex};
 
-use libghostty_vt::render::{Dirty, RenderState};
+use libghostty_vt::render::{CellIterator, CursorVisualStyle, Dirty, RenderState, RowIterator};
 use libghostty_vt::style::RgbColor;
 use libghostty_vt::terminal::{Mode, Options as TerminalOptions, Terminal};
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
@@ -23,9 +24,11 @@ use crate::pane::{AdvanceResult, SequenceNo, TermError};
 /// A terminal pane backed by libghostty-vt + portable-pty.
 ///
 /// libghostty-vt is !Send + !Sync, so this must stay on one thread.
+/// `RenderState` is behind `RefCell` for interior mutability — the trait's
+/// `&self` methods need to take snapshots for screen reading.
 pub struct GhosttyPane<'alloc, 'cb> {
     terminal: Terminal<'alloc, 'cb>,
-    render_state: RenderState<'alloc>,
+    render_state: RefCell<RenderState<'alloc>>,
     #[allow(dead_code)]
     master: Box<dyn MasterPty + Send>,
     child: Box<dyn Child + Send + Sync>,
@@ -36,8 +39,10 @@ pub struct GhosttyPane<'alloc, 'cb> {
     notification_rx: mpsc::Receiver<NotificationEvent>,
     /// Cached palette from last render state update.
     cached_palette: Palette,
-    /// Cached cursor from last render state update.
+    /// Cached cursor shape from last render state update.
     cached_cursor_shape: CursorShape,
+    /// Cached working directory URL (from OSC 7 via pwd()).
+    cached_working_dir: Option<Url>,
 }
 
 impl<'alloc, 'cb> GhosttyPane<'alloc, 'cb>
@@ -96,7 +101,7 @@ where
 
         Ok(Self {
             terminal,
-            render_state,
+            render_state: RefCell::new(render_state),
             master: pair.master,
             child,
             reader: Some(reader),
@@ -106,13 +111,15 @@ where
             notification_rx: rx,
             cached_palette: Palette::default(),
             cached_cursor_shape: CursorShape::Default,
+            cached_working_dir: None,
         })
     }
 
-    /// Refresh cached render state (palette, cursor shape).
+    /// Refresh cached render state (palette, cursor shape, working dir).
     /// Called after vt_write to keep caches warm.
     fn refresh_render_cache(&mut self) {
-        if let Ok(snapshot) = self.render_state.update(&self.terminal) {
+        let mut rs = self.render_state.borrow_mut();
+        if let Ok(snapshot) = rs.update(&self.terminal) {
             // Cache palette
             if let Ok(colors) = snapshot.colors() {
                 let fg = rgb_to_color(colors.foreground);
@@ -132,16 +139,62 @@ where
 
             // Cache cursor shape
             if let Ok(style) = snapshot.cursor_visual_style() {
-                use libghostty_vt::render::CursorVisualStyle;
-                self.cached_cursor_shape = match style {
-                    CursorVisualStyle::Bar => CursorShape::SteadyBar,
-                    CursorVisualStyle::Block => CursorShape::SteadyBlock,
-                    CursorVisualStyle::Underline => CursorShape::SteadyUnderline,
-                    CursorVisualStyle::BlockHollow => CursorShape::SteadyBlock,
-                    _ => CursorShape::Default,
-                };
+                self.cached_cursor_shape = cursor_style_to_shape(style);
             }
         }
+
+        // Cache working directory from OSC 7
+        if let Ok(pwd) = self.terminal.pwd() {
+            if !pwd.is_empty() {
+                self.cached_working_dir = Url::parse(pwd)
+                    .ok()
+                    .or_else(|| Url::parse(&format!("file://{pwd}")).ok());
+            }
+        }
+    }
+
+    /// Read screen text using the render state snapshot iterators.
+    /// Takes &self via RefCell interior mutability.
+    fn read_text_from_snapshot(&self) -> String {
+        let mut rs = self.render_state.borrow_mut();
+        let snapshot = match rs.update(&self.terminal) {
+            Ok(s) => s,
+            Err(_) => return String::new(),
+        };
+
+        let mut row_iter = match RowIterator::new() {
+            Ok(r) => r,
+            Err(_) => return String::new(),
+        };
+        let mut cell_iter = match CellIterator::new() {
+            Ok(c) => c,
+            Err(_) => return String::new(),
+        };
+        let mut row_iteration = match row_iter.update(&snapshot) {
+            Ok(r) => r,
+            Err(_) => return String::new(),
+        };
+
+        let mut lines = Vec::new();
+        while let Some(row) = row_iteration.next() {
+            let mut line = String::new();
+            if let Ok(mut cell_iteration) = cell_iter.update(row) {
+                while let Some(cell) = cell_iteration.next() {
+                    if let Ok(chars) = cell.graphemes() {
+                        for ch in chars {
+                            line.push(ch);
+                        }
+                    }
+                }
+            }
+            lines.push(line.trim_end().to_string());
+        }
+
+        // Trim trailing empty lines
+        while lines.last().is_some_and(|l| l.is_empty()) {
+            lines.pop();
+        }
+        lines.join("\n")
     }
 }
 
@@ -203,9 +256,7 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
     }
 
     fn working_dir(&self) -> Option<&Url> {
-        // libghostty returns &str from pwd(). We'd need a cached Url field
-        // updated via an on_osc7 callback. For the POC, return None.
-        None
+        self.cached_working_dir.as_ref()
     }
 
     fn dimensions(&self) -> (usize, usize) {
@@ -255,8 +306,6 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
     }
 
     fn changed_lines(&self) -> Vec<StableRow> {
-        // libghostty tracks dirty rows via RenderState. For the POC,
-        // report all visible rows when seqno has advanced.
         if self.seqno > self.rendered_seqno {
             let rows = self.terminal.rows().unwrap_or(24) as i64;
             (0..rows).collect()
@@ -267,8 +316,8 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
 
     fn mark_rendered(&mut self) {
         self.rendered_seqno = self.seqno;
-        // Reset dirty tracking
-        if let Ok(snapshot) = self.render_state.update(&self.terminal) {
+        let mut rs = self.render_state.borrow_mut();
+        if let Ok(snapshot) = rs.update(&self.terminal) {
             let _ = snapshot.set_dirty(Dirty::Clean);
         }
     }
@@ -286,20 +335,19 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
     }
 
     fn read_screen_lines(&self, _line_spec: &str, _ansi: bool) -> String {
-        // POC: full implementation would parse line_spec and iterate scrollback.
-        // For now, return empty — the IPC layer will get basic functionality.
-        String::new()
+        // TODO: parse line_spec and handle ANSI formatting.
+        // For now, return visible screen text.
+        self.read_text_from_snapshot()
     }
 
     fn read_screen_text(&self) -> String {
-        // This needs &mut self for render_state.update(), but the trait requires &self.
-        // POC limitation: return empty. A full implementation would maintain a cached
-        // screen text updated in advance()/feed_bytes().
-        String::new()
+        self.read_text_from_snapshot()
     }
 
     fn read_scrollback_text(&self, _max_lines: usize) -> String {
-        String::new()
+        // libghostty's RenderState iterates the viewport, not full scrollback.
+        // For scrollback, we'd use terminal.grid_ref() point-by-point.
+        self.read_text_from_snapshot()
     }
 
     fn read_scrollback_text_range(&self, _start: usize, _end: usize) -> String {
@@ -342,4 +390,14 @@ fn rgb_to_color(rgb: RgbColor) -> Color {
         rgb.b as f32 / 255.0,
         1.0,
     )
+}
+
+fn cursor_style_to_shape(style: CursorVisualStyle) -> CursorShape {
+    match style {
+        CursorVisualStyle::Bar => CursorShape::SteadyBar,
+        CursorVisualStyle::Block => CursorShape::SteadyBlock,
+        CursorVisualStyle::Underline => CursorShape::SteadyUnderline,
+        CursorVisualStyle::BlockHollow => CursorShape::SteadyBlock,
+        _ => CursorShape::Default,
+    }
 }

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -16,7 +16,8 @@ use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize}
 use url::Url;
 
 use crate::backend::{
-    Color, CursorPos, CursorShape, Palette, ProcessExit, StableRow, TerminalBackend,
+    Color, CursorPos, CursorShape, Palette, ProcessExit, ScreenCell, ScreenRow, StableRow,
+    TerminalBackend,
 };
 use crate::osc::NotificationEvent;
 use crate::pane::{AdvanceResult, SequenceNo, TermError};
@@ -356,6 +357,85 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
 
     fn search_scrollback(&self, _query: &str) -> Vec<(usize, usize, usize)> {
         Vec::new()
+    }
+
+    fn read_screen_cells(&self, _scroll_offset: usize) -> Vec<ScreenRow> {
+        let mut rs = self.render_state.borrow_mut();
+        let snapshot = match rs.update(&self.terminal) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+
+        let palette = self.cached_palette.clone();
+        let default_fg = palette.foreground;
+        let default_bg = palette.background;
+
+        let mut row_iter = match RowIterator::new() {
+            Ok(r) => r,
+            Err(_) => return Vec::new(),
+        };
+        let mut cell_iter = match CellIterator::new() {
+            Ok(c) => c,
+            Err(_) => return Vec::new(),
+        };
+        let mut row_iteration = match row_iter.update(&snapshot) {
+            Ok(r) => r,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut rows = Vec::new();
+        while let Some(row) = row_iteration.next() {
+            let wrapped = row
+                .raw_row()
+                .map(|r| r.is_wrapped().unwrap_or(false))
+                .unwrap_or(false);
+            let mut cells = Vec::new();
+            if let Ok(mut cell_iteration) = cell_iter.update(row) {
+                while let Some(cell) = cell_iteration.next() {
+                    let text = cell
+                        .graphemes()
+                        .map(|chars| chars.into_iter().collect::<String>())
+                        .unwrap_or_default();
+
+                    let fg = cell
+                        .fg_color()
+                        .ok()
+                        .flatten()
+                        .map(rgb_to_color)
+                        .unwrap_or(default_fg);
+                    let bg = cell
+                        .bg_color()
+                        .ok()
+                        .flatten()
+                        .map(rgb_to_color)
+                        .unwrap_or(default_bg);
+
+                    let style = cell.style().ok();
+                    let bold = style.as_ref().map(|s| s.bold).unwrap_or(false);
+                    let italic = style.as_ref().map(|s| s.italic).unwrap_or(false);
+                    let underline = style
+                        .as_ref()
+                        .map(|s| !matches!(s.underline, libghostty_vt::style::Underline::None))
+                        .unwrap_or(false);
+                    let strikethrough = style.as_ref().map(|s| s.strikethrough).unwrap_or(false);
+                    let inverse = style.as_ref().map(|s| s.inverse).unwrap_or(false);
+
+                    cells.push(ScreenCell {
+                        text,
+                        fg,
+                        bg,
+                        bold,
+                        italic,
+                        underline,
+                        strikethrough,
+                        reverse: inverse,
+                        hyperlink_url: None,
+                    });
+                }
+            }
+            rows.push(ScreenRow { cells, wrapped });
+        }
+        rows
     }
 
     fn erase_scrollback(&mut self) {

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -402,9 +402,16 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
     }
 
     fn read_scrollback_text(&self, max_lines: usize) -> String {
-        // Currently limited to viewport via render state.
-        // Full scrollback would require grid_ref iteration.
+        // libghostty-vt 0.1.x only exposes viewport via render state.
+        // PointCoordinate fields are private, so grid_ref can't reach scrollback.
         let lines = self.snapshot_lines();
+        if max_lines > lines.len() {
+            tracing::warn!(
+                "read_scrollback_text({max_lines}) requested but only {} viewport lines available \
+                 (ghostty backend cannot read scrollback history)",
+                lines.len()
+            );
+        }
         let total = lines.len();
         let start = total.saturating_sub(max_lines);
         let mut selected: Vec<&str> = lines[start..].iter().map(|s| s.as_str()).collect();
@@ -415,10 +422,23 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
     }
 
     fn read_scrollback_text_range(&self, start: usize, end: usize) -> String {
-        // Currently limited to viewport via render state.
+        // libghostty-vt 0.1.x only exposes viewport via render state.
         let lines = self.snapshot_lines();
-        let s = start.min(lines.len());
-        let e = end.min(lines.len());
+        let viewport_total = self.terminal.total_rows().unwrap_or(0);
+        let viewport_rows = lines.len();
+        let viewport_start = viewport_total.saturating_sub(viewport_rows);
+
+        if start < viewport_start || end > viewport_total {
+            tracing::warn!(
+                "read_scrollback_text_range({start}..{end}) extends beyond viewport \
+                 ({viewport_start}..{viewport_total}), results may be incomplete \
+                 (ghostty backend cannot read scrollback history)"
+            );
+        }
+
+        // Map physical row range to viewport-relative indices.
+        let s = start.saturating_sub(viewport_start).min(viewport_rows);
+        let e = end.saturating_sub(viewport_start).min(viewport_rows);
         if s >= e {
             return String::new();
         }
@@ -436,17 +456,25 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         let query_lower = query.to_lowercase();
         let lines = self.snapshot_lines();
 
+        // Map physical row indices to account for viewport offset.
+        let total = self.terminal.total_rows().unwrap_or(0);
+        let viewport_rows = lines.len();
+        let viewport_start = total.saturating_sub(viewport_rows);
+
         let mut matches = Vec::new();
-        for (phys_row, line) in lines.iter().enumerate() {
+        for (viewport_idx, line) in lines.iter().enumerate() {
             let line_lower = line.to_lowercase();
             let mut search_start = 0;
             while let Some(byte_pos) = line_lower[search_start..].find(&query_lower) {
-                let abs_pos = search_start + byte_pos;
-                let end_pos = abs_pos + query_lower.len();
-                // For ASCII text, byte offset ≈ column. For multi-byte,
-                // this is approximate but correct for the common case.
-                matches.push((phys_row, abs_pos, end_pos));
-                search_start = abs_pos + 1;
+                let abs_byte = search_start + byte_pos;
+                let end_byte = abs_byte + query_lower.len();
+                // Convert byte offsets to character (column) offsets for
+                // correct highlighting with multi-byte UTF-8 content.
+                let start_col = line_lower[..abs_byte].chars().count();
+                let match_chars = line_lower[abs_byte..end_byte].chars().count();
+                let phys_row = viewport_start + viewport_idx;
+                matches.push((phys_row, start_col, start_col + match_chars));
+                search_start = abs_byte + 1;
             }
         }
         matches
@@ -531,15 +559,40 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         rows
     }
 
-    fn read_cells_range(&self, _start_row: usize, _end_row: usize) -> Vec<ScreenRow> {
-        // libghostty render state only exposes the viewport.
-        // For arbitrary row ranges, we'd need grid_ref iteration.
-        // Return viewport cells as a best-effort approximation.
-        self.read_screen_cells(0)
+    fn read_cells_range(&self, start_row: usize, end_row: usize) -> Vec<ScreenRow> {
+        // libghostty-vt's render state only exposes the viewport. grid_ref
+        // supports arbitrary Screen coordinates but PointCoordinate fields
+        // are private in 0.1.x, so we can't use it.
+        // Return the viewport rows that overlap the requested range.
+        let total = self.terminal.total_rows().unwrap_or(0);
+        let viewport_rows = self.terminal.rows().unwrap_or(24) as usize;
+        let viewport_start = total.saturating_sub(viewport_rows);
+        let viewport_end = total;
+
+        // No overlap — requested range is entirely in scrollback history.
+        if end_row <= viewport_start || start_row >= viewport_end {
+            tracing::debug!(
+                "read_cells_range({start_row}..{end_row}) outside viewport \
+                 ({viewport_start}..{viewport_end}), returning empty"
+            );
+            return Vec::new();
+        }
+
+        let all_rows = self.read_screen_cells(0);
+
+        // Map physical row range to viewport-relative indices.
+        let rel_start = start_row.saturating_sub(viewport_start);
+        let rel_end = (end_row - viewport_start).min(all_rows.len());
+        if rel_start >= rel_end {
+            return Vec::new();
+        }
+        all_rows[rel_start..rel_end].to_vec()
     }
 
     fn erase_scrollback(&mut self) {
-        self.terminal.reset();
+        // Send CSI 3 J (Erase Scrollback) to clear scrollback without
+        // resetting the terminal. terminal.reset() would wipe screen too.
+        self.terminal.vt_write(b"\x1b[3J");
     }
 
     fn focus_changed(&mut self, focused: bool) {

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -11,7 +11,7 @@ use std::sync::{mpsc, Arc, Mutex};
 
 use libghostty_vt::render::{CellIterator, CursorVisualStyle, Dirty, RenderState, RowIterator};
 use libghostty_vt::style::RgbColor;
-use libghostty_vt::terminal::{Mode, Options as TerminalOptions, Point, PointCoordinate, Terminal};
+use libghostty_vt::terminal::{Mode, Options as TerminalOptions, Terminal};
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use url::Url;
 
@@ -171,64 +171,26 @@ where
         }
     }
 
-    /// Read a single row of text via grid_ref point queries.
-    /// Returns the text content of the row, trimmed at the right.
-    fn read_row_text(&self, row: u32, cols: u16) -> String {
-        let mut line = String::new();
-        let mut char_buf = ['\0'; 16];
-        for col in 0..cols {
-            let coord: PointCoordinate =
-                libghostty_vt::ffi::GhosttyPointCoordinate { x: col, y: row }.into();
-            if let Ok(grid_ref) = self.terminal.grid_ref(Point::Screen(coord)) {
-                if let Ok(n) = grid_ref.graphemes(&mut char_buf) {
-                    for &ch in &char_buf[..n] {
-                        line.push(ch);
-                    }
-                } else {
-                    line.push(' ');
-                }
-            } else {
-                line.push(' ');
-            }
-        }
-        line.trim_end().to_string()
-    }
-
-    /// Read a range of rows as text lines using grid_ref.
-    /// `start` and `end` are 0-based row indices (end exclusive).
-    fn read_rows_text(&self, start: u32, end: u32) -> String {
-        let cols = self.terminal.cols().unwrap_or(80);
-        let mut lines = Vec::new();
-        for row in start..end {
-            lines.push(self.read_row_text(row, cols));
-        }
-        // Trim trailing empty lines
-        while lines.last().is_some_and(|l| l.is_empty()) {
-            lines.pop();
-        }
-        lines.join("\n")
-    }
-
-    /// Read screen text using the render state snapshot iterators.
-    /// Takes &self via RefCell interior mutability.
-    fn read_text_from_snapshot(&self) -> String {
+    /// Read all visible lines from a render state snapshot.
+    /// Returns a Vec of lines (trimmed on the right).
+    fn snapshot_lines(&self) -> Vec<String> {
         let mut rs = self.render_state.borrow_mut();
         let snapshot = match rs.update(&self.terminal) {
             Ok(s) => s,
-            Err(_) => return String::new(),
+            Err(_) => return Vec::new(),
         };
 
         let mut row_iter = match RowIterator::new() {
             Ok(r) => r,
-            Err(_) => return String::new(),
+            Err(_) => return Vec::new(),
         };
         let mut cell_iter = match CellIterator::new() {
             Ok(c) => c,
-            Err(_) => return String::new(),
+            Err(_) => return Vec::new(),
         };
         let mut row_iteration = match row_iter.update(&snapshot) {
             Ok(r) => r,
-            Err(_) => return String::new(),
+            Err(_) => return Vec::new(),
         };
 
         let mut lines = Vec::new();
@@ -245,7 +207,13 @@ where
             }
             lines.push(line.trim_end().to_string());
         }
+        lines
+    }
 
+    /// Read screen text using the render state snapshot iterators.
+    /// Takes &self via RefCell interior mutability.
+    fn read_text_from_snapshot(&self) -> String {
+        let mut lines = self.snapshot_lines();
         // Trim trailing empty lines
         while lines.last().is_some_and(|l| l.is_empty()) {
             lines.pop();
@@ -392,19 +360,21 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
 
     fn read_screen_lines(&self, line_spec: &str, _ansi: bool) -> String {
         // ANSI formatting not yet supported — returns plain text regardless.
-        let total = self.terminal.total_rows().unwrap_or(0) as u32;
+        // Uses the render state snapshot (viewport lines).
+        let lines = self.snapshot_lines();
+        let total = lines.len();
         if total == 0 {
             return String::new();
         }
 
         let (start, end) = if let Some(rest) = line_spec.strip_prefix('-') {
             // "-N" means last N lines
-            let n: u32 = rest.parse().unwrap_or(total);
+            let n: usize = rest.parse().unwrap_or(total);
             (total.saturating_sub(n), total)
         } else if let Some((a, b)) = line_spec.split_once('-') {
             // "A-B" means lines A through B (1-based)
-            let a: u32 = a.parse().unwrap_or(1);
-            let b: u32 = b.parse().unwrap_or(total);
+            let a: usize = a.parse().unwrap_or(1);
+            let b: usize = b.parse().unwrap_or(total);
             let s = a.saturating_sub(1).min(total);
             let e = b.min(total);
             if s >= e {
@@ -414,12 +384,17 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
             }
         } else {
             // Single line number (1-based)
-            let n: u32 = line_spec.parse().unwrap_or(1);
+            let n: usize = line_spec.parse().unwrap_or(1);
             let idx = n.saturating_sub(1).min(total.saturating_sub(1));
             (idx, (idx + 1).min(total))
         };
 
-        self.read_rows_text(start, end)
+        let mut selected: Vec<&str> = lines[start..end].iter().map(|s| s.as_str()).collect();
+        // Trim trailing empty lines
+        while selected.last().is_some_and(|l| l.is_empty()) {
+            selected.pop();
+        }
+        selected.join("\n")
     }
 
     fn read_screen_text(&self) -> String {
@@ -427,13 +402,31 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
     }
 
     fn read_scrollback_text(&self, max_lines: usize) -> String {
-        let total = self.terminal.total_rows().unwrap_or(0) as u32;
-        let start = total.saturating_sub(max_lines as u32);
-        self.read_rows_text(start, total)
+        // Currently limited to viewport via render state.
+        // Full scrollback would require grid_ref iteration.
+        let lines = self.snapshot_lines();
+        let total = lines.len();
+        let start = total.saturating_sub(max_lines);
+        let mut selected: Vec<&str> = lines[start..].iter().map(|s| s.as_str()).collect();
+        while selected.last().is_some_and(|l| l.is_empty()) {
+            selected.pop();
+        }
+        selected.join("\n")
     }
 
     fn read_scrollback_text_range(&self, start: usize, end: usize) -> String {
-        self.read_rows_text(start as u32, end as u32)
+        // Currently limited to viewport via render state.
+        let lines = self.snapshot_lines();
+        let s = start.min(lines.len());
+        let e = end.min(lines.len());
+        if s >= e {
+            return String::new();
+        }
+        let mut selected: Vec<&str> = lines[s..e].iter().map(|s| s.as_str()).collect();
+        while selected.last().is_some_and(|l| l.is_empty()) {
+            selected.pop();
+        }
+        selected.join("\n")
     }
 
     fn search_scrollback(&self, query: &str) -> Vec<(usize, usize, usize)> {
@@ -441,51 +434,18 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
             return Vec::new();
         }
         let query_lower = query.to_lowercase();
-        let cols = self.terminal.cols().unwrap_or(80);
-        let total = self.terminal.total_rows().unwrap_or(0) as u32;
+        let lines = self.snapshot_lines();
 
         let mut matches = Vec::new();
-        let mut char_buf = ['\0'; 16];
-
-        for row in 0..total {
-            let mut line_text = String::new();
-            let mut col_offsets: Vec<usize> = Vec::new();
-
-            for col in 0..cols {
-                let coord: PointCoordinate =
-                    libghostty_vt::ffi::GhosttyPointCoordinate { x: col, y: row }.into();
-                if let Ok(grid_ref) = self.terminal.grid_ref(Point::Screen(coord)) {
-                    if let Ok(n) = grid_ref.graphemes(&mut char_buf) {
-                        for &ch in &char_buf[..n] {
-                            let mut buf = [0u8; 4];
-                            let s = ch.encode_utf8(&mut buf);
-                            for _ in s.bytes() {
-                                col_offsets.push(col as usize);
-                            }
-                            line_text.push(ch);
-                        }
-                    } else {
-                        col_offsets.push(col as usize);
-                        line_text.push(' ');
-                    }
-                } else {
-                    col_offsets.push(col as usize);
-                    line_text.push(' ');
-                }
-            }
-
-            let line_lower = line_text.to_lowercase();
+        for (phys_row, line) in lines.iter().enumerate() {
+            let line_lower = line.to_lowercase();
             let mut search_start = 0;
             while let Some(byte_pos) = line_lower[search_start..].find(&query_lower) {
                 let abs_pos = search_start + byte_pos;
                 let end_pos = abs_pos + query_lower.len();
-                let start_col = col_offsets.get(abs_pos).copied().unwrap_or(0);
-                let end_col = col_offsets
-                    .get(end_pos.saturating_sub(1))
-                    .copied()
-                    .unwrap_or(start_col)
-                    + 1;
-                matches.push((row as usize, start_col, end_col));
+                // For ASCII text, byte offset ≈ column. For multi-byte,
+                // this is approximate but correct for the common case.
+                matches.push((phys_row, abs_pos, end_pos));
                 search_start = abs_pos + 1;
             }
         }

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -100,7 +100,9 @@ where
         terminal
             .on_pty_write(move |_term, data| {
                 let mut w = write_handle.lock().unwrap_or_else(|e| e.into_inner());
-                let _ = w.write_all(data);
+                if let Err(e) = w.write_all(data) {
+                    tracing::warn!("PTY write failed: {e}");
+                }
             })
             .map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("{e}")))?;
 

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -531,6 +531,13 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         rows
     }
 
+    fn read_cells_range(&self, _start_row: usize, _end_row: usize) -> Vec<ScreenRow> {
+        // libghostty render state only exposes the viewport.
+        // For arbitrary row ranges, we'd need grid_ref iteration.
+        // Return viewport cells as a best-effort approximation.
+        self.read_screen_cells(0)
+    }
+
     fn erase_scrollback(&mut self) {
         self.terminal.reset();
     }

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -28,7 +28,11 @@ use crate::pane::{AdvanceResult, SequenceNo, TermError};
 /// `RenderState` is behind `RefCell` for interior mutability — the trait's
 /// `&self` methods need to take snapshots for screen reading.
 pub struct GhosttyPane<'alloc, 'cb> {
-    terminal: Terminal<'alloc, 'cb>,
+    /// Boxed so the vtable pointer registered via `on_pty_write` etc. remains
+    /// stable when GhosttyPane is moved (into AnyBackend, PaneSurface, etc.).
+    /// libghostty-vt stores `&self.vtable` as a raw C pointer; moving Terminal
+    /// after callback registration would leave a dangling pointer → SIGSEGV.
+    terminal: Box<Terminal<'alloc, 'cb>>,
     render_state: RefCell<RenderState<'alloc>>,
     #[allow(dead_code)]
     master: Box<dyn MasterPty + Send>,
@@ -83,8 +87,13 @@ where
             rows,
             max_scrollback: 10_000,
         };
-        let mut terminal =
-            Terminal::new(opts).map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("{e}")))?;
+        // Box the terminal BEFORE registering callbacks. libghostty-vt stores
+        // a raw pointer to Terminal.vtable via ghostty_terminal_set(USERDATA, &self.vtable).
+        // Boxing first ensures the vtable has a stable heap address that survives
+        // moves of GhosttyPane into AnyBackend/PaneSurface.
+        let mut terminal = Box::new(
+            Terminal::new(opts).map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("{e}")))?,
+        );
 
         // Register on_pty_write callback so terminal responses go back to PTY.
         let write_handle = Arc::clone(&shared);

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -1,0 +1,345 @@
+//! libghostty-vt backend for the TerminalBackend trait.
+//!
+//! POC implementation (#34) proving that `TerminalBackend` can be implemented
+//! against a non-wezterm backend. Wraps libghostty-vt's Terminal + portable-pty.
+//!
+//! Enabled with `--features libghostty`.
+
+use std::io::{Read, Write};
+use std::sync::{mpsc, Arc, Mutex};
+
+use libghostty_vt::render::{Dirty, RenderState};
+use libghostty_vt::style::RgbColor;
+use libghostty_vt::terminal::{Mode, Options as TerminalOptions, Terminal};
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
+use url::Url;
+
+use crate::backend::{
+    Color, CursorPos, CursorShape, Palette, ProcessExit, StableRow, TerminalBackend,
+};
+use crate::osc::NotificationEvent;
+use crate::pane::{AdvanceResult, SequenceNo, TermError};
+
+/// A terminal pane backed by libghostty-vt + portable-pty.
+///
+/// libghostty-vt is !Send + !Sync, so this must stay on one thread.
+pub struct GhosttyPane<'alloc, 'cb> {
+    terminal: Terminal<'alloc, 'cb>,
+    render_state: RenderState<'alloc>,
+    #[allow(dead_code)]
+    master: Box<dyn MasterPty + Send>,
+    child: Box<dyn Child + Send + Sync>,
+    reader: Option<Box<dyn Read + Send>>,
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    seqno: SequenceNo,
+    rendered_seqno: SequenceNo,
+    notification_rx: mpsc::Receiver<NotificationEvent>,
+    /// Cached palette from last render state update.
+    cached_palette: Palette,
+    /// Cached cursor from last render state update.
+    cached_cursor_shape: CursorShape,
+}
+
+impl<'alloc, 'cb> GhosttyPane<'alloc, 'cb>
+where
+    'alloc: 'cb,
+{
+    /// Spawn a new terminal pane running the given command.
+    pub fn spawn(cols: u16, rows: u16, cmd: CommandBuilder) -> Result<Self, TermError> {
+        let pty_system = native_pty_system();
+        let pty_size = PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let pair = pty_system
+            .openpty(pty_size)
+            .map_err(TermError::PtySetupFailed)?;
+
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(TermError::PtySetupFailed)?;
+        let reader = pair
+            .master
+            .try_clone_reader()
+            .map_err(TermError::PtySetupFailed)?;
+
+        let pty_writer = pair
+            .master
+            .take_writer()
+            .map_err(TermError::PtySetupFailed)?;
+        let shared = Arc::new(Mutex::new(pty_writer));
+
+        let opts = TerminalOptions {
+            cols,
+            rows,
+            max_scrollback: 10_000,
+        };
+        let mut terminal =
+            Terminal::new(opts).map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("{e}")))?;
+
+        // Register on_pty_write callback so terminal responses go back to PTY.
+        let write_handle = Arc::clone(&shared);
+        terminal
+            .on_pty_write(move |_term, data| {
+                let mut w = write_handle.lock().unwrap_or_else(|e| e.into_inner());
+                let _ = w.write_all(data);
+            })
+            .map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("{e}")))?;
+
+        let render_state =
+            RenderState::new().map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("{e}")))?;
+
+        let (_tx, rx) = mpsc::channel();
+
+        Ok(Self {
+            terminal,
+            render_state,
+            master: pair.master,
+            child,
+            reader: Some(reader),
+            writer: shared,
+            seqno: 0,
+            rendered_seqno: 0,
+            notification_rx: rx,
+            cached_palette: Palette::default(),
+            cached_cursor_shape: CursorShape::Default,
+        })
+    }
+
+    /// Refresh cached render state (palette, cursor shape).
+    /// Called after vt_write to keep caches warm.
+    fn refresh_render_cache(&mut self) {
+        if let Ok(snapshot) = self.render_state.update(&self.terminal) {
+            // Cache palette
+            if let Ok(colors) = snapshot.colors() {
+                let fg = rgb_to_color(colors.foreground);
+                let bg = rgb_to_color(colors.background);
+                let cursor_color = colors.cursor.map(rgb_to_color).unwrap_or(fg);
+                self.cached_palette = Palette {
+                    foreground: fg,
+                    background: bg,
+                    cursor_fg: bg,
+                    cursor_bg: cursor_color,
+                    cursor_border: cursor_color,
+                    selection_fg: Color::BLACK,
+                    selection_bg: Color(0.4, 0.6, 1.0, 1.0),
+                    colors: colors.palette.iter().map(|&c| rgb_to_color(c)).collect(),
+                };
+            }
+
+            // Cache cursor shape
+            if let Ok(style) = snapshot.cursor_visual_style() {
+                use libghostty_vt::render::CursorVisualStyle;
+                self.cached_cursor_shape = match style {
+                    CursorVisualStyle::Bar => CursorShape::SteadyBar,
+                    CursorVisualStyle::Block => CursorShape::SteadyBlock,
+                    CursorVisualStyle::Underline => CursorShape::SteadyUnderline,
+                    CursorVisualStyle::BlockHollow => CursorShape::SteadyBlock,
+                    _ => CursorShape::Default,
+                };
+            }
+        }
+    }
+}
+
+impl TerminalBackend for GhosttyPane<'_, '_> {
+    fn advance(&mut self) -> AdvanceResult {
+        let reader = match &mut self.reader {
+            Some(r) => r,
+            None => return AdvanceResult::Eof,
+        };
+        let mut buf = [0u8; 8192];
+        match reader.read(&mut buf) {
+            Ok(0) => AdvanceResult::Eof,
+            Ok(n) => {
+                self.terminal.vt_write(&buf[..n]);
+                self.seqno += 1;
+                self.refresh_render_cache();
+                AdvanceResult::Read(n)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => AdvanceResult::WouldBlock,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => AdvanceResult::WouldBlock,
+            Err(_) => AdvanceResult::Eof,
+        }
+    }
+
+    fn resize(&mut self, cols: u16, rows: u16) -> Result<(), TermError> {
+        let pty_size = PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        self.master
+            .resize(pty_size)
+            .map_err(TermError::ResizeFailed)?;
+        self.terminal
+            .resize(cols, rows, 0, 0)
+            .map_err(|e| TermError::ResizeFailed(anyhow::anyhow!("{e}")))?;
+        Ok(())
+    }
+
+    fn write_bytes(&mut self, data: &[u8]) -> Result<(), TermError> {
+        let mut writer = self.writer.lock().unwrap_or_else(|e| e.into_inner());
+        writer.write_all(data).map_err(TermError::WriteFailed)?;
+        Ok(())
+    }
+
+    fn feed_bytes(&mut self, data: &[u8]) {
+        self.terminal.vt_write(data);
+        self.seqno += 1;
+        self.refresh_render_cache();
+    }
+
+    fn take_reader(&mut self) -> Option<Box<dyn Read + Send>> {
+        self.reader.take()
+    }
+
+    fn title(&self) -> &str {
+        self.terminal.title().unwrap_or("?")
+    }
+
+    fn working_dir(&self) -> Option<&Url> {
+        // libghostty returns &str from pwd(). We'd need a cached Url field
+        // updated via an on_osc7 callback. For the POC, return None.
+        None
+    }
+
+    fn dimensions(&self) -> (usize, usize) {
+        let cols = self.terminal.cols().unwrap_or(80) as usize;
+        let rows = self.terminal.rows().unwrap_or(24) as usize;
+        (cols, rows)
+    }
+
+    fn cursor(&self) -> CursorPos {
+        CursorPos {
+            x: self.terminal.cursor_x().unwrap_or(0) as usize,
+            y: self.terminal.cursor_y().unwrap_or(0) as i64,
+            shape: self.cached_cursor_shape,
+            visible: self.terminal.is_cursor_visible().unwrap_or(true),
+        }
+    }
+
+    fn palette(&self) -> Palette {
+        self.cached_palette.clone()
+    }
+
+    fn is_alt_screen_active(&self) -> bool {
+        use libghostty_vt::ffi::GhosttyTerminalScreen_GHOSTTY_TERMINAL_SCREEN_ALTERNATE;
+        self.terminal
+            .active_screen()
+            .map(|s| s == GhosttyTerminalScreen_GHOSTTY_TERMINAL_SCREEN_ALTERNATE)
+            .unwrap_or(false)
+    }
+
+    fn bracketed_paste_enabled(&self) -> bool {
+        self.terminal.mode(Mode::BRACKETED_PASTE).unwrap_or(false)
+    }
+
+    fn child_pid(&self) -> Option<u32> {
+        self.child.process_id()
+    }
+
+    fn is_alive(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(None))
+    }
+
+    fn exit_status(&mut self) -> Option<ProcessExit> {
+        match self.child.try_wait() {
+            Ok(Some(status)) => Some(status.into()),
+            _ => None,
+        }
+    }
+
+    fn changed_lines(&self) -> Vec<StableRow> {
+        // libghostty tracks dirty rows via RenderState. For the POC,
+        // report all visible rows when seqno has advanced.
+        if self.seqno > self.rendered_seqno {
+            let rows = self.terminal.rows().unwrap_or(24) as i64;
+            (0..rows).collect()
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn mark_rendered(&mut self) {
+        self.rendered_seqno = self.seqno;
+        // Reset dirty tracking
+        if let Ok(snapshot) = self.render_state.update(&self.terminal) {
+            let _ = snapshot.set_dirty(Dirty::Clean);
+        }
+    }
+
+    fn current_seqno(&self) -> SequenceNo {
+        self.seqno
+    }
+
+    fn rendered_seqno(&self) -> SequenceNo {
+        self.rendered_seqno
+    }
+
+    fn scrollback_rows(&self) -> usize {
+        self.terminal.total_rows().unwrap_or(0)
+    }
+
+    fn read_screen_lines(&self, _line_spec: &str, _ansi: bool) -> String {
+        // POC: full implementation would parse line_spec and iterate scrollback.
+        // For now, return empty — the IPC layer will get basic functionality.
+        String::new()
+    }
+
+    fn read_screen_text(&self) -> String {
+        // This needs &mut self for render_state.update(), but the trait requires &self.
+        // POC limitation: return empty. A full implementation would maintain a cached
+        // screen text updated in advance()/feed_bytes().
+        String::new()
+    }
+
+    fn read_scrollback_text(&self, _max_lines: usize) -> String {
+        String::new()
+    }
+
+    fn read_scrollback_text_range(&self, _start: usize, _end: usize) -> String {
+        String::new()
+    }
+
+    fn search_scrollback(&self, _query: &str) -> Vec<(usize, usize, usize)> {
+        Vec::new()
+    }
+
+    fn erase_scrollback(&mut self) {
+        self.terminal.reset();
+    }
+
+    fn focus_changed(&mut self, focused: bool) {
+        let event = if focused {
+            libghostty_vt::focus::Event::Gained
+        } else {
+            libghostty_vt::focus::Event::Lost
+        };
+        let mut buf = [0u8; 8];
+        if let Ok(n) = event.encode(&mut buf) {
+            self.terminal.vt_write(&buf[..n]);
+        }
+    }
+
+    fn drain_notifications(&self) -> Vec<NotificationEvent> {
+        let mut events = Vec::new();
+        while let Ok(event) = self.notification_rx.try_recv() {
+            events.push(event);
+        }
+        events
+    }
+}
+
+fn rgb_to_color(rgb: RgbColor) -> Color {
+    Color(
+        rgb.r as f32 / 255.0,
+        rgb.g as f32 / 255.0,
+        rgb.b as f32 / 255.0,
+        1.0,
+    )
+}

--- a/crates/amux-term/src/lib.rs
+++ b/crates/amux-term/src/lib.rs
@@ -10,6 +10,7 @@ pub mod osc;
 pub mod pane;
 
 pub use backend::{
-    Color, CursorPos, CursorShape, Palette, ProcessExit, StableRow, TerminalBackend,
+    Color, CursorPos, CursorShape, Palette, ProcessExit, ScreenCell, ScreenRow, StableRow,
+    TerminalBackend,
 };
 pub use pane::TermError;

--- a/crates/amux-term/src/lib.rs
+++ b/crates/amux-term/src/lib.rs
@@ -7,5 +7,7 @@ pub mod mouse_encoder;
 pub mod osc;
 pub mod pane;
 
-pub use backend::TerminalBackend;
+pub use backend::{
+    Color, CursorPos, CursorShape, Palette, ProcessExit, StableRow, TerminalBackend,
+};
 pub use pane::TermError;

--- a/crates/amux-term/src/lib.rs
+++ b/crates/amux-term/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod backend;
 pub mod color;
 pub mod config;
 pub mod font;
@@ -6,4 +7,5 @@ pub mod mouse_encoder;
 pub mod osc;
 pub mod pane;
 
+pub use backend::TerminalBackend;
 pub use pane::TermError;

--- a/crates/amux-term/src/lib.rs
+++ b/crates/amux-term/src/lib.rs
@@ -2,6 +2,8 @@ pub mod backend;
 pub mod color;
 pub mod config;
 pub mod font;
+#[cfg(feature = "libghostty")]
+pub mod ghostty_pane;
 pub mod key_encoder;
 pub mod mouse_encoder;
 pub mod osc;

--- a/crates/amux-term/src/lib.rs
+++ b/crates/amux-term/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod any_backend;
 pub mod backend;
 pub mod color;
 pub mod config;
@@ -9,6 +10,7 @@ pub mod mouse_encoder;
 pub mod osc;
 pub mod pane;
 
+pub use any_backend::AnyBackend;
 pub use backend::{
     Color, CursorPos, CursorShape, Palette, ProcessExit, ScreenCell, ScreenRow, StableRow,
     TerminalBackend,

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -7,7 +7,7 @@ use wezterm_term::color::ColorPalette;
 use wezterm_term::terminal::Terminal;
 use wezterm_term::{CursorPosition, StableRowIndex, TerminalSize};
 
-use crate::backend::TerminalBackend;
+use crate::backend::{CursorPos, Palette, ProcessExit, StableRow, TerminalBackend};
 use crate::config::AmuxTermConfig;
 use crate::osc::{ChannelAlertHandler, NotificationEvent};
 
@@ -240,16 +240,17 @@ impl TerminalPane {
         matches!(self.child.try_wait(), Ok(None))
     }
 
-    /// Get the child exit status, if it has exited.
-    pub fn exit_status(&mut self) -> Option<portable_pty::ExitStatus> {
+    /// Get the child exit status, if it has exited (portable-pty native type).
+    pub fn pty_exit_status(&mut self) -> Option<portable_pty::ExitStatus> {
         match self.child.try_wait() {
             Ok(Some(status)) => Some(status),
             _ => None,
         }
     }
 
-    /// Get stable row indices of lines changed since the last `mark_rendered()` call.
-    pub fn changed_lines(&self) -> Vec<StableRowIndex> {
+    /// Get stable row indices of lines changed since the last `mark_rendered()` call
+    /// (wezterm-native StableRowIndex type).
+    pub fn changed_line_indices(&self) -> Vec<StableRowIndex> {
         let size = self.terminal.get_size();
         let screen = self.terminal.screen();
         // Compute the visible stable row range
@@ -263,8 +264,8 @@ impl TerminalPane {
         self.seqno = self.terminal.current_seqno();
     }
 
-    /// Get the current cursor position.
-    pub fn cursor(&self) -> CursorPosition {
+    /// Get the current cursor position (wezterm-native type).
+    pub fn cursor_pos(&self) -> CursorPosition {
         self.terminal.cursor_pos()
     }
 
@@ -274,8 +275,8 @@ impl TerminalPane {
         (size.cols, size.rows)
     }
 
-    /// Get the current color palette.
-    pub fn palette(&self) -> ColorPalette {
+    /// Get the current color palette (wezterm-native type).
+    pub fn color_palette(&self) -> ColorPalette {
         self.terminal.palette()
     }
 
@@ -606,12 +607,12 @@ impl TerminalBackend for TerminalPane {
         self.dimensions()
     }
 
-    fn cursor(&self) -> CursorPosition {
-        self.cursor()
+    fn cursor(&self) -> CursorPos {
+        self.cursor_pos().into()
     }
 
-    fn palette(&self) -> ColorPalette {
-        self.palette()
+    fn palette(&self) -> Palette {
+        self.color_palette().into()
     }
 
     fn is_alt_screen_active(&self) -> bool {
@@ -630,12 +631,15 @@ impl TerminalBackend for TerminalPane {
         self.is_alive()
     }
 
-    fn exit_status(&mut self) -> Option<portable_pty::ExitStatus> {
-        self.exit_status()
+    fn exit_status(&mut self) -> Option<ProcessExit> {
+        self.pty_exit_status().map(Into::into)
     }
 
-    fn changed_lines(&self) -> Vec<StableRowIndex> {
-        self.changed_lines()
+    fn changed_lines(&self) -> Vec<StableRow> {
+        self.changed_line_indices()
+            .into_iter()
+            .map(|r| r as StableRow)
+            .collect()
     }
 
     fn mark_rendered(&mut self) {

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -7,6 +7,7 @@ use wezterm_term::color::ColorPalette;
 use wezterm_term::terminal::Terminal;
 use wezterm_term::{CursorPosition, StableRowIndex, TerminalSize};
 
+use crate::backend::TerminalBackend;
 use crate::config::AmuxTermConfig;
 use crate::osc::{ChannelAlertHandler, NotificationEvent};
 
@@ -307,6 +308,11 @@ impl TerminalPane {
         self.seqno
     }
 
+    /// Total rows in scrollback + visible screen.
+    pub fn scrollback_rows(&self) -> usize {
+        self.terminal.screen().scrollback_rows()
+    }
+
     /// Read lines from the scrollback or visible screen, with optional ANSI formatting.
     ///
     /// `line_spec` formats:
@@ -564,6 +570,120 @@ impl TerminalPane {
             }
         }
         matches
+    }
+}
+
+impl TerminalBackend for TerminalPane {
+    fn advance(&mut self) -> AdvanceResult {
+        self.advance()
+    }
+
+    fn resize(&mut self, cols: u16, rows: u16) -> Result<(), TermError> {
+        self.resize(cols, rows)
+    }
+
+    fn write_bytes(&mut self, data: &[u8]) -> Result<(), TermError> {
+        self.write_bytes(data)
+    }
+
+    fn feed_bytes(&mut self, data: &[u8]) {
+        self.feed_bytes(data);
+    }
+
+    fn take_reader(&mut self) -> Option<Box<dyn Read + Send>> {
+        self.take_reader()
+    }
+
+    fn title(&self) -> &str {
+        self.title()
+    }
+
+    fn working_dir(&self) -> Option<&Url> {
+        self.working_dir()
+    }
+
+    fn dimensions(&self) -> (usize, usize) {
+        self.dimensions()
+    }
+
+    fn cursor(&self) -> CursorPosition {
+        self.cursor()
+    }
+
+    fn palette(&self) -> ColorPalette {
+        self.palette()
+    }
+
+    fn is_alt_screen_active(&self) -> bool {
+        self.is_alt_screen_active()
+    }
+
+    fn bracketed_paste_enabled(&self) -> bool {
+        self.bracketed_paste_enabled()
+    }
+
+    fn child_pid(&self) -> Option<u32> {
+        self.child_pid()
+    }
+
+    fn is_alive(&mut self) -> bool {
+        self.is_alive()
+    }
+
+    fn exit_status(&mut self) -> Option<portable_pty::ExitStatus> {
+        self.exit_status()
+    }
+
+    fn changed_lines(&self) -> Vec<StableRowIndex> {
+        self.changed_lines()
+    }
+
+    fn mark_rendered(&mut self) {
+        self.mark_rendered();
+    }
+
+    fn current_seqno(&self) -> SequenceNo {
+        self.current_seqno()
+    }
+
+    fn rendered_seqno(&self) -> SequenceNo {
+        self.rendered_seqno()
+    }
+
+    fn scrollback_rows(&self) -> usize {
+        self.scrollback_rows()
+    }
+
+    fn read_screen_lines(&self, line_spec: &str, ansi: bool) -> String {
+        self.read_screen_lines(line_spec, ansi)
+    }
+
+    fn read_screen_text(&self) -> String {
+        self.read_screen_text()
+    }
+
+    fn read_scrollback_text(&self, max_lines: usize) -> String {
+        self.read_scrollback_text(max_lines)
+    }
+
+    fn read_scrollback_text_range(&self, start: usize, end: usize) -> String {
+        self.read_scrollback_text_range(start, end)
+    }
+
+    fn search_scrollback(&self, query: &str) -> Vec<(usize, usize, usize)> {
+        self.search_scrollback(query)
+    }
+
+    fn erase_scrollback(&mut self) {
+        self.erase_scrollback();
+    }
+
+    fn focus_changed(&mut self, focused: bool) {
+        self.focus_changed(focused);
+    }
+
+    fn drain_notifications(&self) -> Vec<NotificationEvent> {
+        self.drain_notifications()
     }
 }
 

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -7,7 +7,10 @@ use wezterm_term::color::ColorPalette;
 use wezterm_term::terminal::Terminal;
 use wezterm_term::{CursorPosition, StableRowIndex, TerminalSize};
 
-use crate::backend::{CursorPos, Palette, ProcessExit, StableRow, TerminalBackend};
+use crate::backend::{
+    Color, CursorPos, Palette, ProcessExit, ScreenCell, ScreenRow, StableRow, TerminalBackend,
+};
+use crate::color::resolve_color;
 use crate::config::AmuxTermConfig;
 use crate::osc::{ChannelAlertHandler, NotificationEvent};
 
@@ -676,6 +679,46 @@ impl TerminalBackend for TerminalPane {
 
     fn search_scrollback(&self, query: &str) -> Vec<(usize, usize, usize)> {
         self.search_scrollback(query)
+    }
+
+    fn read_screen_cells(&self, scroll_offset: usize) -> Vec<ScreenRow> {
+        let (cols, rows) = self.dimensions();
+        let screen = self.terminal.screen();
+        let palette = self.terminal.palette();
+        let total = screen.scrollback_rows();
+        let end = total.saturating_sub(scroll_offset);
+        let start = end.saturating_sub(rows);
+        let lines = screen.lines_in_phys_range(start..end);
+
+        let mut result = Vec::with_capacity(rows);
+        for line in &lines {
+            let mut cells = Vec::with_capacity(cols);
+            for cell_ref in line.visible_cells() {
+                let col_idx = cell_ref.cell_index();
+                if col_idx >= cols {
+                    break;
+                }
+                let attrs = cell_ref.attrs();
+                let reverse = attrs.reverse();
+                let fg_srgba = resolve_color(&attrs.foreground(), &palette, true, reverse);
+                let bg_srgba = resolve_color(&attrs.background(), &palette, false, reverse);
+
+                cells.push(ScreenCell {
+                    text: cell_ref.str().to_string(),
+                    fg: Color::from(fg_srgba),
+                    bg: Color::from(bg_srgba),
+                    bold: attrs.intensity() == wezterm_term::Intensity::Bold,
+                    italic: attrs.italic(),
+                    underline: attrs.underline() != wezterm_term::Underline::None,
+                    strikethrough: attrs.strikethrough(),
+                    reverse,
+                    hyperlink_url: attrs.hyperlink().map(|h| h.uri().to_string()),
+                });
+            }
+            let wrapped = line.last_cell_was_wrapped();
+            result.push(ScreenRow { cells, wrapped });
+        }
+        result
     }
 
     fn erase_scrollback(&mut self) {

--- a/crates/amux-term/src/pane.rs
+++ b/crates/amux-term/src/pane.rs
@@ -575,6 +575,43 @@ impl TerminalPane {
         }
         matches
     }
+
+    /// Convert a range of physical rows to `ScreenRow` structs.
+    fn lines_to_screen_rows(&self, start: usize, end: usize, cols: usize) -> Vec<ScreenRow> {
+        let screen = self.terminal.screen();
+        let palette = self.terminal.palette();
+        let lines = screen.lines_in_phys_range(start..end);
+
+        let mut result = Vec::with_capacity(lines.len());
+        for line in &lines {
+            let mut cells = Vec::with_capacity(cols);
+            for cell_ref in line.visible_cells() {
+                let col_idx = cell_ref.cell_index();
+                if col_idx >= cols {
+                    break;
+                }
+                let attrs = cell_ref.attrs();
+                let reverse = attrs.reverse();
+                let fg_srgba = resolve_color(&attrs.foreground(), &palette, true, reverse);
+                let bg_srgba = resolve_color(&attrs.background(), &palette, false, reverse);
+
+                cells.push(ScreenCell {
+                    text: cell_ref.str().to_string(),
+                    fg: Color::from(fg_srgba),
+                    bg: Color::from(bg_srgba),
+                    bold: attrs.intensity() == wezterm_term::Intensity::Bold,
+                    italic: attrs.italic(),
+                    underline: attrs.underline() != wezterm_term::Underline::None,
+                    strikethrough: attrs.strikethrough(),
+                    reverse,
+                    hyperlink_url: attrs.hyperlink().map(|h| h.uri().to_string()),
+                });
+            }
+            let wrapped = line.last_cell_was_wrapped();
+            result.push(ScreenRow { cells, wrapped });
+        }
+        result
+    }
 }
 
 impl TerminalBackend for TerminalPane {
@@ -684,41 +721,15 @@ impl TerminalBackend for TerminalPane {
     fn read_screen_cells(&self, scroll_offset: usize) -> Vec<ScreenRow> {
         let (cols, rows) = self.dimensions();
         let screen = self.terminal.screen();
-        let palette = self.terminal.palette();
         let total = screen.scrollback_rows();
         let end = total.saturating_sub(scroll_offset);
         let start = end.saturating_sub(rows);
-        let lines = screen.lines_in_phys_range(start..end);
+        self.lines_to_screen_rows(start, end, cols)
+    }
 
-        let mut result = Vec::with_capacity(rows);
-        for line in &lines {
-            let mut cells = Vec::with_capacity(cols);
-            for cell_ref in line.visible_cells() {
-                let col_idx = cell_ref.cell_index();
-                if col_idx >= cols {
-                    break;
-                }
-                let attrs = cell_ref.attrs();
-                let reverse = attrs.reverse();
-                let fg_srgba = resolve_color(&attrs.foreground(), &palette, true, reverse);
-                let bg_srgba = resolve_color(&attrs.background(), &palette, false, reverse);
-
-                cells.push(ScreenCell {
-                    text: cell_ref.str().to_string(),
-                    fg: Color::from(fg_srgba),
-                    bg: Color::from(bg_srgba),
-                    bold: attrs.intensity() == wezterm_term::Intensity::Bold,
-                    italic: attrs.italic(),
-                    underline: attrs.underline() != wezterm_term::Underline::None,
-                    strikethrough: attrs.strikethrough(),
-                    reverse,
-                    hyperlink_url: attrs.hyperlink().map(|h| h.uri().to_string()),
-                });
-            }
-            let wrapped = line.last_cell_was_wrapped();
-            result.push(ScreenRow { cells, wrapped });
-        }
-        result
+    fn read_cells_range(&self, start_row: usize, end_row: usize) -> Vec<ScreenRow> {
+        let (cols, _) = self.dimensions();
+        self.lines_to_screen_rows(start_row, end_row, cols)
     }
 
     fn erase_scrollback(&mut self) {

--- a/crates/amux-term/tests/ghostty_integration.rs
+++ b/crates/amux-term/tests/ghostty_integration.rs
@@ -1,0 +1,211 @@
+//! Integration tests for GhosttyPane via the TerminalBackend trait.
+//!
+//! Mirrors pty_integration.rs but exercises the libghostty-vt backend.
+//! Run with: cargo test -p amux-term --features libghostty
+
+#![cfg(feature = "libghostty")]
+
+use std::thread;
+use std::time::Duration;
+
+use portable_pty::CommandBuilder;
+
+use amux_term::backend::TerminalBackend;
+use amux_term::ghostty_pane::GhosttyPane;
+use amux_term::pane::AdvanceResult;
+
+/// Helper: spawn a GhosttyPane running a bash script, advance until EOF or timeout.
+fn spawn_and_run(script: &str) -> Box<GhosttyPane<'static, 'static>> {
+    let mut cmd = CommandBuilder::new("bash");
+    cmd.args(["--norc", "--noprofile", "-c", script]);
+    let mut pane = Box::new(GhosttyPane::spawn(80, 24, cmd).expect("spawn failed"));
+
+    for _ in 0..60 {
+        if let AdvanceResult::Eof = pane.advance() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    pane
+}
+
+#[test]
+fn dimensions_match_spawn_size() {
+    let cmd = CommandBuilder::new("true");
+    let pane = GhosttyPane::spawn(120, 40, cmd).expect("spawn failed");
+    let (cols, rows) = pane.dimensions();
+    assert_eq!(cols, 120);
+    assert_eq!(rows, 40);
+}
+
+#[test]
+fn resize_updates_dimensions() {
+    let cmd = CommandBuilder::new("true");
+    let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
+    pane.resize(100, 30).expect("resize failed");
+    let (cols, rows) = pane.dimensions();
+    assert_eq!(cols, 100);
+    assert_eq!(rows, 30);
+}
+
+#[test]
+fn screen_text_contains_output() {
+    let mut cmd = CommandBuilder::new("bash");
+    cmd.args([
+        "--norc",
+        "--noprofile",
+        "-c",
+        "printf 'hello ghostty\\n'; exit 0",
+    ]);
+    let mut pane = Box::new(GhosttyPane::spawn(80, 24, cmd).expect("spawn failed"));
+
+    for _ in 0..60 {
+        if let AdvanceResult::Eof = pane.advance() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    let text = pane.read_screen_text();
+    assert!(
+        text.contains("hello ghostty"),
+        "expected 'hello ghostty' in screen text, got: {text:?}"
+    );
+}
+
+#[test]
+fn feed_bytes_renders_to_screen() {
+    let mut cmd = CommandBuilder::new("sleep");
+    cmd.arg("10");
+    let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
+
+    // Feed bytes directly into the VT state machine (bypass PTY)
+    pane.feed_bytes(b"direct feed test\r\n");
+
+    let text = pane.read_screen_text();
+    assert!(
+        text.contains("direct feed test"),
+        "expected 'direct feed test' in screen text, got: {text:?}"
+    );
+}
+
+#[test]
+fn exit_status_reports_success() {
+    let mut pane = spawn_and_run("exit 0");
+    // Child may not have fully exited yet — wait briefly.
+    for _ in 0..20 {
+        if pane.exit_status().is_some() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    let exit = pane.exit_status();
+    assert!(exit.is_some(), "expected exit status");
+    let exit = exit.unwrap();
+    assert!(
+        exit.success(),
+        "expected success, got code {}",
+        exit.exit_code()
+    );
+}
+
+#[test]
+fn exit_status_reports_failure() {
+    let mut pane = spawn_and_run("exit 42");
+    let exit = pane.exit_status();
+    assert!(exit.is_some(), "expected exit status");
+    let exit = exit.unwrap();
+    assert_eq!(exit.exit_code(), 42);
+    assert!(!exit.success());
+}
+
+#[test]
+fn read_screen_cells_has_content() {
+    let pane = spawn_and_run("printf 'cells test\\n'; exit 0");
+    let rows = pane.read_screen_cells(0);
+    assert!(!rows.is_empty(), "expected non-empty screen cells");
+
+    let all_text: String = rows
+        .iter()
+        .flat_map(|r| r.cells.iter().map(|c| c.text.as_str()))
+        .collect();
+    assert!(
+        all_text.contains("cells test"),
+        "expected 'cells test' in cells, got: {all_text:?}"
+    );
+}
+
+#[test]
+fn read_screen_cells_detects_bold() {
+    let pane = spawn_and_run("printf '\\033[1mBOLD\\033[0m\\n'; exit 0");
+    let rows = pane.read_screen_cells(0);
+    let has_bold = rows
+        .iter()
+        .any(|r| r.cells.iter().any(|c| c.bold && !c.text.trim().is_empty()));
+    assert!(has_bold, "expected at least one bold cell");
+}
+
+#[test]
+fn read_screen_lines_range() {
+    let pane = spawn_and_run("printf 'line1\\nline2\\nline3\\n'; exit 0");
+    // Lines are 1-based: line1 is at row 1, line2 at row 2, line3 at row 3
+    let range = pane.read_screen_lines("1-3", false);
+    assert!(
+        range.contains("line1") && range.contains("line2"),
+        "expected range 1-3 to contain line1 and line2, got: {range:?}"
+    );
+    // Single line
+    let single = pane.read_screen_lines("2", false);
+    assert!(
+        single.contains("line2"),
+        "expected line 2 to contain 'line2', got: {single:?}"
+    );
+}
+
+#[test]
+fn search_scrollback_finds_match() {
+    let pane = spawn_and_run("printf 'findme here\\n'; exit 0");
+    let hits = pane.search_scrollback("findme");
+    assert!(
+        !hits.is_empty(),
+        "expected at least one search hit for 'findme'"
+    );
+}
+
+#[test]
+fn search_scrollback_case_insensitive() {
+    let pane = spawn_and_run("printf 'CamelCase\\n'; exit 0");
+    let hits = pane.search_scrollback("camelcase");
+    assert!(
+        !hits.is_empty(),
+        "expected case-insensitive match for 'camelcase'"
+    );
+}
+
+#[test]
+fn is_alive_while_running() {
+    let mut cmd = CommandBuilder::new("sleep");
+    cmd.arg("10");
+    let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
+    assert!(pane.is_alive(), "expected process to be alive");
+}
+
+#[test]
+fn seqno_increments_on_advance() {
+    let mut cmd = CommandBuilder::new("bash");
+    cmd.args(["--norc", "--noprofile", "-c", "printf 'x\\n'; exit 0"]);
+    let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
+
+    let before = pane.current_seqno();
+    for _ in 0..10 {
+        if let AdvanceResult::Eof = pane.advance() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    let after = pane.current_seqno();
+    assert!(
+        after > before,
+        "expected seqno to increment: {before} -> {after}"
+    );
+}


### PR DESCRIPTION
## Summary

- Extract `TerminalBackend` trait (26 methods) from `TerminalPane`, replacing wezterm-specific types with amux-native types (`Color`, `CursorPos`, `Palette`, `ScreenCell`, `ScreenRow`, etc.)
- Implement `GhosttyPane` — a complete `TerminalBackend` backed by libghostty-vt + portable-pty, gated behind `--features libghostty`
- All trait methods have real implementations: screen text, cell-level rendering, notifications (bell/title), line reading, search, resize, focus, etc.
- 13 integration tests + 2 runnable examples (`ghostty_smoke`, `backend_compare`)

## Test plan

- [x] `cargo fmt --check && cargo clippy --workspace -- -D warnings && cargo test --workspace` — all 138 tests pass
- [x] `cargo test -p amux-term --features libghostty --test ghostty_integration --test-threads=1` — all 13 ghostty tests pass
- [x] `cargo run -p amux-term --features libghostty --example backend_compare` — side-by-side wezterm vs ghostty output
- [ ] Verify default build (no `libghostty` feature) is completely unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selectable Ghostty terminal backend and unified backend abstraction; backend configurable via new option and gated by a feature.
  * New runnable examples to exercise and compare backends.

* **Bug Fixes**
  * Improved scrollback, selection/copy text extraction, cursor rendering, and hyperlink hover/click handling (safer link opening).

* **Tests**
  * Added integration tests validating the new backend and backend trait behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->