### PR TITLE
Hide browser webviews when switching workspaces (fixes #129)

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -292,6 +292,34 @@ impl eframe::App for AmuxApp {
                 );
                 self.last_panel_rect = Some(panel_rect);
 
+                // Hide browser webviews that don't belong to the active workspace.
+                // Native webviews sit above egui, so they must be explicitly hidden
+                // when switching workspaces — render_single_pane only manages
+                // visibility for the pane it's rendering, not cross-workspace.
+                let active_pane_ids: std::collections::HashSet<u64> = self
+                    .active_workspace()
+                    .tree
+                    .iter_panes()
+                    .into_iter()
+                    .collect();
+                for (&pid, entry) in &self.panes {
+                    if let PaneEntry::Browser(b) = entry {
+                        if !active_pane_ids.contains(&pid) {
+                            // Check if this browser pane belongs to any active-workspace managed pane
+                            let belongs_to_active = active_pane_ids.iter().any(|&aid| {
+                                self.panes
+                                    .get(&aid)
+                                    .and_then(|e| e.as_terminal())
+                                    .map(|m| m.browser_pane_ids().contains(&pid))
+                                    .unwrap_or(false)
+                            });
+                            if !belongs_to_active {
+                                b.set_visible(false);
+                            }
+                        }
+                    }
+                }
+
                 // Handle divider dragging
                 self.handle_divider_drag(ui, panel_rect);
 

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -296,26 +296,21 @@ impl eframe::App for AmuxApp {
                 // Native webviews sit above egui, so they must be explicitly hidden
                 // when switching workspaces — render_single_pane only manages
                 // visibility for the pane it's rendering, not cross-workspace.
-                let active_pane_ids: std::collections::HashSet<u64> = self
+                let active_pane_ids: std::collections::HashSet<PaneId> = self
                     .active_workspace()
                     .tree
                     .iter_panes()
                     .into_iter()
                     .collect();
+                let active_browser_ids: std::collections::HashSet<PaneId> = active_pane_ids
+                    .iter()
+                    .filter_map(|&aid| self.panes.get(&aid).and_then(|e| e.as_terminal()))
+                    .flat_map(|m| m.browser_pane_ids())
+                    .collect();
                 for (&pid, entry) in &self.panes {
                     if let PaneEntry::Browser(b) = entry {
-                        if !active_pane_ids.contains(&pid) {
-                            // Check if this browser pane belongs to any active-workspace managed pane
-                            let belongs_to_active = active_pane_ids.iter().any(|&aid| {
-                                self.panes
-                                    .get(&aid)
-                                    .and_then(|e| e.as_terminal())
-                                    .map(|m| m.browser_pane_ids().contains(&pid))
-                                    .unwrap_or(false)
-                            });
-                            if !belongs_to_active {
-                                b.set_visible(false);
-                            }
+                        if !active_pane_ids.contains(&pid) && !active_browser_ids.contains(&pid) {
+                            b.set_visible(false);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Native browser webviews (wry) sit above egui as OS-level overlays
- When switching workspaces, the old workspace's browser panes were never told to hide
- Add per-frame check that hides all browser panes not belonging to the active workspace

## Test plan
- [ ] Open a browser tab in Workspace 1
- [ ] Switch to Workspace 2 — browser webview should disappear
- [ ] Switch back to Workspace 1 — browser tab should reappear
- [ ] `cargo clippy --workspace -- -D warnings && cargo fmt --check && cargo test --workspace`

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)