### PR TITLE
Visual polish for tabs, theme, and cell width accuracy

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1208,11 +1208,11 @@ impl AmuxApp {
         let pane_u64 = pane_id;
         let ring_rect = rect.shrink(2.0);
 
+        // Fetch pane state once; used for both flash detection and animation.
+        let pane_state = self.notifications.pane_state(pane_u64);
         // Is a flash animation currently running? (used to suppress the
         // persistent ring so the two don't double-stroke the same path)
-        let flash_active = self
-            .notifications
-            .pane_state(pane_u64)
+        let flash_active = pane_state
             .and_then(|s| s.flash_started_at)
             .is_some_and(|started| started.elapsed().as_secs_f32() < FLASH_DURATION);
 
@@ -1230,7 +1230,7 @@ impl AmuxApp {
         }
 
         // 2. Flash animation (on ANY pane including focused)
-        if let Some(state) = self.notifications.pane_state(pane_u64) {
+        if let Some(state) = pane_state {
             if let Some(started) = state.flash_started_at {
                 let elapsed = started.elapsed().as_secs_f32();
                 if elapsed < FLASH_DURATION {

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -803,7 +803,7 @@ impl AmuxApp {
                     .user_title
                     .as_deref()
                     .unwrap_or_else(|| surface.pane.title());
-                let title = if raw_title.is_empty() || raw_title == "?" {
+                let raw = if raw_title.is_empty() || raw_title == "?" {
                     // Fall back to working directory path.
                     surface
                         .metadata
@@ -825,11 +825,17 @@ impl AmuxApp {
                             p.to_string()
                         })
                         .unwrap_or_else(|| "Tab".to_string())
-                } else if raw_title.chars().count() > 20 {
-                    let prefix: String = raw_title.chars().take(17).collect();
-                    format!("{prefix}...")
                 } else {
                     raw_title.to_string()
+                };
+                // Cap at 20 chars for any title source — long cwd paths would
+                // otherwise overflow the TAB_MAX_WIDTH-clamped tab and overlap
+                // neighbors. Ellipsize with "..." when truncated.
+                let title = if raw.chars().count() > 20 {
+                    let prefix: String = raw.chars().take(17).collect();
+                    format!("{prefix}...")
+                } else {
+                    raw
                 };
                 let label = format!("{tab_icon}{title}");
 

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -78,7 +78,9 @@ fn get_cwd_from_pid(pid: u32) -> Option<String> {
 }
 
 const DEFAULT_SIDEBAR_WIDTH: f32 = 200.0;
-const TAB_BAR_HEIGHT: f32 = 24.0;
+const TAB_BAR_HEIGHT: f32 = 26.0;
+const TAB_MIN_WIDTH: f32 = 100.0;
+const TAB_MAX_WIDTH: f32 = 240.0;
 /// Content top inset: tab bar height + 1px border between tab bar and content.
 const TAB_CONTENT_TOP_INSET: f32 = TAB_BAR_HEIGHT + 1.0;
 /// Visual padding above the tab bar. On macOS with fullSizeContentView,
@@ -775,8 +777,8 @@ impl AmuxApp {
             painter.hline(tab_rect.x_range(), tab_rect.max.y, bar_stroke);
 
             let active_idx = managed.active_surface_idx;
-            let tab_font = egui::FontId::proportional(11.0);
-            let tab_font_bold = fonts::bold_font(11.0);
+            let tab_font = egui::FontId::proportional(11.5);
+            let tab_icon = ">_ ";
             let mut x = tab_rect.min.x + 2.0;
 
             // Get pointer state for hover detection and drag
@@ -801,19 +803,34 @@ impl AmuxApp {
                     .user_title
                     .as_deref()
                     .unwrap_or_else(|| surface.pane.title());
-                let label = if raw_title.is_empty() {
-                    format!("tab {}", surface.id + 1)
+                let title = if raw_title.is_empty() || raw_title == "?" {
+                    // Fall back to working directory path.
+                    surface
+                        .metadata
+                        .cwd
+                        .as_deref()
+                        .map(|p| {
+                            // Replace home dir prefix with ~
+                            if let Some(home) = dirs::home_dir() {
+                                if let Some(rest) = p.strip_prefix(home.to_str().unwrap_or("")) {
+                                    return format!("~{rest}");
+                                }
+                            }
+                            p.to_string()
+                        })
+                        .unwrap_or_else(|| "Tab".to_string())
                 } else if raw_title.chars().count() > 20 {
                     let prefix: String = raw_title.chars().take(17).collect();
                     format!("{prefix}...")
                 } else {
                     raw_title.to_string()
                 };
+                let label = format!("{tab_icon}{title}");
 
                 let text_galley =
                     painter.layout_no_wrap(label.clone(), tab_font.clone(), egui::Color32::WHITE);
                 let text_width = text_galley.size().x;
-                let tab_w = (text_width + 24.0).max(120.0);
+                let tab_w = (text_width + 24.0).clamp(TAB_MIN_WIDTH, TAB_MAX_WIDTH);
 
                 let this_tab = egui::Rect::from_min_size(
                     egui::pos2(x, tab_rect.min.y),
@@ -824,9 +841,11 @@ impl AmuxApp {
                 let tab_hovered = hover_pos.is_some_and(|p| this_tab.contains(p));
 
                 let is_dead = surface.exited.is_some();
+                let is_leftmost = idx == 0;
 
                 // Tab background + border
                 let border_color = self.theme.chrome.tab_border;
+                let side_stroke = egui::Stroke::new(1.0, border_color);
                 if is_active {
                     painter.rect_filled(this_tab, 0.0, self.theme.chrome.tab_active_bg);
                     // Active highlight at the top
@@ -840,23 +859,37 @@ impl AmuxApp {
                         self.theme.chrome.accent
                     };
                     painter.rect_filled(topline, 0.0, accent);
-                }
-                // 1px border around each tab
-                painter.rect_stroke(
-                    this_tab,
-                    0.0,
-                    egui::Stroke::new(1.0, border_color),
-                    egui::StrokeKind::Outside,
-                );
-                let (text_color, text_font) = if is_dead {
-                    (egui::Color32::from_gray(80), tab_font.clone())
-                } else if is_active {
-                    (egui::Color32::WHITE, tab_font_bold.clone())
+                    // Side borders only (no bottom border — tab merges with terminal)
+                    if !is_leftmost {
+                        painter.vline(this_tab.min.x, this_tab.y_range(), side_stroke);
+                    }
+                    painter.vline(this_tab.max.x, this_tab.y_range(), side_stroke);
+                    // Paint over the tab bar bottom border so active tab merges cleanly
+                    painter.rect_filled(
+                        egui::Rect::from_min_max(
+                            egui::pos2(this_tab.min.x + 1.0, tab_rect.max.y - 1.0),
+                            egui::pos2(this_tab.max.x, tab_rect.max.y + 1.0),
+                        ),
+                        0.0,
+                        self.theme.chrome.tab_active_bg,
+                    );
                 } else {
-                    (egui::Color32::from_gray(130), tab_font.clone())
+                    // Inactive tabs: top, right, bottom borders (skip left for leftmost)
+                    painter.hline(this_tab.x_range(), this_tab.min.y, side_stroke);
+                    painter.hline(this_tab.x_range(), this_tab.max.y, side_stroke);
+                    painter.vline(this_tab.max.x, this_tab.y_range(), side_stroke);
+                    if !is_leftmost {
+                        painter.vline(this_tab.min.x, this_tab.y_range(), side_stroke);
+                    }
+                }
+                let text_color = if is_dead {
+                    egui::Color32::from_gray(80)
+                } else {
+                    egui::Color32::from_gray(180)
                 };
+                let text_font = tab_font.clone();
                 painter.text(
-                    egui::pos2(x + 6.0, tab_rect.min.y + 5.0),
+                    egui::pos2(x + 6.0, tab_rect.min.y + 6.0),
                     egui::Align2::LEFT_TOP,
                     &label,
                     text_font,

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1196,8 +1196,16 @@ impl AmuxApp {
         let pane_u64 = pane_id;
         let ring_rect = rect.shrink(2.0);
 
-        // 1. Persistent unread ring (NOT on focused pane)
-        if !is_focused && self.notifications.pane_unread(pane_u64) > 0 {
+        // Is a flash animation currently running? (used to suppress the
+        // persistent ring so the two don't double-stroke the same path)
+        let flash_active = self
+            .notifications
+            .pane_state(pane_u64)
+            .and_then(|s| s.flash_started_at)
+            .is_some_and(|started| started.elapsed().as_secs_f32() < FLASH_DURATION);
+
+        // 1. Persistent unread ring (NOT on focused pane, NOT during flash)
+        if !is_focused && !flash_active && self.notifications.pane_unread(pane_u64) > 0 {
             // Steady blue ring with glow
             let ring_color = egui::Color32::from_rgba_unmultiplied(40, 120, 255, 89); // 0.35 * 255
             ui.painter().rect_stroke(
@@ -1221,9 +1229,12 @@ impl AmuxApp {
                     };
                     let glow_alpha = (alpha * 0.6 * 255.0) as u8;
                     let ring_alpha = (alpha * 255.0) as u8;
-                    // Glow (wider, more transparent)
+                    // Glow (wider, more transparent). Anchor on ring_rect with
+                    // Outside kind so it butts up directly against the inner ring
+                    // at the ring_rect boundary — any gap or expansion leaves a
+                    // visible 1px dark line where the terminal bg shows through.
                     ui.painter().rect_stroke(
-                        ring_rect.expand(1.0),
+                        ring_rect,
                         6.0,
                         egui::Stroke::new(
                             4.0,

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -810,10 +810,16 @@ impl AmuxApp {
                         .cwd
                         .as_deref()
                         .map(|p| {
-                            // Replace home dir prefix with ~
+                            // Replace home-dir prefix with ~ using path semantics
+                            // (string strip_prefix would match partial components
+                            // like "/home/dave" vs "/home/dave2").
                             if let Some(home) = dirs::home_dir() {
-                                if let Some(rest) = p.strip_prefix(home.to_str().unwrap_or("")) {
-                                    return format!("~{rest}");
+                                let path = std::path::Path::new(p);
+                                if let Ok(rest) = path.strip_prefix(&home) {
+                                    if rest.as_os_str().is_empty() {
+                                        return "~".to_string();
+                                    }
+                                    return format!("~/{}", rest.to_string_lossy());
                                 }
                             }
                             p.to_string()

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -25,7 +25,7 @@ pub(crate) struct TerminalColors {
 #[derive(Debug, Clone)]
 pub(crate) struct ChromeColors {
     pub sidebar_bg: Color32,
-    /// Active/selected row background in the sidebar.
+    /// Active/selected row background in the sidebar (derived from accent).
     pub sidebar_active_bg: Color32,
     /// Tab bar background. Falls back to terminal background when `None`.
     pub tab_bar_bg: Option<Color32>,
@@ -145,16 +145,17 @@ impl Theme {
 
         // Derive chrome colors from terminal background for a cohesive look.
         let [br, bg, bb] = terminal.background;
+        let accent = default.chrome.accent;
         let chrome = ChromeColors {
             sidebar_bg: darken_rgb(br, bg, bb, 0.15),
-            sidebar_active_bg: lighten_rgb(br, bg, bb, 0.25),
+            sidebar_active_bg: accent,
             tab_bar_bg: None, // falls back to terminal background
             titlebar_bg: None,
-            tab_active_bg: lighten_rgb(br, bg, bb, 0.08),
+            tab_active_bg: Color32::from_rgb(br, bg, bb), // match terminal background
             tab_bar_border: lighten_rgb(br, bg, bb, 0.15),
             tab_border: lighten_rgb(br, bg, bb, 0.15),
             divider: lighten_rgb(br, bg, bb, 0.18),
-            accent: default.chrome.accent, // keep accent color
+            accent,
         };
 
         Self { terminal, chrome }
@@ -213,10 +214,10 @@ impl Default for Theme {
             },
             chrome: ChromeColors {
                 sidebar_bg: Color32::from_gray(35),
-                sidebar_active_bg: Color32::from_rgb(24, 64, 120),
+                sidebar_active_bg: Color32::from_rgb(0, 145, 255), // same as accent
                 tab_bar_bg: None,  // falls back to terminal background
                 titlebar_bg: None, // falls back to tab bar background
-                tab_active_bg: Color32::from_rgb(0x24, 0x28, 0x3b), // Tokyo Night Storm
+                tab_active_bg: Color32::from_rgb(0x1a, 0x1b, 0x26), // match terminal bg
                 tab_bar_border: Color32::from_gray(55),
                 tab_border: Color32::from_gray(55),
                 divider: Color32::from_gray(60),

--- a/crates/amux-ghostty-config/src/lib.rs
+++ b/crates/amux-ghostty-config/src/lib.rs
@@ -201,9 +201,12 @@ fn config_search_paths() -> Vec<PathBuf> {
         paths.push(config_dir.join("ghostty").join("config"));
     }
 
-    // macOS: ~/Library/Application Support/com.mitchellh.ghostty/config
+    // macOS: Ghostty also reads ~/.config/ghostty/config (XDG path), and most
+    // users put their config there — but on macOS `dirs::config_dir()` returns
+    // `~/Library/Application Support`, so the XDG path isn't covered above.
     #[cfg(target_os = "macos")]
     if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(".config").join("ghostty").join("config"));
         paths.push(
             home.join("Library")
                 .join("Application Support")
@@ -243,6 +246,12 @@ fn load_theme(name: &str, config_dir: Option<&Path>) -> Option<GhosttyConfig> {
     // macOS themes directory
     #[cfg(target_os = "macos")]
     if let Some(home) = dirs::home_dir() {
+        search.push(
+            home.join(".config")
+                .join("ghostty")
+                .join("themes")
+                .join(name),
+        );
         search.push(
             home.join("Library")
                 .join("Application Support")

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -57,9 +57,10 @@ impl GpuRenderer {
         let font_size = font_config.size;
         let line_height = (font_size * 1.3).ceil();
         let metrics = Metrics::new(font_size, line_height);
-        // Ceil cell width to an integer pixel to prevent hairline gaps between
-        // adjacent cells caused by fractional coordinates accumulating rounding errors.
-        let cell_width = font::measure_cell_width(&mut font_system, metrics).ceil();
+        // Use raw fractional advance width — no logical-pixel rounding.
+        // Ghostty rounds only after DPI scaling; rounding at logical size
+        // either inflates (ceil) or clips (round) the grid.
+        let cell_width = font::measure_cell_width(&mut font_system, metrics);
         let cell_height = line_height;
         let decoration_metrics = font::measure_decoration_metrics(&mut font_system, font_size);
 
@@ -147,7 +148,7 @@ impl GpuRenderer {
             .callback_resources
             .get_mut::<TerminalGpuResources>()
         {
-            let cell_width = font::measure_cell_width(&mut r.font_system, metrics).ceil();
+            let cell_width = font::measure_cell_width(&mut r.font_system, metrics);
             r.metrics = metrics;
             r.decoration_metrics = font::measure_decoration_metrics(&mut r.font_system, font_size);
             // Clear all pane render states to force full rebuild with new metrics.

--- a/crates/amux-render-soft/src/lib.rs
+++ b/crates/amux-render-soft/src/lib.rs
@@ -44,7 +44,10 @@ impl SoftRenderer {
         let line_height = (font_size * 1.3).ceil();
         let metrics = Metrics::new(font_size, line_height);
 
-        let cell_width = font::measure_cell_width(&mut font_system, metrics);
+        // Soft renderer does integer pixel math (i32 casts per column), so
+        // accumulation of fractional widths would cause gaps/overlaps. Round
+        // up to whole pixels here; the GPU path keeps the fractional value.
+        let cell_width = font::measure_cell_width(&mut font_system, metrics).ceil();
         let cell_height = line_height;
 
         Self {

--- a/crates/amux-render-soft/src/lib.rs
+++ b/crates/amux-render-soft/src/lib.rs
@@ -44,7 +44,7 @@ impl SoftRenderer {
         let line_height = (font_size * 1.3).ceil();
         let metrics = Metrics::new(font_size, line_height);
 
-        let cell_width = font::measure_cell_width(&mut font_system, metrics).ceil();
+        let cell_width = font::measure_cell_width(&mut font_system, metrics);
         let cell_height = line_height;
 
         Self {

--- a/crates/amux-term/src/font.rs
+++ b/crates/amux-term/src/font.rs
@@ -93,29 +93,36 @@ pub fn create_font_system(config: &FontConfig) -> FontSystem {
     font_system
 }
 
-/// Measure the width of a single monospace cell by laying out "M" with
-/// cosmic-text and reading the glyph advance. Falls back to `font_size * 0.6`.
+/// Measure the width of a single monospace cell by finding the maximum advance
+/// width across all printable ASCII glyphs (0x20..=0x7E), matching Ghostty's
+/// approach. Falls back to `font_size * 0.6`.
 pub fn measure_cell_width(font_system: &mut FontSystem, metrics: Metrics) -> f32 {
-    let mut buffer = Buffer::new_empty(metrics);
-    {
-        let mut borrowed = buffer.borrow_with(font_system);
-        borrowed.set_size(Some(200.0), Some(metrics.line_height));
-        borrowed.set_text(
-            "M",
-            Attrs::new().family(Family::Monospace),
-            Shaping::Advanced,
-        );
-        borrowed.shape_until_scroll(true);
-    }
+    let attrs = Attrs::new().family(Family::Monospace);
+    let mut max_width: f32 = 0.0;
 
-    for run in buffer.layout_runs() {
-        if let Some(glyph) = run.glyphs.iter().next() {
-            return glyph.w;
+    // Measure each printable ASCII character individually to find the widest.
+    for ch in ' '..='~' {
+        let mut buf = Buffer::new_empty(metrics);
+        {
+            let mut borrowed = buf.borrow_with(font_system);
+            borrowed.set_size(Some(200.0), Some(metrics.line_height));
+            let s: String = ch.to_string();
+            borrowed.set_text(&s, attrs, Shaping::Advanced);
+            borrowed.shape_until_scroll(true);
+        }
+        for run in buf.layout_runs() {
+            if let Some(glyph) = run.glyphs.first() {
+                max_width = max_width.max(glyph.w);
+            }
         }
     }
 
-    // Fallback: estimate from font size
-    metrics.font_size * 0.6
+    if max_width > 0.0 {
+        max_width
+    } else {
+        // Fallback: estimate from font size
+        metrics.font_size * 0.6
+    }
 }
 
 /// Extract decoration metrics (underline/strikethrough position and thickness)

--- a/crates/amux-term/src/font.rs
+++ b/crates/amux-term/src/font.rs
@@ -100,20 +100,20 @@ pub fn measure_cell_width(font_system: &mut FontSystem, metrics: Metrics) -> f32
     let attrs = Attrs::new().family(Family::Monospace);
     let mut max_width: f32 = 0.0;
 
-    // Measure each printable ASCII character individually to find the widest.
-    for ch in ' '..='~' {
-        let mut buf = Buffer::new_empty(metrics);
-        {
-            let mut borrowed = buf.borrow_with(font_system);
-            borrowed.set_size(Some(200.0), Some(metrics.line_height));
-            let s: String = ch.to_string();
-            borrowed.set_text(&s, attrs, Shaping::Advanced);
-            borrowed.shape_until_scroll(true);
-        }
-        for run in buf.layout_runs() {
-            if let Some(glyph) = run.glyphs.first() {
-                max_width = max_width.max(glyph.w);
-            }
+    // Shape all printable ASCII at once and find the widest laid-out glyph.
+    // Preserves the "max advance" behavior without per-character allocations.
+    const PRINTABLE_ASCII: &str =
+        " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+    let mut buf = Buffer::new_empty(metrics);
+    {
+        let mut borrowed = buf.borrow_with(font_system);
+        borrowed.set_size(Some(f32::INFINITY), Some(metrics.line_height));
+        borrowed.set_text(PRINTABLE_ASCII, attrs, Shaping::Advanced);
+        borrowed.shape_until_scroll(true);
+    }
+    for run in buf.layout_runs() {
+        for glyph in run.glyphs.iter() {
+            max_width = max_width.max(glyph.w);
         }
     }
 


### PR DESCRIPTION
## Summary

- **Tabs**: Active tab merges with terminal (no bottom border, matching background); leftmost tab drops its left border; all tabs share the same text color/weight matching cmux's subtler active-tab treatment; added `>_` icon prefix; tab titles fall back to full cwd path with `~/` prefix when the shell hasn't yet sent an OSC title (e.g. on restored sessions before first prompt).
- **Theme**: Sidebar active workspace highlight now uses the same `accent` color as the tab top-line, so changing one changes both.
- **Cell width accuracy**: Fixed a latent rendering bug where `ceil()` on fractional glyph advance widths was stretching every character cell by up to ~14% depending on the font. For example, Menlo 12pt has a 7.22px advance width but `ceil()` produced 8px cells — a 10.7% horizontal stretch across every column. Now keeps the fractional advance width in logical space (Ghostty's approach) and measures max advance across printable ASCII instead of only 'M'.
- **Notification ring artifact**: Fixed a 1px dark line tracing the notification ring. Two causes: (1) during flash animation the persistent unread ring and flash ring double-stroked the same path — suppress the persistent ring while flash is active; (2) the flash glow was drawn Outside of `ring_rect.expand(1.0)` while the inner ring was drawn Inside of `ring_rect`, leaving a 1px gap where the terminal bg showed through — anchor the glow on `ring_rect` so it butts directly against the inner ring.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [ ] Side-by-side visual comparison with cmux — tab spacing and character spacing should now match
- [ ] Try multiple fonts (Menlo, IBM Plex Mono, JetBrains Mono) — no more clipping or over-spacing
- [ ] Restored session still shows cwd as tab title until first OSC 0/2
- [ ] Changing the accent color updates both sidebar highlight and active tab line
- [x] Trigger a notification (`amux notify`) — ring renders clean with no dark line during flash or persistent states

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tab bar height and sizing improved; tab widths now clamp for better layout.
  * Tab labels use directory fallback with an icon prefix and refined typography/positioning.
  * Tab borders and active tab rendering refined to visually merge with content.
  * Theme colors updated for active/selected chrome elements.
  * Notification ring flash behavior adjusted to avoid double-stroking during animation.
  * Text rendering and cell-width measurement refined for more accurate layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->