### PR TITLE
Fix invisible text in context menus and modals (fixes #131)

### DIFF
--- a/crates/amux-app/src/notifications_ui.rs
+++ b/crates/amux-app/src/notifications_ui.rs
@@ -524,9 +524,6 @@ where
     // Expand the ui's min_rect to include this widget so egui's tooltip
     // system can position hover text correctly.
     ui.expand_to_include_rect(rect);
-    // NOTE: global style sets widget fg_stroke to TRANSPARENT (to hide panel
-    // resize handles), so default tooltip text would be invisible. Use an
-    // explicit color via RichText.
     let tooltip_text = egui::RichText::new(tooltip).color(egui::Color32::from_gray(220));
     let response = ui
         .interact(rect, id, egui::Sense::click())

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -111,6 +111,14 @@ pub(crate) fn render_sidebar(
 ) -> Vec<SidebarAction> {
     let mut actions = Vec::new();
 
+    // Hide the sidebar resize indicator by temporarily matching its stroke
+    // color to the sidebar background. Restored after the panel renders so
+    // context menus and other widgets keep their default stroke colors.
+    let saved_bg_stroke = ctx.style().visuals.widgets.noninteractive.bg_stroke.color;
+    ctx.style_mut(|style| {
+        style.visuals.widgets.noninteractive.bg_stroke.color = theme.chrome.sidebar_bg;
+    });
+
     egui::SidePanel::left("sidebar")
         .resizable(true)
         .show_separator_line(false)
@@ -207,6 +215,11 @@ pub(crate) fn render_sidebar(
                     }
                 });
         });
+
+    // Restore default stroke color so context menus/popups use normal styling.
+    ctx.style_mut(|style| {
+        style.visuals.widgets.noninteractive.bg_stroke.color = saved_bg_stroke;
+    });
 
     actions
 }

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -220,7 +220,7 @@ pub(crate) fn render_sidebar(
                 });
         });
 
-    // Restore widget styles so context menus/popups use normal styling.
+    // Restore widget styles so UI rendered after the sidebar uses normal styling.
     ctx.style_mut(|style| {
         style.visuals.widgets = saved_styles;
     });

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -111,12 +111,16 @@ pub(crate) fn render_sidebar(
 ) -> Vec<SidebarAction> {
     let mut actions = Vec::new();
 
-    // Hide the sidebar resize indicator by temporarily matching its stroke
-    // color to the sidebar background. Restored after the panel renders so
-    // context menus and other widgets keep their default stroke colors.
-    let saved_bg_stroke = ctx.style().visuals.widgets.noninteractive.bg_stroke.color;
+    // Hide the sidebar resize indicator (including hover/active states) by
+    // temporarily matching stroke colors to the sidebar background. egui draws
+    // the resize line using hovered.fg_stroke and active.fg_stroke even when
+    // show_separator_line(false) is set. Restored after the panel renders.
+    let saved_styles = ctx.style().visuals.widgets.clone();
+    let hide_color = theme.chrome.sidebar_bg;
     ctx.style_mut(|style| {
-        style.visuals.widgets.noninteractive.bg_stroke.color = theme.chrome.sidebar_bg;
+        style.visuals.widgets.noninteractive.bg_stroke.color = hide_color;
+        style.visuals.widgets.hovered.fg_stroke.color = hide_color;
+        style.visuals.widgets.active.fg_stroke.color = hide_color;
     });
 
     egui::SidePanel::left("sidebar")
@@ -216,9 +220,9 @@ pub(crate) fn render_sidebar(
                 });
         });
 
-    // Restore default stroke color so context menus/popups use normal styling.
+    // Restore widget styles so context menus/popups use normal styling.
     ctx.style_mut(|style| {
-        style.visuals.widgets.noninteractive.bg_stroke.color = saved_bg_stroke;
+        style.visuals.widgets = saved_styles;
     });
 
     actions

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -132,12 +132,11 @@ pub(crate) fn run() -> anyhow::Result<()> {
             // Add system monospace font as fallback for braille/symbol coverage
             fonts::install_system_font_fallback(&_cc.egui_ctx);
 
-            // Hide the panel resize handle entirely (cursor still changes on hover).
+            // Hide the panel resize separator visual. The sidebar already uses
+            // show_separator_line(false); this ensures the resize interaction
+            // zone doesn't paint a visible stroke either.
             _cc.egui_ctx.style_mut(|style| {
-                style.visuals.widgets.noninteractive.fg_stroke.color = egui::Color32::TRANSPARENT;
-                style.visuals.widgets.inactive.fg_stroke.color = egui::Color32::TRANSPARENT;
-                style.visuals.widgets.hovered.fg_stroke.color = egui::Color32::TRANSPARENT;
-                style.visuals.widgets.active.fg_stroke.color = egui::Color32::TRANSPARENT;
+                style.visuals.widgets.noninteractive.bg_stroke.color = egui::Color32::TRANSPARENT;
             });
 
             #[cfg(feature = "gpu-renderer")]

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -132,13 +132,6 @@ pub(crate) fn run() -> anyhow::Result<()> {
             // Add system monospace font as fallback for braille/symbol coverage
             fonts::install_system_font_fallback(&_cc.egui_ctx);
 
-            // Hide the panel resize separator visual. The sidebar already uses
-            // show_separator_line(false); this ensures the resize interaction
-            // zone doesn't paint a visible stroke either.
-            _cc.egui_ctx.style_mut(|style| {
-                style.visuals.widgets.noninteractive.bg_stroke.color = egui::Color32::TRANSPARENT;
-            });
-
             #[cfg(feature = "gpu-renderer")]
             let gpu_renderer = _cc.wgpu_render_state.as_ref().map(|rs| {
                 tracing::info!("GPU renderer initialized (wgpu backend)");


### PR DESCRIPTION
## Summary
- Global `fg_stroke.color = TRANSPARENT` on all widget states was killing text in context menus, rename modals, tooltips, and all egui popups
- Replace with targeted `bg_stroke.color = TRANSPARENT` on noninteractive widgets only, which hides the resize separator without affecting text
- Remove stale workaround comment in notifications_ui.rs

## Test plan
- [ ] Right-click a tab — context menu text should be visible
- [ ] Double-click a tab to rename — rename modal text should be visible
- [ ] Hover titlebar icons — tooltips should show text
- [ ] Sidebar resize handle should still be invisible
- [ ] `cargo clippy --workspace -- -D warnings && cargo fmt --check && cargo test --workspace`

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored panel resize handle visibility and adjusted sidebar resize/indicator stroke so the resize control renders and is usable.
* **Chores**
  * Removed outdated inline implementation notes/comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->