### PR TITLE
Extract instance vertex types to quad.rs (refs #88)

### DIFF
--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -4,6 +4,7 @@ mod color;
 mod custom_glyphs;
 mod decorations;
 mod pipeline;
+mod quad;
 mod resources;
 mod screen_line;
 mod shape;

--- a/crates/amux-render-gpu/src/pipeline.rs
+++ b/crates/amux-render-gpu/src/pipeline.rs
@@ -1,17 +1,7 @@
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
-/// Per-cell background instance data.
-#[repr(C)]
-#[derive(Copy, Clone, Pod, Zeroable)]
-pub struct CellBgInstance {
-    /// Cell position in physical pixels (top-left corner).
-    pub pos: [f32; 2],
-    /// Cell size in physical pixels.
-    pub size: [f32; 2],
-    /// Background color (sRGB or linear RGBA, depending on render target format).
-    pub color: [f32; 4],
-}
+use crate::quad::{CellBgInstance, CellFgInstance, ImageQuadInstance};
 
 /// Viewport uniform data.
 #[repr(C)]
@@ -209,25 +199,6 @@ impl BackgroundPipeline {
 // ---------------------------------------------------------------------------
 // Foreground pipeline (textured glyph quads)
 // ---------------------------------------------------------------------------
-
-/// Per-glyph foreground instance data.
-#[repr(C)]
-#[derive(Copy, Clone, Pod, Zeroable)]
-pub struct CellFgInstance {
-    /// Glyph position in physical pixels (top-left corner).
-    pub pos: [f32; 2],
-    /// Glyph size in physical pixels.
-    pub size: [f32; 2],
-    /// Atlas UV min (top-left).
-    pub uv_min: [f32; 2],
-    /// Atlas UV max (bottom-right).
-    pub uv_max: [f32; 2],
-    /// Foreground color (sRGB or linear RGBA, depending on render target format).
-    pub color: [f32; 4],
-    /// 1.0 for color emoji, 0.0 for monochrome glyphs.
-    pub is_color: f32,
-    pub _pad: [f32; 3],
-}
 
 /// Foreground rendering pipeline: instanced textured quads for glyphs.
 ///
@@ -483,20 +454,6 @@ impl ForegroundPipeline {
 // Image pipeline (inline terminal images via Kitty protocol)
 // ---------------------------------------------------------------------------
 
-/// Per-quad image instance data.
-#[repr(C)]
-#[derive(Copy, Clone, Pod, Zeroable)]
-pub struct ImageQuadInstance {
-    /// Quad position in physical pixels (top-left corner).
-    pub pos: [f32; 2],
-    /// Quad size in physical pixels.
-    pub size: [f32; 2],
-    /// Texture UV min (top-left).
-    pub uv_min: [f32; 2],
-    /// Texture UV max (bottom-right).
-    pub uv_max: [f32; 2],
-}
-
 /// Image rendering pipeline: instanced textured quads for inline images.
 ///
 /// Each draw call binds a single image texture. Instance buffers provide
@@ -696,25 +653,4 @@ impl ImagePipeline {
         render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
         render_pass.draw_indexed(0..6, 0, 0..instance_count);
     }
-}
-
-/// Create or grow an instance buffer if needed. Returns the buffer and its capacity.
-pub fn ensure_instance_buffer<T: Pod>(
-    device: &wgpu::Device,
-    existing: Option<&wgpu::Buffer>,
-    existing_capacity: usize,
-    required: usize,
-    label: &str,
-) -> Option<(wgpu::Buffer, usize)> {
-    if required <= existing_capacity && existing.is_some() {
-        return None; // existing buffer is fine
-    }
-    let new_capacity = required.max(1024).next_power_of_two();
-    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
-        label: Some(label),
-        size: (new_capacity * std::mem::size_of::<T>()) as u64,
-        usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
-        mapped_at_creation: false,
-    });
-    Some((buffer, new_capacity))
 }

--- a/crates/amux-render-gpu/src/quad.rs
+++ b/crates/amux-render-gpu/src/quad.rs
@@ -71,7 +71,7 @@ pub fn ensure_instance_buffer<T: Pod>(
     let new_capacity = required.max(1024).next_power_of_two();
     let buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: Some(label),
-        size: (new_capacity * std::mem::size_of::<T>()) as u64,
+        size: new_capacity as u64 * std::mem::size_of::<T>() as u64,
         usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });

--- a/crates/amux-render-gpu/src/quad.rs
+++ b/crates/amux-render-gpu/src/quad.rs
@@ -1,0 +1,79 @@
+//! Per-instance vertex types for the terminal's instanced quad pipelines.
+//!
+//! The three `*Instance` structs below are the per-cell (or per-glyph / per-image)
+//! records uploaded into the instance buffers consumed by the background,
+//! foreground, and image render pipelines. Modeled on wezterm-gui's `quad.rs`,
+//! which similarly separates instance/vertex type definitions from pipeline
+//! construction.
+//!
+//! `ensure_instance_buffer` is a shared helper for creating or growing an
+//! instance buffer when the number of instances exceeds the current capacity.
+
+use bytemuck::{Pod, Zeroable};
+use egui_wgpu::wgpu;
+
+/// Per-cell background instance data.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct CellBgInstance {
+    /// Cell position in physical pixels (top-left corner).
+    pub pos: [f32; 2],
+    /// Cell size in physical pixels.
+    pub size: [f32; 2],
+    /// Background color (sRGB or linear RGBA, depending on render target format).
+    pub color: [f32; 4],
+}
+
+/// Per-glyph foreground instance data.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct CellFgInstance {
+    /// Glyph position in physical pixels (top-left corner).
+    pub pos: [f32; 2],
+    /// Glyph size in physical pixels.
+    pub size: [f32; 2],
+    /// Atlas UV min (top-left).
+    pub uv_min: [f32; 2],
+    /// Atlas UV max (bottom-right).
+    pub uv_max: [f32; 2],
+    /// Foreground color (sRGB or linear RGBA, depending on render target format).
+    pub color: [f32; 4],
+    /// 1.0 for color emoji, 0.0 for monochrome glyphs.
+    pub is_color: f32,
+    pub _pad: [f32; 3],
+}
+
+/// Per-quad image instance data.
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct ImageQuadInstance {
+    /// Quad position in physical pixels (top-left corner).
+    pub pos: [f32; 2],
+    /// Quad size in physical pixels.
+    pub size: [f32; 2],
+    /// Texture UV min (top-left).
+    pub uv_min: [f32; 2],
+    /// Texture UV max (bottom-right).
+    pub uv_max: [f32; 2],
+}
+
+/// Create or grow an instance buffer if needed. Returns the buffer and its capacity.
+pub fn ensure_instance_buffer<T: Pod>(
+    device: &wgpu::Device,
+    existing: Option<&wgpu::Buffer>,
+    existing_capacity: usize,
+    required: usize,
+    label: &str,
+) -> Option<(wgpu::Buffer, usize)> {
+    if required <= existing_capacity && existing.is_some() {
+        return None; // existing buffer is fine
+    }
+    let new_capacity = required.max(1024).next_power_of_two();
+    let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        size: (new_capacity * std::mem::size_of::<T>()) as u64,
+        usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    Some((buffer, new_capacity))
+}

--- a/crates/amux-render-gpu/src/screen_line.rs
+++ b/crates/amux-render-gpu/src/screen_line.rs
@@ -22,7 +22,7 @@ use egui_wgpu::{CallbackResources, CallbackTrait, ScreenDescriptor};
 use crate::callback::TerminalPaintCallback;
 use crate::color::maybe_linearize;
 use crate::decorations::{rasterize_curly_tile, rasterize_dotted_tile};
-use crate::pipeline::{ensure_instance_buffer, CellBgInstance, CellFgInstance, ImageQuadInstance};
+use crate::quad::{ensure_instance_buffer, CellBgInstance, CellFgInstance, ImageQuadInstance};
 use crate::resources::TerminalGpuResources;
 use crate::shape::{shape_and_rasterize, shape_run};
 use crate::state::{ImageTextureEntry, PaneRenderState, PhysRect, TextRun};

--- a/crates/amux-render-gpu/src/shape.rs
+++ b/crates/amux-render-gpu/src/shape.rs
@@ -12,7 +12,7 @@
 use cosmic_text::{Attrs, Buffer, Metrics, Shaping};
 use egui_wgpu::wgpu;
 
-use crate::pipeline::CellFgInstance;
+use crate::quad::CellFgInstance;
 use crate::resources::TerminalGpuResources;
 use crate::state::{CachedGlyph, ShapedGlyphEntry, TextRun};
 

--- a/crates/amux-render-gpu/src/state.rs
+++ b/crates/amux-render-gpu/src/state.rs
@@ -7,7 +7,7 @@
 use amux_term::backend::CursorShape;
 use egui_wgpu::wgpu;
 
-use crate::pipeline::{CellBgInstance, CellFgInstance};
+use crate::quad::{CellBgInstance, CellFgInstance};
 use crate::snapshot::TerminalSnapshot;
 
 /// Physical pixel rectangle for the pane area.


### PR DESCRIPTION
## Summary

Extracts per-instance vertex types (`CellBgInstance`, `CellFgInstance`, `ImageQuadInstance`) and the `ensure_instance_buffer` helper out of `pipeline.rs` into a new `quad.rs` module. Mirrors wezterm-gui's `quad.rs`, which keeps vertex/instance type definitions separate from pipeline construction.

After this split:
- `pipeline.rs` (656 LoC): pipeline construction — device/layout/shader setup for bg/fg/image pipelines
- `quad.rs` (79 LoC): public per-instance ABI + shared instance-buffer grow helper

Stack: #89 → #90 → #91 → #92 → #93 → **this PR**.

## Test plan

- [x] `cargo build -p amux-render-gpu`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [ ] Manual smoke: terminal rendering still pixel-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)