### PR TITLE
Unify tab model with TabEntry enum (refs #124)

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -85,7 +85,7 @@ impl eframe::App for AmuxApp {
             let PaneEntry::Terminal(managed) = entry else {
                 continue;
             };
-            for surface in &mut managed.surfaces {
+            for surface in managed.surfaces_mut() {
                 let mut bytes_this_frame = 0;
                 while bytes_this_frame < MAX_BYTES_PER_SURFACE_PER_FRAME {
                     match surface.byte_rx.try_recv() {

--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -345,7 +345,7 @@ impl AmuxApp {
                     {
                         let total = managed.tab_count();
                         if total > 1 {
-                            managed.active_surface_idx = (managed.active_surface_idx + 1) % total;
+                            managed.active_tab_idx = (managed.active_tab_idx + 1) % total;
                         }
                     }
                     return true;
@@ -358,10 +358,10 @@ impl AmuxApp {
                     {
                         let total = managed.tab_count();
                         if total > 1 {
-                            managed.active_surface_idx = if managed.active_surface_idx == 0 {
+                            managed.active_tab_idx = if managed.active_tab_idx == 0 {
                                 total - 1
                             } else {
-                                managed.active_surface_idx - 1
+                                managed.active_tab_idx - 1
                             };
                         }
                     }
@@ -900,18 +900,16 @@ impl AmuxApp {
                     let col = col.min(cols.saturating_sub(1));
 
                     if let Some(PaneEntry::Terminal(m)) = self.panes.get_mut(&pane_id) {
+                        // Pre-fetch line text before mutably borrowing selection
+                        let line_text =
+                            selection::line_text_string(&m.active_surface().pane, stable_row, cols);
                         if let Some(ref mut sel) = m.selection {
                             match sel.mode {
                                 SelectionMode::Cell => {
                                     sel.end = (col, stable_row);
                                 }
                                 SelectionMode::Word => {
-                                    let text = selection::line_text_string(
-                                        &m.surfaces[m.active_surface_idx].pane,
-                                        stable_row,
-                                        cols,
-                                    );
-                                    let (_, wend) = selection::word_bounds_in_line(&text, col);
+                                    let (_, wend) = selection::word_bounds_in_line(&line_text, col);
                                     // Extend: keep anchor word start, update end word boundary
                                     if stable_row > sel.anchor.1
                                         || (stable_row == sel.anchor.1 && col >= sel.anchor.0)
@@ -919,7 +917,7 @@ impl AmuxApp {
                                         sel.end = (wend, stable_row);
                                     } else {
                                         let (wstart, _) =
-                                            selection::word_bounds_in_line(&text, col);
+                                            selection::word_bounds_in_line(&line_text, col);
                                         sel.end = (wstart, stable_row);
                                     }
                                 }

--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -783,7 +783,9 @@ impl AmuxApp {
                                         self.close_pane(pane_id);
                                     } else {
                                         managed.tabs.remove(idx);
-                                        if managed.active_tab_idx >= managed.tabs.len() {
+                                        if idx < managed.active_tab_idx {
+                                            managed.active_tab_idx -= 1;
+                                        } else if managed.active_tab_idx >= managed.tabs.len() {
                                             managed.active_tab_idx = managed.tabs.len() - 1;
                                         }
                                     }

--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -47,18 +47,21 @@ impl AmuxApp {
                 for ws in &self.workspaces {
                     for pane_id in ws.tree.iter_panes() {
                         if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&pane_id) {
-                            for (sf_idx, sf) in managed.surfaces.iter_mut().enumerate() {
-                                let (cols, rows) = sf.pane.dimensions();
-                                surfaces.push(serde_json::json!({
-                                    "id": sf.id.to_string(),
-                                    "pane_id": pane_id.to_string(),
-                                    "workspace_id": ws.id.to_string(),
-                                    "title": sf.pane.title(),
-                                    "cols": cols,
-                                    "rows": rows,
-                                    "alive": sf.pane.is_alive(),
-                                    "active": sf_idx == managed.active_surface_idx,
-                                }));
+                            let active_idx = managed.active_tab_idx;
+                            for (tab_idx, tab) in managed.tabs.iter_mut().enumerate() {
+                                if let managed_pane::TabEntry::Terminal(sf) = tab {
+                                    let (cols, rows) = sf.pane.dimensions();
+                                    surfaces.push(serde_json::json!({
+                                        "id": sf.id.to_string(),
+                                        "pane_id": pane_id.to_string(),
+                                        "workspace_id": ws.id.to_string(),
+                                        "title": sf.pane.title(),
+                                        "cols": cols,
+                                        "rows": rows,
+                                        "alive": sf.pane.is_alive(),
+                                        "active": tab_idx == active_idx,
+                                    }));
+                                }
                             }
                         }
                     }
@@ -583,7 +586,7 @@ impl AmuxApp {
                         let sf = managed.active_surface_mut();
                         let (cols, rows) = sf.pane.dimensions();
                         let alive = sf.pane.is_alive();
-                        let tab_count = managed.surfaces.len();
+                        let tab_count = managed.tab_count();
                         pane_list.push(serde_json::json!({
                             "id": id.to_string(),
                             "focused": *id == focused,
@@ -731,8 +734,10 @@ impl AmuxApp {
                                         .unwrap()
                                         .as_terminal_mut()
                                         .unwrap();
-                                    managed.surfaces.push(surface);
-                                    managed.active_surface_idx = managed.surfaces.len() - 1;
+                                    managed
+                                        .tabs
+                                        .push(managed_pane::TabEntry::Terminal(Box::new(surface)));
+                                    managed.active_tab_idx = managed.tabs.len() - 1;
                                     Response::ok(
                                         req.id.clone(),
                                         serde_json::json!({"surface_id": sf_id.to_string()}),
@@ -762,9 +767,9 @@ impl AmuxApp {
                                 // Find which pane owns this surface
                                 let target = self.panes.iter().find_map(|(&pid, entry)| {
                                     let m = entry.as_terminal()?;
-                                    m.surfaces
+                                    m.tabs
                                         .iter()
-                                        .position(|s| s.id == sf_id)
+                                        .position(|t| t.as_surface().is_some_and(|s| s.id == sf_id))
                                         .map(|idx| (pid, idx))
                                 });
                                 if let Some((pane_id, idx)) = target {
@@ -774,12 +779,12 @@ impl AmuxApp {
                                         .unwrap()
                                         .as_terminal_mut()
                                         .unwrap();
-                                    if managed.surfaces.len() <= 1 {
+                                    if managed.tabs.len() <= 1 {
                                         self.close_pane(pane_id);
                                     } else {
-                                        managed.surfaces.remove(idx);
-                                        if managed.active_surface_idx >= managed.surfaces.len() {
-                                            managed.active_surface_idx = managed.surfaces.len() - 1;
+                                        managed.tabs.remove(idx);
+                                        if managed.active_tab_idx >= managed.tabs.len() {
+                                            managed.active_tab_idx = managed.tabs.len() - 1;
                                         }
                                     }
                                     Response::ok(req.id.clone(), serde_json::json!({}))
@@ -797,12 +802,12 @@ impl AmuxApp {
                             // Close active surface in focused pane
                             if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&focused)
                             {
-                                if managed.surfaces.len() <= 1 {
+                                if managed.tabs.len() <= 1 {
                                     self.close_pane(focused);
                                 } else {
-                                    managed.surfaces.remove(managed.active_surface_idx);
-                                    if managed.active_surface_idx >= managed.surfaces.len() {
-                                        managed.active_surface_idx = managed.surfaces.len() - 1;
+                                    managed.tabs.remove(managed.active_tab_idx);
+                                    if managed.active_tab_idx >= managed.tabs.len() {
+                                        managed.active_tab_idx = managed.tabs.len() - 1;
                                     }
                                 }
                                 Response::ok(req.id.clone(), serde_json::json!({}))
@@ -826,15 +831,15 @@ impl AmuxApp {
                             let found = self.panes.iter_mut().find_map(|(pid, entry)| {
                                 let managed = entry.as_terminal_mut()?;
                                 managed
-                                    .surfaces
+                                    .tabs
                                     .iter()
-                                    .position(|s| s.id == sf_id)
+                                    .position(|t| t.as_surface().is_some_and(|s| s.id == sf_id))
                                     .map(|idx| (*pid, idx))
                             });
                             if let Some((pid, idx)) = found {
                                 let m =
                                     self.panes.get_mut(&pid).unwrap().as_terminal_mut().unwrap();
-                                m.active_surface_idx = idx;
+                                m.active_tab_idx = idx;
                                 // Switch to the owning workspace before setting focus
                                 if let Some(ws_idx) = self
                                     .workspaces
@@ -968,15 +973,21 @@ impl AmuxApp {
                 .panes
                 .iter()
                 .find(|(_, entry)| {
-                    entry
-                        .as_terminal()
-                        .is_some_and(|m| m.surfaces.iter().any(|s| s.id == sf_id))
+                    entry.as_terminal().is_some_and(|m| {
+                        m.tabs
+                            .iter()
+                            .any(|t| t.as_surface().is_some_and(|s| s.id == sf_id))
+                    })
                 })
                 .map(|(pid, _)| *pid);
 
             if let Some(pid) = target_pane {
                 let m = self.panes.get_mut(&pid)?.as_terminal_mut()?;
-                return m.surfaces.iter_mut().find(|s| s.id == sf_id);
+                return m
+                    .tabs
+                    .iter_mut()
+                    .filter_map(|t| t.as_surface_mut())
+                    .find(|s| s.id == sf_id);
             }
 
             // Fall back to treating it as a pane ID
@@ -1044,7 +1055,7 @@ impl AmuxApp {
         } else if let Ok(sf_id) = surface_id.parse::<u64>() {
             for entry in self.panes.values() {
                 if let PaneEntry::Terminal(managed) = entry {
-                    if let Some(sf) = managed.surfaces.iter().find(|s| s.id == sf_id) {
+                    if let Some(sf) = managed.surfaces().find(|s| s.id == sf_id) {
                         return Some(sf);
                     }
                 }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -294,7 +294,7 @@ impl AmuxApp {
         let pane_ids = ws.tree.iter_panes();
         let existing = pane_ids.iter().find_map(|&tree_pane_id| {
             let managed = self.panes.get(&tree_pane_id)?.as_terminal()?;
-            let browser_id = managed.browser_tab_ids.first().copied()?;
+            let browser_id = managed.browser_pane_ids().into_iter().next()?;
             Some((tree_pane_id, browser_id))
         });
 
@@ -305,11 +305,11 @@ impl AmuxApp {
             // Switch to the browser tab
             if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&tree_pane_id) {
                 if let Some(idx) = managed
-                    .browser_tab_ids
+                    .tabs
                     .iter()
-                    .position(|&id| id == browser_id)
+                    .position(|t| t.browser_pane_id() == Some(browser_id))
                 {
-                    managed.active_surface_idx = managed.surfaces.len() + idx;
+                    managed.active_tab_idx = idx;
                 }
             }
             self.set_focus(tree_pane_id);
@@ -350,19 +350,11 @@ impl AmuxApp {
                     // Insert right after the active tab (cmux behavior).
                     let focused = self.focused_pane_id();
                     if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&focused) {
-                        let browser_insert = if managed.active_surface_idx >= managed.surfaces.len()
-                        {
-                            // Active is a browser tab — insert right after it
-                            let browser_idx = managed.active_surface_idx - managed.surfaces.len();
-                            (browser_idx + 1).min(managed.browser_tab_ids.len())
-                        } else {
-                            // Active is a terminal tab — append to end of browser list
-                            managed.browser_tab_ids.len()
-                        };
+                        let insert_at = (managed.active_tab_idx + 1).min(managed.tabs.len());
                         managed
-                            .browser_tab_ids
-                            .insert(browser_insert, browser_pane_id);
-                        managed.active_surface_idx = managed.surfaces.len() + browser_insert;
+                            .tabs
+                            .insert(insert_at, managed_pane::TabEntry::Browser(browser_pane_id));
+                        managed.active_tab_idx = insert_at;
                     }
                     tracing::info!(
                         "Created browser tab {} in pane {} with URL: {}",
@@ -385,8 +377,8 @@ impl AmuxApp {
                 Ok(browser) => {
                     self.panes
                         .insert(browser_pane_id, PaneEntry::Browser(browser));
-                    // browser_tab_ids was already populated during session restore
-                    // in startup.rs — no need to push again here.
+                    // tabs list was already populated with Browser entries during
+                    // session restore in startup.rs — no need to push again here.
                     tracing::info!(
                         "Restored browser tab {} in pane {} with URL: {}",
                         browser_pane_id,
@@ -408,7 +400,7 @@ impl AmuxApp {
             let PaneEntry::Terminal(managed) = entry else {
                 continue;
             };
-            for surface in &mut managed.surfaces {
+            for surface in managed.surfaces_mut() {
                 while let Ok(bytes) = surface.byte_rx.try_recv() {
                     surface.pane.feed_bytes(&bytes);
                 }
@@ -424,8 +416,7 @@ impl AmuxApp {
                 match self.panes.get(&pane_id) {
                     Some(PaneEntry::Terminal(managed)) => {
                         let surfaces: Vec<amux_session::SavedSurface> = managed
-                            .surfaces
-                            .iter()
+                            .surfaces()
                             .map(|sf| {
                                 let working_dir = sf.metadata.cwd.clone().or_else(|| {
                                     sf.pane
@@ -465,7 +456,7 @@ impl AmuxApp {
                             .collect();
                         // Save browser tabs within this pane
                         let browser_tabs: Vec<amux_session::SavedBrowserTab> = managed
-                            .browser_tab_ids
+                            .browser_pane_ids()
                             .iter()
                             .filter_map(|&bid| {
                                 let b = self.panes.get(&bid)?.as_browser()?;
@@ -482,7 +473,7 @@ impl AmuxApp {
                             amux_session::SavedManagedPane {
                                 panel_type: managed.panel_type().to_string(),
                                 surfaces,
-                                active_surface_idx: managed.active_surface_idx,
+                                active_surface_idx: managed.active_tab_idx,
                                 browser: None,
                                 browser_tabs,
                             },

--- a/crates/amux-app/src/managed_pane.rs
+++ b/crates/amux-app/src/managed_pane.rs
@@ -1,8 +1,8 @@
 //! Managed pane types for the amux application.
 //!
 //! `PaneEntry` is the top-level enum stored in `AmuxApp.panes`. Terminal and
-//! browser surfaces share the same tab bar within a `ManagedPane`, matching
-//! the cmux UX where browser tabs sit alongside terminal tabs.
+//! browser tabs are stored in a single ordered `Vec<TabEntry>` within a
+//! `ManagedPane`, allowing arbitrary interleaving and insert-after-active.
 
 use std::sync::mpsc;
 
@@ -112,13 +112,55 @@ impl PaneEntry {
 }
 
 // ---------------------------------------------------------------------------
-// Tab kind — unified tab index for terminal + browser tabs
+// Tab entry — a single tab in the unified tab list
+// ---------------------------------------------------------------------------
+
+/// A tab in a ManagedPane's tab bar. Can be either a terminal surface or a
+/// reference to a browser pane in the global panes map.
+pub(crate) enum TabEntry {
+    Terminal(Box<PaneSurface>),
+    Browser(PaneId),
+}
+
+impl TabEntry {
+    /// Returns true if this is a browser tab.
+    pub(crate) fn is_browser(&self) -> bool {
+        matches!(self, TabEntry::Browser(_))
+    }
+
+    /// Returns the browser PaneId if this is a browser tab.
+    pub(crate) fn browser_pane_id(&self) -> Option<PaneId> {
+        match self {
+            TabEntry::Browser(id) => Some(*id),
+            TabEntry::Terminal(_) => None,
+        }
+    }
+
+    /// Returns a reference to the terminal surface if this is a terminal tab.
+    pub(crate) fn as_surface(&self) -> Option<&PaneSurface> {
+        match self {
+            TabEntry::Terminal(s) => Some(s),
+            TabEntry::Browser(_) => None,
+        }
+    }
+
+    /// Returns a mutable reference to the terminal surface if this is a terminal tab.
+    pub(crate) fn as_surface_mut(&mut self) -> Option<&mut PaneSurface> {
+        match self {
+            TabEntry::Terminal(s) => Some(s),
+            TabEntry::Browser(_) => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Active tab kind
 // ---------------------------------------------------------------------------
 
 /// Which kind of tab is active in a ManagedPane.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ActiveTab {
-    /// A terminal surface at the given index in `surfaces`.
+    /// A terminal surface at the given index in `tabs`.
     Terminal(usize),
     /// A browser tab — the PaneId references a `PaneEntry::Browser` in the panes map.
     Browser(PaneId),
@@ -142,73 +184,95 @@ pub(crate) struct PaneSurface {
     pub(crate) exited: Option<ExitInfo>,
 }
 
-/// A leaf in the split tree. Each pane has its own tab bar with both
-/// terminal surfaces and browser tabs.
+/// A leaf in the split tree. Each pane has its own tab bar with
+/// terminal surfaces and browser tabs in a single ordered list.
 pub(crate) struct ManagedPane {
-    pub(crate) surfaces: Vec<PaneSurface>,
-    /// Browser pane IDs that appear as tabs in this pane's tab bar.
-    /// Each ID references a `PaneEntry::Browser` in the main panes map.
-    pub(crate) browser_tab_ids: Vec<PaneId>,
-    pub(crate) active_surface_idx: usize,
+    pub(crate) tabs: Vec<TabEntry>,
+    pub(crate) active_tab_idx: usize,
     pub(crate) selection: Option<SelectionState>,
 }
 
 #[allow(dead_code)]
 impl ManagedPane {
-    /// Total number of tabs (terminal surfaces + browser tabs).
+    /// Total number of tabs.
     pub(crate) fn tab_count(&self) -> usize {
-        self.surfaces.len() + self.browser_tab_ids.len()
+        self.tabs.len()
     }
 
     /// What kind of tab is currently active.
     pub(crate) fn active_tab(&self) -> ActiveTab {
-        if self.active_surface_idx < self.surfaces.len() {
-            ActiveTab::Terminal(self.active_surface_idx)
-        } else {
-            let browser_idx = self.active_surface_idx - self.surfaces.len();
-            ActiveTab::Browser(self.browser_tab_ids[browser_idx])
+        match &self.tabs[self.active_tab_idx] {
+            TabEntry::Terminal(_) => ActiveTab::Terminal(self.active_tab_idx),
+            TabEntry::Browser(id) => ActiveTab::Browser(*id),
         }
     }
 
     /// Whether the active tab is a browser tab.
     pub(crate) fn active_is_browser(&self) -> bool {
-        self.active_surface_idx >= self.surfaces.len()
+        self.tabs[self.active_tab_idx].is_browser()
     }
 
     /// Returns the active terminal surface.
-    /// When a browser tab is active, returns the last terminal surface as a
+    /// When a browser tab is active, returns the nearest terminal surface as a
     /// safe fallback (callers should check `active_is_browser()` first).
     ///
     /// # Panics
-    /// Panics if `surfaces` is empty (invariant: at least one surface must exist).
+    /// Panics if there are no terminal surfaces.
     pub(crate) fn active_surface(&self) -> &PaneSurface {
-        assert!(
-            !self.surfaces.is_empty(),
-            "active_surface() called with no terminal surfaces"
-        );
-        let idx = self.active_surface_idx.min(self.surfaces.len() - 1);
-        &self.surfaces[idx]
+        if let TabEntry::Terminal(s) = &self.tabs[self.active_tab_idx] {
+            return s;
+        }
+        // Fallback: find nearest terminal surface
+        self.tabs
+            .iter()
+            .filter_map(|t| t.as_surface())
+            .next_back()
+            .expect("active_surface() called with no terminal surfaces")
     }
 
     /// Returns the active terminal surface mutably.
-    /// When a browser tab is active, returns the last terminal surface as a
+    /// When a browser tab is active, returns the nearest terminal surface as a
     /// safe fallback (callers should check `active_is_browser()` first).
     ///
     /// # Panics
-    /// Panics if `surfaces` is empty (invariant: at least one surface must exist).
+    /// Panics if there are no terminal surfaces.
     pub(crate) fn active_surface_mut(&mut self) -> &mut PaneSurface {
-        assert!(
-            !self.surfaces.is_empty(),
-            "active_surface_mut() called with no terminal surfaces"
-        );
-        let idx = self.active_surface_idx.min(self.surfaces.len() - 1);
-        &mut self.surfaces[idx]
+        // Try active tab first
+        let idx = if matches!(self.tabs[self.active_tab_idx], TabEntry::Terminal(_)) {
+            self.active_tab_idx
+        } else {
+            // Fallback: find last terminal tab index
+            self.tabs
+                .iter()
+                .rposition(|t| matches!(t, TabEntry::Terminal(_)))
+                .expect("active_surface_mut() called with no terminal surfaces")
+        };
+        match &mut self.tabs[idx] {
+            TabEntry::Terminal(s) => s,
+            TabEntry::Browser(_) => unreachable!(),
+        }
+    }
+
+    /// Collect all browser PaneIds referenced by this pane's tabs.
+    pub(crate) fn browser_pane_ids(&self) -> Vec<PaneId> {
+        self.tabs
+            .iter()
+            .filter_map(|t| t.browser_pane_id())
+            .collect()
+    }
+
+    /// Iterator over all terminal surfaces.
+    pub(crate) fn surfaces(&self) -> impl Iterator<Item = &PaneSurface> {
+        self.tabs.iter().filter_map(|t| t.as_surface())
+    }
+
+    /// Mutable iterator over all terminal surfaces.
+    pub(crate) fn surfaces_mut(&mut self) -> impl Iterator<Item = &mut PaneSurface> {
+        self.tabs.iter_mut().filter_map(|t| t.as_surface_mut())
     }
 
     /// Display title for this pane (user title > OSC title > shell fallback).
     pub(crate) fn title(&self) -> String {
-        // If active tab is a browser, title comes from the browser pane
-        // (handled by caller since we don't have access to the panes map here).
         if self.active_is_browser() {
             return "Browser".to_string();
         }
@@ -233,7 +297,7 @@ impl ManagedPane {
     /// Current dimensions (cols, rows) of the active surface.
     pub(crate) fn dimensions(&self) -> (usize, usize) {
         if self.active_is_browser() {
-            return (80, 24); // placeholder for browser tabs
+            return (80, 24);
         }
         self.active_surface().pane.dimensions()
     }
@@ -244,12 +308,12 @@ impl ManagedPane {
     }
 
     /// Drain pending PTY output from the byte channel into the terminal state machine
-    /// for all surfaces (not just the active one). Background tabs must keep their
-    /// terminal state current so that titles, metadata, and scrollback stay in sync.
+    /// for all terminal surfaces (not just the active one). Background tabs must keep
+    /// their terminal state current so titles, metadata, and scrollback stay in sync.
     /// Returns `true` if any bytes were processed (screen may need repaint).
     pub(crate) fn drain_pty_output(&mut self) -> bool {
         let mut any = false;
-        for surface in &mut self.surfaces {
+        for surface in self.surfaces_mut() {
             while let Ok(bytes) = surface.byte_rx.try_recv() {
                 surface.pane.feed_bytes(&bytes);
                 any = true;

--- a/crates/amux-app/src/managed_pane.rs
+++ b/crates/amux-app/src/managed_pane.rs
@@ -222,7 +222,7 @@ impl ManagedPane {
         if let TabEntry::Terminal(s) = &self.tabs[self.active_tab_idx] {
             return s;
         }
-        // Fallback: find nearest terminal surface
+        // Fallback: find the last terminal surface
         self.tabs
             .iter()
             .filter_map(|t| t.as_surface())
@@ -231,7 +231,7 @@ impl ManagedPane {
     }
 
     /// Returns the active terminal surface mutably.
-    /// When a browser tab is active, returns the nearest terminal surface as a
+    /// When a browser tab is active, returns the last terminal surface as a
     /// safe fallback (callers should check `active_is_browser()` first).
     ///
     /// # Panics

--- a/crates/amux-app/src/notifications_ui.rs
+++ b/crates/amux-app/src/notifications_ui.rs
@@ -44,7 +44,7 @@ impl AmuxApp {
                 continue;
             };
             let ws_id = self.workspace_for_pane(pane_id).unwrap_or(0);
-            for surface in &managed.surfaces {
+            for surface in managed.surfaces() {
                 for event in surface.pane.drain_notifications() {
                     events.push((ws_id, pane_id, surface.id, event));
                 }
@@ -65,7 +65,7 @@ impl AmuxApp {
                 NotificationEvent::WorkingDirectoryChanged => {
                     // Store the CWD from OSC 7 into surface metadata
                     if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&pane_id) {
-                        for surface in &mut managed.surfaces {
+                        for surface in managed.surfaces_mut() {
                             if surface.id == surface_id {
                                 let cwd = surface
                                     .pane

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -568,6 +568,13 @@ impl AmuxApp {
                     self.close_pane(pane_id);
                     return;
                 }
+                // Don't remove the last terminal tab — close the whole pane instead
+                // to preserve the "at least one terminal surface" invariant.
+                let is_browser = managed.tabs[idx].is_browser();
+                if !is_browser && managed.tabs.iter().filter(|t| !t.is_browser()).count() <= 1 {
+                    self.close_pane(pane_id);
+                    return;
+                }
                 // Get the browser pane ID before removing (if it's a browser tab)
                 let browser_pane_id = managed.tabs[idx].browser_pane_id();
                 let managed = self

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -20,19 +20,14 @@ impl AmuxApp {
         is_focused: bool,
     ) {
         // Collect info we need before borrowing panes mutably
-        let (active_is_browser, active_surface_idx, browser_tab_ids, active_browser_id) =
+        let (active_is_browser, active_browser_id, browser_pane_ids) =
             match self.panes.get(&pane_id) {
                 Some(PaneEntry::Terminal(m)) => {
                     let active_bid = match m.active_tab() {
                         managed_pane::ActiveTab::Browser(bid) => Some(bid),
                         _ => None,
                     };
-                    (
-                        m.active_is_browser(),
-                        m.active_surface_idx,
-                        m.browser_tab_ids.clone(),
-                        active_bid,
-                    )
+                    (m.active_is_browser(), active_bid, m.browser_pane_ids())
                 }
                 _ => return,
             };
@@ -44,14 +39,15 @@ impl AmuxApp {
         let overlay_open = self.show_notification_panel
             || self.rename_modal.is_some()
             || self.find_state.is_some();
-        for &bid in &browser_tab_ids {
+        for &bid in &browser_pane_ids {
             if let Some(PaneEntry::Browser(b)) = self.panes.get(&bid) {
                 b.set_visible(active_browser_id == Some(bid) && !overlay_open);
             }
         }
 
-        // Pre-collect browser tab info and favicon textures before mutable borrow
-        let browser_tab_info: Vec<(String, Option<egui::TextureId>)> = browser_tab_ids
+        // Pre-collect browser tab info and favicon textures before mutable borrow.
+        // Build a map from browser PaneId to (title, icon_tex) for tab rendering.
+        let browser_tab_info: HashMap<PaneId, (String, Option<egui::TextureId>)> = browser_pane_ids
             .iter()
             .map(|&bid| {
                 let (title, favicon_url) = self
@@ -69,7 +65,7 @@ impl AmuxApp {
                     })
                     .unwrap_or_else(|| ("Browser".to_string(), None));
                 let icon_tex = favicon_url.and_then(|url| self.get_favicon(ui.ctx(), &url, bid));
-                (title, icon_tex)
+                (bid, (title, icon_tex))
             })
             .collect();
 
@@ -77,7 +73,6 @@ impl AmuxApp {
             Some(PaneEntry::Terminal(m)) => m,
             _ => return,
         };
-        let _ = active_surface_idx; // used later in tab rendering
 
         // Always show tab bar
         let tab_rect =
@@ -103,7 +98,7 @@ impl AmuxApp {
             painter.hline(tab_rect.x_range(), tab_rect.min.y, bar_stroke);
             painter.hline(tab_rect.x_range(), tab_rect.max.y, bar_stroke);
 
-            let active_idx = managed.active_surface_idx;
+            let active_idx = managed.active_tab_idx;
             let tab_font = egui::FontId::proportional(11.5);
             let mut x = tab_rect.min.x + 2.0;
 
@@ -123,11 +118,7 @@ impl AmuxApp {
             let mut drag_start: Option<usize> = None;
             let mut start_rename_tab: Option<usize> = None;
 
-            // Build unified tab list: terminal surfaces + browser tabs
-            let terminal_count = managed.surfaces.len();
-            let total_tabs = managed.tab_count();
-
-            // Collect tab info for unified iteration
+            // Build tab info for rendering from the unified tab list
             enum TabIcon {
                 Terminal,
                 Favicon(egui::TextureId),
@@ -137,51 +128,62 @@ impl AmuxApp {
                 icon: TabIcon,
                 title: String,
                 is_dead: bool,
+                is_browser: bool,
             }
-            let mut tabs: Vec<TabInfo> = Vec::with_capacity(total_tabs);
-            for surface in &managed.surfaces {
-                let raw_title = surface
-                    .user_title
-                    .as_deref()
-                    .unwrap_or_else(|| surface.pane.title());
-                let raw = if raw_title.is_empty() || raw_title == "?" {
-                    surface
-                        .metadata
-                        .cwd
-                        .as_deref()
-                        .map(|p| {
-                            if let Some(home) = dirs::home_dir() {
-                                let path = std::path::Path::new(p);
-                                if let Ok(rest) = path.strip_prefix(&home) {
-                                    if rest.as_os_str().is_empty() {
-                                        return "~".to_string();
+            let tabs: Vec<TabInfo> = managed
+                .tabs
+                .iter()
+                .map(|tab| match tab {
+                    managed_pane::TabEntry::Terminal(surface) => {
+                        let raw_title = surface
+                            .user_title
+                            .as_deref()
+                            .unwrap_or_else(|| surface.pane.title());
+                        let raw = if raw_title.is_empty() || raw_title == "?" {
+                            surface
+                                .metadata
+                                .cwd
+                                .as_deref()
+                                .map(|p| {
+                                    if let Some(home) = dirs::home_dir() {
+                                        let path = std::path::Path::new(p);
+                                        if let Ok(rest) = path.strip_prefix(&home) {
+                                            if rest.as_os_str().is_empty() {
+                                                return "~".to_string();
+                                            }
+                                            return format!("~/{}", rest.to_string_lossy());
+                                        }
                                     }
-                                    return format!("~/{}", rest.to_string_lossy());
-                                }
-                            }
-                            p.to_string()
-                        })
-                        .unwrap_or_else(|| "Tab".to_string())
-                } else {
-                    raw_title.to_string()
-                };
-                tabs.push(TabInfo {
-                    icon: TabIcon::Terminal,
-                    title: raw,
-                    is_dead: surface.exited.is_some(),
-                });
-            }
-            // Browser tabs: use pre-collected titles and favicon textures
-            for (title, icon_texture) in &browser_tab_info {
-                tabs.push(TabInfo {
-                    icon: match icon_texture {
-                        Some(tex) => TabIcon::Favicon(*tex),
-                        None => TabIcon::None,
-                    },
-                    title: title.clone(),
-                    is_dead: false,
-                });
-            }
+                                    p.to_string()
+                                })
+                                .unwrap_or_else(|| "Tab".to_string())
+                        } else {
+                            raw_title.to_string()
+                        };
+                        TabInfo {
+                            icon: TabIcon::Terminal,
+                            title: raw,
+                            is_dead: surface.exited.is_some(),
+                            is_browser: false,
+                        }
+                    }
+                    managed_pane::TabEntry::Browser(bid) => {
+                        let (title, icon_tex) = browser_tab_info
+                            .get(bid)
+                            .cloned()
+                            .unwrap_or_else(|| ("Browser".to_string(), None));
+                        TabInfo {
+                            icon: match icon_tex {
+                                Some(tex) => TabIcon::Favicon(tex),
+                                None => TabIcon::None,
+                            },
+                            title,
+                            is_dead: false,
+                            is_browser: true,
+                        }
+                    }
+                })
+                .collect();
 
             for (idx, tab) in tabs.iter().enumerate() {
                 let is_active = idx == active_idx;
@@ -325,9 +327,8 @@ impl AmuxApp {
                 // Right-click context menu
                 let tab_id = ui.id().with("tab_ctx").with(pane_id).with(idx);
                 let tab_response = ui.interact(this_tab, tab_id, egui::Sense::click());
-                let is_browser_tab = idx >= terminal_count;
                 tab_response.context_menu(|ui| {
-                    if !is_browser_tab && ui.button("Rename Tab").clicked() {
+                    if !tab.is_browser && ui.button("Rename Tab").clicked() {
                         start_rename_tab = Some(idx);
                         ui.close_menu();
                     }
@@ -375,27 +376,24 @@ impl AmuxApp {
                         self.tab_drag = None;
                         if from != to {
                             if let Some(PaneEntry::Terminal(m)) = self.panes.get_mut(&pane_id) {
-                                // Only reorder within terminal tabs
-                                if from >= m.surfaces.len() || to >= m.surfaces.len() {
+                                if from >= m.tabs.len() || to >= m.tabs.len() {
                                     return;
                                 }
-                                let surface = m.surfaces.remove(from);
+                                let tab = m.tabs.remove(from);
                                 let insert_idx = if from < to {
-                                    (to - 1).min(m.surfaces.len())
+                                    (to - 1).min(m.tabs.len())
                                 } else {
-                                    to.min(m.surfaces.len())
+                                    to.min(m.tabs.len())
                                 };
-                                m.surfaces.insert(insert_idx, surface);
-                                if m.active_surface_idx == from {
-                                    m.active_surface_idx = insert_idx;
-                                } else if from < m.active_surface_idx
-                                    && insert_idx >= m.active_surface_idx
+                                m.tabs.insert(insert_idx, tab);
+                                if m.active_tab_idx == from {
+                                    m.active_tab_idx = insert_idx;
+                                } else if from < m.active_tab_idx && insert_idx >= m.active_tab_idx
                                 {
-                                    m.active_surface_idx -= 1;
-                                } else if from > m.active_surface_idx
-                                    && insert_idx <= m.active_surface_idx
+                                    m.active_tab_idx -= 1;
+                                } else if from > m.active_tab_idx && insert_idx <= m.active_tab_idx
                                 {
-                                    m.active_surface_idx += 1;
+                                    m.active_tab_idx += 1;
                                 }
                             }
                             return;
@@ -534,9 +532,12 @@ impl AmuxApp {
                             None,
                         ) {
                             if let Some(PaneEntry::Terminal(m)) = self.panes.get_mut(&pane_id) {
-                                let insert_at = (m.active_surface_idx + 1).min(m.surfaces.len());
-                                m.surfaces.insert(insert_at, surface);
-                                m.active_surface_idx = insert_at;
+                                let insert_at = (m.active_tab_idx + 1).min(m.tabs.len());
+                                m.tabs.insert(
+                                    insert_at,
+                                    managed_pane::TabEntry::Terminal(Box::new(surface)),
+                                );
+                                m.active_tab_idx = insert_at;
                             }
                         }
                         return;
@@ -563,47 +564,33 @@ impl AmuxApp {
                     .get(&pane_id)
                     .and_then(|e| e.as_terminal())
                     .unwrap();
-                let tc = managed.tab_count();
-                let tcount = managed.surfaces.len();
-                if tc <= 1 {
+                if managed.tabs.len() <= 1 {
                     self.close_pane(pane_id);
                     return;
                 }
-                if idx < tcount {
-                    // Close terminal tab
-                    let managed = self
-                        .panes
-                        .get_mut(&pane_id)
-                        .unwrap()
-                        .as_terminal_mut()
-                        .unwrap();
-                    managed.surfaces.remove(idx);
-                    if idx < managed.active_surface_idx {
-                        managed.active_surface_idx -= 1;
-                    } else if managed.active_surface_idx >= managed.tab_count() {
-                        managed.active_surface_idx = managed.tab_count() - 1;
-                    }
-                } else {
-                    // Close browser tab
-                    let browser_idx = idx - tcount;
-                    let managed = self
-                        .panes
-                        .get_mut(&pane_id)
-                        .unwrap()
-                        .as_terminal_mut()
-                        .unwrap();
-                    let browser_pane_id = managed.browser_tab_ids.remove(browser_idx);
-                    self.panes.remove(&browser_pane_id);
-                    self.omnibar_state.remove(&browser_pane_id);
-                    let managed = self
-                        .panes
-                        .get_mut(&pane_id)
-                        .unwrap()
-                        .as_terminal_mut()
-                        .unwrap();
-                    if managed.active_surface_idx >= managed.tab_count() {
-                        managed.active_surface_idx = managed.tab_count() - 1;
-                    }
+                // Get the browser pane ID before removing (if it's a browser tab)
+                let browser_pane_id = managed.tabs[idx].browser_pane_id();
+                let managed = self
+                    .panes
+                    .get_mut(&pane_id)
+                    .unwrap()
+                    .as_terminal_mut()
+                    .unwrap();
+                managed.tabs.remove(idx);
+                if let Some(bid) = browser_pane_id {
+                    self.panes.remove(&bid);
+                    self.omnibar_state.remove(&bid);
+                }
+                let managed = self
+                    .panes
+                    .get_mut(&pane_id)
+                    .unwrap()
+                    .as_terminal_mut()
+                    .unwrap();
+                if idx < managed.active_tab_idx {
+                    managed.active_tab_idx -= 1;
+                } else if managed.active_tab_idx >= managed.tabs.len() {
+                    managed.active_tab_idx = managed.tabs.len() - 1;
                 }
             } else if let Some(idx) = switch_to {
                 // Determine old and new browser tab IDs for visibility management
@@ -621,7 +608,7 @@ impl AmuxApp {
                     .unwrap()
                     .as_terminal_mut()
                     .unwrap();
-                managed.active_surface_idx = idx;
+                managed.active_tab_idx = idx;
                 let new_browser = match managed.active_tab() {
                     managed_pane::ActiveTab::Browser(bid) => Some(bid),
                     _ => None,
@@ -643,11 +630,10 @@ impl AmuxApp {
                 }
             }
 
-            // Open rename modal for tab
+            // Open rename modal for tab (terminal tabs only)
             if let Some(idx) = start_rename_tab {
                 if let Some(PaneEntry::Terminal(managed)) = self.panes.get(&pane_id) {
-                    if idx < managed.surfaces.len() {
-                        let surface = &managed.surfaces[idx];
+                    if let Some(surface) = managed.tabs[idx].as_surface() {
                         let current_title = surface
                             .user_title
                             .clone()

--- a/crates/amux-app/src/rename_modal.rs
+++ b/crates/amux-app/src/rename_modal.rs
@@ -106,7 +106,7 @@ impl AmuxApp {
                     } => {
                         if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&pane_id) {
                             if let Some(surface) =
-                                managed.surfaces.iter_mut().find(|s| s.id == surface_id)
+                                managed.surfaces_mut().find(|s| s.id == surface_id)
                             {
                                 surface.user_title = Some(new_name);
                             }

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -228,9 +228,8 @@ pub(crate) fn fresh_startup(
     let surface = spawn_surface(80, 24, ipc_addr, socket_token, config, 0, 0, None, None)?;
 
     let managed = PaneEntry::Terminal(ManagedPane {
-        surfaces: vec![surface],
-        browser_tab_ids: Vec::new(),
-        active_surface_idx: 0,
+        tabs: vec![managed_pane::TabEntry::Terminal(Box::new(surface))],
+        active_tab_idx: 0,
         selection: None,
     });
 
@@ -341,21 +340,24 @@ pub(crate) fn restore_session(
                 continue;
             }
 
-            // Queue browser tab restores for this pane
-            let mut browser_tab_ids = Vec::new();
+            // Build unified tab list: terminals first, then browser tabs
+            // (matches old layout order for backward compat with old sessions)
+            let mut tabs: Vec<TabEntry> = surfaces
+                .into_iter()
+                .map(|s| TabEntry::Terminal(Box::new(s)))
+                .collect();
             for bt in &saved_pane.browser_tabs {
                 pending_browser_restores.push((pane_id, bt.pane_id, bt.url.clone()));
-                browser_tab_ids.push(bt.pane_id);
+                tabs.push(TabEntry::Browser(bt.pane_id));
             }
 
-            let max_idx = (surfaces.len() + browser_tab_ids.len()).saturating_sub(1);
+            let max_idx = tabs.len().saturating_sub(1);
             let active_idx = saved_pane.active_surface_idx.min(max_idx);
             panes.insert(
                 pane_id,
                 PaneEntry::Terminal(ManagedPane {
-                    surfaces,
-                    browser_tab_ids,
-                    active_surface_idx: active_idx,
+                    tabs,
+                    active_tab_idx: active_idx,
                     selection: None,
                 }),
             );

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -20,6 +20,7 @@ impl AmuxApp {
             .unwrap_or_default();
         for bid in browser_ids {
             self.panes.remove(&bid);
+            self.omnibar_state.remove(&bid);
         }
         self.panes.remove(&pane_id);
     }
@@ -295,29 +296,37 @@ impl AmuxApp {
         let focused_id = self.focused_pane_id();
 
         // First check: close a tab if >1 tab in focused pane
-        if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&focused_id) {
+        if let Some(PaneEntry::Terminal(managed)) = self.panes.get(&focused_id) {
             if managed.tabs.len() > 1 {
-                // If closing a browser tab, also remove it from the panes map
-                if let Some(bid) = managed.tabs[managed.active_tab_idx].browser_pane_id() {
-                    managed.tabs.remove(managed.active_tab_idx);
-                    self.panes.remove(&bid);
-                } else {
-                    let managed = self
-                        .panes
-                        .get_mut(&focused_id)
-                        .unwrap()
-                        .as_terminal_mut()
-                        .unwrap();
-                    managed.tabs.remove(managed.active_tab_idx);
+                let active_idx = managed.active_tab_idx;
+                let is_browser = managed.tabs[active_idx].browser_pane_id();
+                let is_last_terminal = is_browser.is_none()
+                    && managed.tabs.iter().filter(|t| !t.is_browser()).count() <= 1;
+
+                if is_last_terminal {
+                    // Don't remove the last terminal tab — close the whole pane
+                    // to preserve the "at least one terminal surface" invariant.
+                    self.close_pane(focused_id);
+                    return true;
                 }
+
+                let bid = is_browser;
                 let managed = self
                     .panes
                     .get_mut(&focused_id)
                     .unwrap()
                     .as_terminal_mut()
                     .unwrap();
-                if managed.active_tab_idx >= managed.tabs.len() {
+                managed.tabs.remove(active_idx);
+                if active_idx < managed.active_tab_idx {
+                    managed.active_tab_idx -= 1;
+                } else if managed.active_tab_idx >= managed.tabs.len() {
                     managed.active_tab_idx = managed.tabs.len() - 1;
+                }
+
+                if let Some(bid) = bid {
+                    self.panes.remove(&bid);
+                    self.omnibar_state.remove(&bid);
                 }
                 return true;
             }
@@ -341,6 +350,10 @@ impl AmuxApp {
             Some(PaneEntry::Terminal(m)) => m,
             _ => return,
         };
+        // Only restart if the active tab is a terminal surface
+        if managed.active_is_browser() {
+            return;
+        }
         let old_surface = managed.active_surface_mut();
         let cwd = old_surface.metadata.cwd.clone();
         let (cols, rows) = old_surface.pane.dimensions();

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -16,7 +16,7 @@ impl AmuxApp {
             .panes
             .get(&pane_id)
             .and_then(|e| e.as_terminal())
-            .map(|m| m.browser_tab_ids.clone())
+            .map(|m| m.browser_pane_ids())
             .unwrap_or_default();
         for bid in browser_ids {
             self.panes.remove(&bid);
@@ -48,9 +48,8 @@ impl AmuxApp {
                 self.panes.insert(
                     pane_id,
                     PaneEntry::Terminal(ManagedPane {
-                        surfaces: vec![surface],
-                        browser_tab_ids: Vec::new(),
-                        active_surface_idx: 0,
+                        tabs: vec![managed_pane::TabEntry::Terminal(Box::new(surface))],
+                        active_tab_idx: 0,
                         selection: None,
                     }),
                 );
@@ -88,9 +87,8 @@ impl AmuxApp {
                 self.panes.insert(
                     pane_id,
                     PaneEntry::Terminal(ManagedPane {
-                        surfaces: vec![surface],
-                        browser_tab_ids: Vec::new(),
-                        active_surface_idx: 0,
+                        tabs: vec![managed_pane::TabEntry::Terminal(Box::new(surface))],
+                        active_tab_idx: 0,
                         selection: None,
                     }),
                 );
@@ -137,10 +135,12 @@ impl AmuxApp {
             Ok(surface) => {
                 if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&focused) {
                     // Insert right after the active tab (cmux behavior).
-                    // If active is a browser tab, clamp to end of terminal list.
-                    let insert_at = (managed.active_surface_idx + 1).min(managed.surfaces.len());
-                    managed.surfaces.insert(insert_at, surface);
-                    managed.active_surface_idx = insert_at;
+                    let insert_at = (managed.active_tab_idx + 1).min(managed.tabs.len());
+                    managed.tabs.insert(
+                        insert_at,
+                        managed_pane::TabEntry::Terminal(Box::new(surface)),
+                    );
+                    managed.active_tab_idx = insert_at;
                     Some(sf_id)
                 } else {
                     None
@@ -296,10 +296,28 @@ impl AmuxApp {
 
         // First check: close a tab if >1 tab in focused pane
         if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&focused_id) {
-            if managed.surfaces.len() > 1 {
-                managed.surfaces.remove(managed.active_surface_idx);
-                if managed.active_surface_idx >= managed.surfaces.len() {
-                    managed.active_surface_idx = managed.surfaces.len() - 1;
+            if managed.tabs.len() > 1 {
+                // If closing a browser tab, also remove it from the panes map
+                if let Some(bid) = managed.tabs[managed.active_tab_idx].browser_pane_id() {
+                    managed.tabs.remove(managed.active_tab_idx);
+                    self.panes.remove(&bid);
+                } else {
+                    let managed = self
+                        .panes
+                        .get_mut(&focused_id)
+                        .unwrap()
+                        .as_terminal_mut()
+                        .unwrap();
+                    managed.tabs.remove(managed.active_tab_idx);
+                }
+                let managed = self
+                    .panes
+                    .get_mut(&focused_id)
+                    .unwrap()
+                    .as_terminal_mut()
+                    .unwrap();
+                if managed.active_tab_idx >= managed.tabs.len() {
+                    managed.active_tab_idx = managed.tabs.len() - 1;
                 }
                 return true;
             }
@@ -341,8 +359,8 @@ impl AmuxApp {
             None,
         ) {
             Ok(new_surface) => {
-                let idx = managed.active_surface_idx;
-                managed.surfaces[idx] = new_surface;
+                let idx = managed.active_tab_idx;
+                managed.tabs[idx] = managed_pane::TabEntry::Terminal(Box::new(new_surface));
             }
             Err(e) => {
                 tracing::warn!("Failed to restart surface: {e}");


### PR DESCRIPTION
## Summary
- Replace separate `surfaces` + `browser_tab_ids` + `active_surface_idx` in `ManagedPane` with unified `tabs: Vec<TabEntry>` + `active_tab_idx`
- `TabEntry` enum allows arbitrary interleaving of terminal and browser tabs
- New tabs (terminal or browser) now insert after the active tab instead of appending to separate lists
- Session save/restore maintains backward compatibility with old format

## Test plan
- [ ] Launch with existing session — old format loads correctly (terminals first, then browsers)
- [ ] Create terminal and browser tabs — verify insert-after-active ordering
- [ ] Drag-reorder tabs — verify mixed terminal/browser reordering works
- [ ] Close tabs — verify correct tab becomes active
- [ ] Save/restore session with mixed tab order
- [ ] `cargo clippy --workspace -- -D warnings && cargo fmt --check && cargo test --workspace`

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)