### PR TITLE
Add top-left titlebar icons (sidebar/notifications/new workspace)

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -591,7 +591,7 @@ impl eframe::App for AmuxApp {
                     self.theme.titlebar_bg(),
                 );
                 // Top-left titlebar icons: sidebar toggle, notifications, new workspace.
-                self.render_titlebar_icons(ui, full_rect);
+                self.render_titlebar_icons(ui.ctx());
                 // Shift content area down by the top padding.
                 let panel_rect = egui::Rect::from_min_max(
                     egui::pos2(full_rect.min.x, full_rect.min.y + TERMINAL_TOP_PAD),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -581,11 +581,22 @@ impl eframe::App for AmuxApp {
             .frame(egui::Frame::NONE)
             .show(ctx, |ui| {
                 let full_rect = ui.available_rect_before_wrap();
-                // Paint top padding strip with titlebar color.
-                ui.painter().rect_filled(
+                // Paint the titlebar strip across the FULL viewport, not just
+                // the CentralPanel region. render_titlebar_icons draws in
+                // window coordinates starting at screen.min.x + left_inset,
+                // which on macOS (78px inset) lands over the sidebar when it
+                // is visible. Using a background layer painter on the full
+                // screen rect keeps the strip coherent regardless of sidebar
+                // state and decouples it from sidebar_bg's color.
+                let screen = ui.ctx().screen_rect();
+                let strip_painter = ui.ctx().layer_painter(egui::LayerId::new(
+                    egui::Order::Background,
+                    egui::Id::new("amux_titlebar_strip"),
+                ));
+                strip_painter.rect_filled(
                     egui::Rect::from_min_max(
-                        full_rect.min,
-                        egui::pos2(full_rect.max.x, full_rect.min.y + TERMINAL_TOP_PAD),
+                        screen.min,
+                        egui::pos2(screen.max.x, screen.min.y + TERMINAL_TOP_PAD),
                     ),
                     0.0,
                     self.theme.titlebar_bg(),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -590,8 +590,8 @@ impl eframe::App for AmuxApp {
                     0.0,
                     self.theme.titlebar_bg(),
                 );
-                // Notification bell button in the top-right of the titlebar strip.
-                self.render_notification_bell(ui, full_rect);
+                // Top-left titlebar icons: sidebar toggle, notifications, new workspace.
+                self.render_titlebar_icons(ui, full_rect);
                 // Shift content area down by the top padding.
                 let panel_rect = egui::Rect::from_min_max(
                     egui::pos2(full_rect.min.x, full_rect.min.y + TERMINAL_TOP_PAD),

--- a/crates/amux-app/src/notifications_ui.rs
+++ b/crates/amux-app/src/notifications_ui.rs
@@ -373,23 +373,29 @@ impl AmuxApp {
             })
             .collect();
 
-        // Align the panel horizontally to the bell icon's center (with
-        // clamping to keep the panel fully on-screen). Uses the shared
-        // titlebar geometry constants so the panel stays aligned if the
-        // icon row layout ever changes.
+        // Align the panel horizontally to the bell icon's center, clamping
+        // BOTH the panel dimensions and its anchor to the current viewport so
+        // the panel cannot overflow off-screen on small windows. Uses the
+        // shared titlebar geometry constants so the panel stays aligned if
+        // the icon row layout ever changes.
         let bell_center_x = titlebar_bell_center_x();
-        let panel_width = 400.0_f32;
-        let screen_w = ctx.screen_rect().width();
-        let max_left = (screen_w - panel_width - 10.0).max(10.0);
-        let panel_left = (bell_center_x - panel_width / 2.0).max(10.0).min(max_left);
+        let horizontal_margin = 10.0_f32;
+        let top_margin = TERMINAL_TOP_PAD + 4.0;
+        let bottom_margin = 10.0_f32;
+        let screen = ctx.screen_rect();
+        let panel_width = 400.0_f32.min((screen.width() - horizontal_margin * 2.0).max(0.0));
+        let panel_height = 500.0_f32.min((screen.height() - top_margin - bottom_margin).max(0.0));
+        let max_left = (screen.width() - panel_width - horizontal_margin).max(0.0);
+        let min_left = horizontal_margin.min(max_left);
+        let panel_left = (bell_center_x - panel_width / 2.0).clamp(min_left, max_left);
 
         egui::Window::new("Notifications")
             .title_bar(false)
             .movable(false)
             .collapsible(false)
             .resizable(false)
-            .default_size([panel_width, 500.0])
-            .anchor(egui::Align2::LEFT_TOP, [panel_left, TERMINAL_TOP_PAD + 4.0])
+            .fixed_size([panel_width, panel_height])
+            .anchor(egui::Align2::LEFT_TOP, [panel_left, top_margin])
             .frame(
                 egui::Frame::window(&ctx.style())
                     .fill(self.theme.chrome.sidebar_bg)

--- a/crates/amux-app/src/notifications_ui.rs
+++ b/crates/amux-app/src/notifications_ui.rs
@@ -206,56 +206,55 @@ impl AmuxApp {
         }
     }
 
-    /// Render a bell button in the top-right of the titlebar strip.
-    /// Shows an unread-count badge when there are unread notifications.
-    /// Clicking toggles the notifications panel (cmux-style popover).
-    pub(crate) fn render_notification_bell(&mut self, ui: &mut egui::Ui, full_rect: egui::Rect) {
-        let unread = self.notifications.total_unread();
-        let btn_size = egui::vec2(26.0, 22.0);
-        let margin = egui::vec2(8.0, 3.0);
-        let btn_rect = egui::Rect::from_min_size(
-            egui::pos2(
-                full_rect.max.x - btn_size.x - margin.x,
-                full_rect.min.y + margin.y,
-            ),
-            btn_size,
+    /// Render the top-left titlebar icon row: sidebar toggle, notifications bell,
+    /// and new workspace — mirroring cmux's titlebar layout.
+    pub(crate) fn render_titlebar_icons(&mut self, ui: &mut egui::Ui, full_rect: egui::Rect) {
+        let icon_size = egui::vec2(28.0, 22.0);
+        let gap = 2.0;
+        // On macOS the traffic-light buttons live in the leftmost ~76px. On
+        // Windows/Linux there are no traffic lights so the icon row starts
+        // at the left edge.
+        #[cfg(target_os = "macos")]
+        let left_inset = 78.0;
+        #[cfg(not(target_os = "macos"))]
+        let left_inset = 8.0;
+        let top_y = full_rect.min.y + 3.0;
+        let mut x = full_rect.min.x + left_inset;
+
+        // --- Sidebar toggle ---
+        let r_sidebar = egui::Rect::from_min_size(egui::pos2(x, top_y), icon_size);
+        let sidebar_on = self.sidebar.visible;
+        let resp_sidebar = draw_icon_button(
+            ui,
+            r_sidebar,
+            ui.id().with("titlebar_sidebar_btn"),
+            sidebar_on,
+            &self.theme,
+            "Toggle sidebar",
+            draw_sidebar_glyph,
         );
-
-        let id = ui.id().with("notif_bell_button");
-        let response = ui.interact(btn_rect, id, egui::Sense::click());
-        let painter = ui.painter();
-
-        // Hover/active background
-        let bg_color = if response.is_pointer_button_down_on() {
-            egui::Color32::from_white_alpha(24)
-        } else if response.hovered() {
-            egui::Color32::from_white_alpha(14)
-        } else {
-            egui::Color32::TRANSPARENT
-        };
-        if bg_color != egui::Color32::TRANSPARENT {
-            painter.rect_filled(btn_rect, 5.0, bg_color);
+        if resp_sidebar.clicked() {
+            self.sidebar.visible = !self.sidebar.visible;
         }
+        x += icon_size.x + gap;
 
-        // Bell glyph.
-        let bell_color = if self.show_notification_panel {
-            self.theme.chrome.accent
-        } else if response.hovered() {
-            egui::Color32::from_gray(230)
-        } else {
-            egui::Color32::from_gray(170)
-        };
-        painter.text(
-            btn_rect.center(),
-            egui::Align2::CENTER_CENTER,
-            "\u{1F514}", // 🔔
-            egui::FontId::proportional(13.0),
-            bell_color,
+        // --- Notifications bell ---
+        let unread = self.notifications.total_unread();
+        let r_bell = egui::Rect::from_min_size(egui::pos2(x, top_y), icon_size);
+        let bell_on = self.show_notification_panel;
+        let resp_bell = draw_icon_button(
+            ui,
+            r_bell,
+            ui.id().with("titlebar_bell_btn"),
+            bell_on,
+            &self.theme,
+            "Notifications",
+            draw_bell_glyph,
         );
-
-        // Unread badge (red dot with count).
+        // Unread badge (red dot + count).
         if unread > 0 {
-            let badge_center = egui::pos2(btn_rect.max.x - 4.0, btn_rect.min.y + 5.0);
+            let painter = ui.painter();
+            let badge_center = egui::pos2(r_bell.max.x - 5.0, r_bell.min.y + 5.0);
             let badge_radius = 6.5;
             painter.circle_filled(
                 badge_center,
@@ -281,12 +280,24 @@ impl AmuxApp {
                 egui::Color32::WHITE,
             );
         }
-
-        if response.clicked() {
+        if resp_bell.clicked() {
             self.show_notification_panel = !self.show_notification_panel;
         }
-        if response.hovered() {
-            ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+        x += icon_size.x + gap;
+
+        // --- New workspace (+) ---
+        let r_new = egui::Rect::from_min_size(egui::pos2(x, top_y), icon_size);
+        let resp_new = draw_icon_button(
+            ui,
+            r_new,
+            ui.id().with("titlebar_new_ws_btn"),
+            false,
+            &self.theme,
+            "New workspace",
+            draw_plus_glyph,
+        );
+        if resp_new.clicked() {
+            self.create_workspace(None);
         }
     }
 
@@ -448,6 +459,128 @@ impl AmuxApp {
             self.show_notification_panel = false;
         }
     }
+}
+
+/// Shared chrome for a titlebar icon button: hover/active background tint,
+/// cursor, tooltip, and a caller-supplied glyph drawer.
+fn draw_icon_button<F>(
+    ui: &mut egui::Ui,
+    rect: egui::Rect,
+    id: egui::Id,
+    active: bool,
+    theme: &theme::Theme,
+    tooltip: &str,
+    draw_glyph: F,
+) -> egui::Response
+where
+    F: FnOnce(&egui::Painter, egui::Rect, egui::Color32),
+{
+    let response = ui
+        .interact(rect, id, egui::Sense::click())
+        .on_hover_text(tooltip);
+    let painter = ui.painter();
+
+    // Background tint.
+    let bg = if response.is_pointer_button_down_on() {
+        egui::Color32::from_white_alpha(28)
+    } else if active {
+        egui::Color32::from_white_alpha(22)
+    } else if response.hovered() {
+        egui::Color32::from_white_alpha(14)
+    } else {
+        egui::Color32::TRANSPARENT
+    };
+    if bg != egui::Color32::TRANSPARENT {
+        painter.rect_filled(rect, 5.0, bg);
+    }
+
+    let color = if active {
+        theme.chrome.accent
+    } else if response.hovered() {
+        egui::Color32::from_gray(232)
+    } else {
+        egui::Color32::from_gray(170)
+    };
+    draw_glyph(painter, rect, color);
+
+    if response.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+    response
+}
+
+/// Monochrome sidebar-toggle glyph: rounded rect with a filled left column.
+fn draw_sidebar_glyph(p: &egui::Painter, rect: egui::Rect, color: egui::Color32) {
+    let gw = 14.0;
+    let gh = 11.0;
+    let origin = egui::pos2(rect.center().x - gw / 2.0, rect.center().y - gh / 2.0);
+    let outer = egui::Rect::from_min_size(origin, egui::vec2(gw, gh));
+    p.rect_stroke(
+        outer,
+        1.5,
+        egui::Stroke::new(1.4, color),
+        egui::StrokeKind::Inside,
+    );
+    // Left column separator + fill.
+    let split_x = origin.x + 4.5;
+    p.line_segment(
+        [
+            egui::pos2(split_x, origin.y),
+            egui::pos2(split_x, origin.y + gh),
+        ],
+        egui::Stroke::new(1.2, color),
+    );
+    // Two tiny dots in the left column to mimic cmux's sidebar glyph.
+    for dy in [3.0, 7.0] {
+        p.circle_filled(egui::pos2(origin.x + 2.2, origin.y + dy), 0.6, color);
+    }
+}
+
+/// Monochrome bell glyph approximating SF Symbol "bell".
+fn draw_bell_glyph(p: &egui::Painter, rect: egui::Rect, color: egui::Color32) {
+    let c = rect.center();
+    let stroke = egui::Stroke::new(1.3, color);
+    // Bell body: a rounded trapezoid, represented as an open path.
+    let top_y = c.y - 5.0;
+    let bot_y = c.y + 4.0;
+    let half_top = 3.0;
+    let half_bot = 5.5;
+    let path = vec![
+        egui::pos2(c.x - half_bot, bot_y),
+        egui::pos2(c.x - half_top, top_y + 1.0),
+        egui::pos2(c.x - half_top + 0.5, top_y - 0.5),
+        egui::pos2(c.x + half_top - 0.5, top_y - 0.5),
+        egui::pos2(c.x + half_top, top_y + 1.0),
+        egui::pos2(c.x + half_bot, bot_y),
+    ];
+    p.add(egui::Shape::line(path, stroke));
+    // Bottom rim.
+    p.line_segment(
+        [
+            egui::pos2(c.x - half_bot - 0.5, bot_y),
+            egui::pos2(c.x + half_bot + 0.5, bot_y),
+        ],
+        stroke,
+    );
+    // Clapper.
+    p.circle_filled(egui::pos2(c.x, bot_y + 2.2), 1.1, color);
+    // Top cap.
+    p.circle_filled(egui::pos2(c.x, top_y - 1.0), 0.9, color);
+}
+
+/// Monochrome plus glyph.
+fn draw_plus_glyph(p: &egui::Painter, rect: egui::Rect, color: egui::Color32) {
+    let c = rect.center();
+    let arm = 6.0;
+    let stroke = egui::Stroke::new(1.5, color);
+    p.line_segment(
+        [egui::pos2(c.x - arm, c.y), egui::pos2(c.x + arm, c.y)],
+        stroke,
+    );
+    p.line_segment(
+        [egui::pos2(c.x, c.y - arm), egui::pos2(c.x, c.y + arm)],
+        stroke,
+    );
 }
 
 enum RowAction {

--- a/crates/amux-app/src/notifications_ui.rs
+++ b/crates/amux-app/src/notifications_ui.rs
@@ -207,8 +207,10 @@ impl AmuxApp {
     }
 
     /// Render the top-left titlebar icon row: sidebar toggle, notifications bell,
-    /// and new workspace — mirroring cmux's titlebar layout.
-    pub(crate) fn render_titlebar_icons(&mut self, ui: &mut egui::Ui, full_rect: egui::Rect) {
+    /// and new workspace — mirroring cmux's titlebar layout. The icons are
+    /// anchored to the window's absolute top-left so they stay put regardless
+    /// of sidebar visibility.
+    pub(crate) fn render_titlebar_icons(&mut self, ctx: &egui::Context) {
         let icon_size = egui::vec2(28.0, 22.0);
         let gap = 2.0;
         // On macOS the traffic-light buttons live in the leftmost ~76px. On
@@ -218,19 +220,36 @@ impl AmuxApp {
         let left_inset = 78.0;
         #[cfg(not(target_os = "macos"))]
         let left_inset = 8.0;
-        let top_y = full_rect.min.y + 3.0;
-        let mut x = full_rect.min.x + left_inset;
+        let screen = ctx.screen_rect();
+        let top_y = screen.min.y + 3.0;
+        let origin_x = screen.min.x + left_inset;
+
+        egui::Area::new(egui::Id::new("amux_titlebar_icons"))
+            .order(egui::Order::Foreground)
+            .fixed_pos(egui::pos2(origin_x, top_y))
+            .show(ctx, |ui| {
+                self.render_titlebar_icons_inner(ui, icon_size, gap);
+            });
+    }
+
+    fn render_titlebar_icons_inner(&mut self, ui: &mut egui::Ui, icon_size: egui::Vec2, gap: f32) {
+        let origin = ui.min_rect().min;
+        let top_y = origin.y;
+        let mut x = origin.x;
+
+        // Platform-specific shortcut labels.
+        #[cfg(target_os = "macos")]
+        let (sc_sidebar, sc_notif, sc_new) = ("⌘B", "⌘I", "⌘N");
+        #[cfg(not(target_os = "macos"))]
+        let (sc_sidebar, sc_notif, sc_new) = ("Ctrl+B", "Ctrl+I", "Ctrl+Shift+N");
 
         // --- Sidebar toggle ---
         let r_sidebar = egui::Rect::from_min_size(egui::pos2(x, top_y), icon_size);
-        let sidebar_on = self.sidebar.visible;
         let resp_sidebar = draw_icon_button(
             ui,
             r_sidebar,
             ui.id().with("titlebar_sidebar_btn"),
-            sidebar_on,
-            &self.theme,
-            "Toggle sidebar",
+            &format!("Toggle sidebar  ({sc_sidebar})"),
             draw_sidebar_glyph,
         );
         if resp_sidebar.clicked() {
@@ -241,14 +260,11 @@ impl AmuxApp {
         // --- Notifications bell ---
         let unread = self.notifications.total_unread();
         let r_bell = egui::Rect::from_min_size(egui::pos2(x, top_y), icon_size);
-        let bell_on = self.show_notification_panel;
         let resp_bell = draw_icon_button(
             ui,
             r_bell,
             ui.id().with("titlebar_bell_btn"),
-            bell_on,
-            &self.theme,
-            "Notifications",
+            &format!("Notifications  ({sc_notif})"),
             draw_bell_glyph,
         );
         // Unread badge (red dot + count).
@@ -291,9 +307,7 @@ impl AmuxApp {
             ui,
             r_new,
             ui.id().with("titlebar_new_ws_btn"),
-            false,
-            &self.theme,
-            "New workspace",
+            &format!("New workspace  ({sc_new})"),
             draw_plus_glyph,
         );
         if resp_new.clicked() {
@@ -334,13 +348,28 @@ impl AmuxApp {
             })
             .collect();
 
+        // Align the panel horizontally to the bell icon's center (with
+        // clamping to keep the panel fully on-screen).
+        #[cfg(target_os = "macos")]
+        let titlebar_left_inset: f32 = 78.0;
+        #[cfg(not(target_os = "macos"))]
+        let titlebar_left_inset: f32 = 8.0;
+        let icon_w = 28.0_f32;
+        let icon_gap = 2.0_f32;
+        // Bell is the 2nd icon: sidebar, bell, plus.
+        let bell_center_x = titlebar_left_inset + icon_w + icon_gap + icon_w / 2.0;
+        let panel_width = 400.0_f32;
+        let screen_w = ctx.screen_rect().width();
+        let max_left = (screen_w - panel_width - 10.0).max(10.0);
+        let panel_left = (bell_center_x - panel_width / 2.0).max(10.0).min(max_left);
+
         egui::Window::new("Notifications")
             .title_bar(false)
             .movable(false)
             .collapsible(false)
             .resizable(true)
-            .default_size([400.0, 500.0])
-            .anchor(egui::Align2::RIGHT_TOP, [-10.0, TERMINAL_TOP_PAD + 4.0])
+            .default_size([panel_width, 500.0])
+            .anchor(egui::Align2::LEFT_TOP, [panel_left, TERMINAL_TOP_PAD + 4.0])
             .frame(
                 egui::Frame::window(&ctx.style())
                     .fill(self.theme.chrome.sidebar_bg)
@@ -461,46 +490,31 @@ impl AmuxApp {
     }
 }
 
-/// Shared chrome for a titlebar icon button: hover/active background tint,
-/// cursor, tooltip, and a caller-supplied glyph drawer.
+/// Shared chrome for a titlebar icon button: cursor, tooltip, and a
+/// caller-supplied glyph drawer. Intentionally flat — no hover/active tint.
 fn draw_icon_button<F>(
     ui: &mut egui::Ui,
     rect: egui::Rect,
     id: egui::Id,
-    active: bool,
-    theme: &theme::Theme,
     tooltip: &str,
     draw_glyph: F,
 ) -> egui::Response
 where
     F: FnOnce(&egui::Painter, egui::Rect, egui::Color32),
 {
+    // Expand the ui's min_rect to include this widget so egui's tooltip
+    // system can position hover text correctly.
+    ui.expand_to_include_rect(rect);
+    // NOTE: global style sets widget fg_stroke to TRANSPARENT (to hide panel
+    // resize handles), so default tooltip text would be invisible. Use an
+    // explicit color via RichText.
+    let tooltip_text = egui::RichText::new(tooltip).color(egui::Color32::from_gray(220));
     let response = ui
         .interact(rect, id, egui::Sense::click())
-        .on_hover_text(tooltip);
+        .on_hover_text(tooltip_text);
     let painter = ui.painter();
 
-    // Background tint.
-    let bg = if response.is_pointer_button_down_on() {
-        egui::Color32::from_white_alpha(28)
-    } else if active {
-        egui::Color32::from_white_alpha(22)
-    } else if response.hovered() {
-        egui::Color32::from_white_alpha(14)
-    } else {
-        egui::Color32::TRANSPARENT
-    };
-    if bg != egui::Color32::TRANSPARENT {
-        painter.rect_filled(rect, 5.0, bg);
-    }
-
-    let color = if active {
-        theme.chrome.accent
-    } else if response.hovered() {
-        egui::Color32::from_gray(232)
-    } else {
-        egui::Color32::from_gray(170)
-    };
+    let color = egui::Color32::from_gray(170);
     draw_glyph(painter, rect, color);
 
     if response.hovered() {

--- a/crates/amux-app/src/notifications_ui.rs
+++ b/crates/amux-app/src/notifications_ui.rs
@@ -2,6 +2,38 @@
 
 use crate::*;
 
+// --- Shared titlebar icon-row geometry -------------------------------------
+// These constants describe the fixed-position icon row in the titlebar and
+// are referenced by both the icon renderer and the notifications panel so
+// that the panel always anchors on the actual bell-icon center.
+
+const TITLEBAR_ICON_W: f32 = 28.0;
+const TITLEBAR_ICON_H: f32 = 22.0;
+const TITLEBAR_ICON_GAP: f32 = 2.0;
+/// Index of the bell in the icon row: sidebar(0), bell(1), plus(2).
+const TITLEBAR_BELL_INDEX: usize = 1;
+
+/// Left inset before the first icon. On macOS we reserve space for the
+/// native traffic-light buttons; on other platforms the row hugs the edge.
+fn titlebar_left_inset() -> f32 {
+    #[cfg(target_os = "macos")]
+    {
+        78.0
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        8.0
+    }
+}
+
+/// Horizontal center of the bell icon in screen-local x coordinates,
+/// relative to the window's left edge.
+fn titlebar_bell_center_x() -> f32 {
+    titlebar_left_inset()
+        + (TITLEBAR_BELL_INDEX as f32) * (TITLEBAR_ICON_W + TITLEBAR_ICON_GAP)
+        + TITLEBAR_ICON_W / 2.0
+}
+
 impl AmuxApp {
     pub(crate) fn drain_notifications(&mut self) {
         // Collect events first to avoid borrow conflicts
@@ -211,18 +243,11 @@ impl AmuxApp {
     /// anchored to the window's absolute top-left so they stay put regardless
     /// of sidebar visibility.
     pub(crate) fn render_titlebar_icons(&mut self, ctx: &egui::Context) {
-        let icon_size = egui::vec2(28.0, 22.0);
-        let gap = 2.0;
-        // On macOS the traffic-light buttons live in the leftmost ~76px. On
-        // Windows/Linux there are no traffic lights so the icon row starts
-        // at the left edge.
-        #[cfg(target_os = "macos")]
-        let left_inset = 78.0;
-        #[cfg(not(target_os = "macos"))]
-        let left_inset = 8.0;
+        let icon_size = egui::vec2(TITLEBAR_ICON_W, TITLEBAR_ICON_H);
+        let gap = TITLEBAR_ICON_GAP;
         let screen = ctx.screen_rect();
         let top_y = screen.min.y + 3.0;
-        let origin_x = screen.min.x + left_inset;
+        let origin_x = screen.min.x + titlebar_left_inset();
 
         egui::Area::new(egui::Id::new("amux_titlebar_icons"))
             .order(egui::Order::Foreground)
@@ -349,15 +374,10 @@ impl AmuxApp {
             .collect();
 
         // Align the panel horizontally to the bell icon's center (with
-        // clamping to keep the panel fully on-screen).
-        #[cfg(target_os = "macos")]
-        let titlebar_left_inset: f32 = 78.0;
-        #[cfg(not(target_os = "macos"))]
-        let titlebar_left_inset: f32 = 8.0;
-        let icon_w = 28.0_f32;
-        let icon_gap = 2.0_f32;
-        // Bell is the 2nd icon: sidebar, bell, plus.
-        let bell_center_x = titlebar_left_inset + icon_w + icon_gap + icon_w / 2.0;
+        // clamping to keep the panel fully on-screen). Uses the shared
+        // titlebar geometry constants so the panel stays aligned if the
+        // icon row layout ever changes.
+        let bell_center_x = titlebar_bell_center_x();
         let panel_width = 400.0_f32;
         let screen_w = ctx.screen_rect().width();
         let max_left = (screen_w - panel_width - 10.0).max(10.0);
@@ -367,7 +387,7 @@ impl AmuxApp {
             .title_bar(false)
             .movable(false)
             .collapsible(false)
-            .resizable(true)
+            .resizable(false)
             .default_size([panel_width, 500.0])
             .anchor(egui::Align2::LEFT_TOP, [panel_left, TERMINAL_TOP_PAD + 4.0])
             .frame(

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -13,8 +13,6 @@ const ROW_HOVER_BG: Color32 = Color32::from_rgba_premultiplied(15, 15, 15, 15);
 const TEXT_ACTIVE: Color32 = Color32::WHITE;
 const TEXT_INACTIVE: Color32 = Color32::from_gray(180);
 const BADGE_ACTIVE_BG: Color32 = Color32::from_rgba_premultiplied(64, 64, 64, 64);
-const NEW_BTN_TEXT: Color32 = Color32::from_gray(140);
-const NEW_BTN_HOVER: Color32 = Color32::from_rgba_premultiplied(15, 15, 15, 15);
 const CLOSE_BTN_COLOR: Color32 = Color32::from_rgba_premultiplied(140, 140, 140, 179);
 const PROGRESS_TRACK: Color32 = Color32::from_rgba_premultiplied(20, 20, 20, 20);
 
@@ -195,34 +193,8 @@ pub(crate) fn render_sidebar(
                             .rect_filled(indicator_rect, 1.0, theme.chrome.accent);
                     }
 
-                    ui.add_space(8.0);
-
-                    // "+ New Workspace" button
-                    let avail_w = ui.available_width();
-                    let (btn_rect, btn_response) =
-                        ui.allocate_exact_size(egui::vec2(avail_w, 28.0), egui::Sense::click());
-                    if ui.is_rect_visible(btn_rect) {
-                        if btn_response.hovered() {
-                            ui.painter()
-                                .rect_filled(btn_rect, ROW_CORNER_RADIUS, NEW_BTN_HOVER);
-                        }
-                        ui.painter().text(
-                            btn_rect.center(),
-                            egui::Align2::CENTER_CENTER,
-                            "+ New Workspace",
-                            egui::FontId::proportional(11.0),
-                            if btn_response.hovered() {
-                                TEXT_INACTIVE
-                            } else {
-                                NEW_BTN_TEXT
-                            },
-                        );
-                    }
-                    if btn_response.clicked() {
-                        actions.push(SidebarAction::CreateWorkspace);
-                    }
-
                     // Fill remaining space (double-click to create workspace)
+                    let avail_w = ui.available_width();
                     let remaining = ui.available_height().max(0.0);
                     if remaining > 0.0 {
                         let (_, empty_response) = ui.allocate_exact_size(


### PR DESCRIPTION
## Summary
- Adds three top-left titlebar icons matching cmux's layout: sidebar toggle, notifications bell (with unread badge), and new workspace (+).
- Icons are anchored to absolute window coordinates so they stay put regardless of sidebar visibility.
- Monochrome glyphs drawn via egui painter primitives; flat styling, no hover/active color change.
- Tooltips show the action + keyboard shortcut (⌘B / ⌘I / ⌘N on macOS, Ctrl equivalents elsewhere). Explicit RichText color works around the global style that sets widget fg_stroke to TRANSPARENT.
- Notifications overlay now centers horizontally on the bell icon (clamped on-screen).
- Removes the now-redundant \"+ New Workspace\" button from the sidebar (double-click-to-create on empty space is preserved).

Closes #82.

## Test plan
- [ ] Verify the three icons render in the top-left titlebar, offset right of macOS traffic lights.
- [ ] Toggle sidebar via the icon and via ⌘B — icons stay in place either way.
- [ ] Click the bell — panel opens horizontally centered on the bell.
- [ ] Hover each icon — tooltip shows label + shortcut.
- [ ] Click + — new workspace is created.
- [ ] Unread notifications show the red badge on the bell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a left-side titlebar icon row: sidebar toggle, notifications bell (with badge), and a + button to create workspaces.
  * Notifications panel now anchors to the bell and uses a fixed, non-resizable size.

* **Bug Fixes / Improvements**
  * Titlebar background painting extended to the full top area for consistent appearance.
  * Removed the separate “+ New Workspace” button from the sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->