### PR TITLE
Delegate viewport scrolling to libghostty backend (fixes #136)

### DIFF
--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -736,8 +736,7 @@ impl AmuxApp {
         let focused_id = self.focused_pane_id();
         if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&focused_id) {
             let surface = managed.active_surface_mut();
-            surface.scroll_offset = 0;
-            surface.scroll_accum = 0.0;
+            surface.snap_scroll_to_bottom();
             if surface.pane.bracketed_paste_enabled() {
                 let _ = surface.pane.write_bytes(b"\x1b[200~");
                 let _ = surface.pane.write_bytes(text.as_bytes());
@@ -1010,8 +1009,7 @@ impl AmuxApp {
         for event in &events {
             match event {
                 egui::Event::Text(text) => {
-                    surface.scroll_offset = 0;
-                    surface.scroll_accum = 0.0;
+                    surface.snap_scroll_to_bottom();
                     let _ = surface.pane.write_bytes(text.as_bytes());
                 }
                 egui::Event::Key {
@@ -1021,14 +1019,12 @@ impl AmuxApp {
                     ..
                 } => {
                     if let Some(bytes) = key_encode::encode_egui_key(key, modifiers) {
-                        surface.scroll_offset = 0;
-                        surface.scroll_accum = 0.0;
+                        surface.snap_scroll_to_bottom();
                         let _ = surface.pane.write_bytes(&bytes);
                     }
                 }
                 egui::Event::Paste(text) => {
-                    surface.scroll_offset = 0;
-                    surface.scroll_accum = 0.0;
+                    surface.snap_scroll_to_bottom();
                     if surface.pane.bracketed_paste_enabled() {
                         let _ = surface.pane.write_bytes(b"\x1b[200~");
                         let _ = surface.pane.write_bytes(text.as_bytes());
@@ -1039,8 +1035,7 @@ impl AmuxApp {
                 }
                 egui::Event::Ime(ime_event) => match ime_event {
                     egui::ImeEvent::Commit(text) => {
-                        surface.scroll_offset = 0;
-                        surface.scroll_accum = 0.0;
+                        surface.snap_scroll_to_bottom();
                         self.ime_preedit = None;
                         let _ = surface.pane.write_bytes(text.as_bytes());
                     }

--- a/crates/amux-app/src/managed_pane.rs
+++ b/crates/amux-app/src/managed_pane.rs
@@ -184,6 +184,19 @@ pub(crate) struct PaneSurface {
     pub(crate) exited: Option<ExitInfo>,
 }
 
+impl PaneSurface {
+    /// Snap the viewport to the bottom (most recent output).
+    /// For backends that manage their own scroll (e.g., libghostty), this
+    /// also tells the backend to jump to the bottom.
+    pub(crate) fn snap_scroll_to_bottom(&mut self) {
+        self.scroll_offset = 0;
+        self.scroll_accum = 0.0;
+        if self.pane.manages_own_scroll() {
+            self.pane.scroll_to_bottom();
+        }
+    }
+}
+
 /// A leaf in the split tree. Each pane has its own tab bar with
 /// terminal surfaces and browser tabs in a single ordered list.
 pub(crate) struct ManagedPane {

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -456,10 +456,17 @@ impl AmuxApp {
             let (_, rows) = surface.pane.dimensions();
             let page_size = rows.saturating_sub(1).max(1);
             let lines = pages * page_size as isize;
-            let total = surface.pane.scrollback_rows();
-            let max_offset = total.saturating_sub(rows);
-            let new_offset = surface.scroll_offset as isize - lines;
-            surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
+            if surface.pane.manages_own_scroll() {
+                // Delegate to backend (e.g., libghostty manages its own viewport).
+                // Delta convention: positive = toward bottom, negative = toward top.
+                // `lines` from pages: positive pages = scroll down (toward bottom).
+                surface.pane.scroll_viewport(lines);
+            } else {
+                let total = surface.pane.scrollback_rows();
+                let max_offset = total.saturating_sub(rows);
+                let new_offset = surface.scroll_offset as isize - lines;
+                surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
+            }
         }
         true
     }
@@ -467,11 +474,15 @@ impl AmuxApp {
     pub(crate) fn do_scroll_lines_for(&mut self, pane_id: PaneId, lines: isize) {
         if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&pane_id) {
             let surface = managed.active_surface_mut();
-            let (_, rows) = surface.pane.dimensions();
-            let total = surface.pane.scrollback_rows();
-            let max_offset = total.saturating_sub(rows);
-            let new_offset = surface.scroll_offset as isize - lines;
-            surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
+            if surface.pane.manages_own_scroll() {
+                surface.pane.scroll_viewport(lines);
+            } else {
+                let (_, rows) = surface.pane.dimensions();
+                let total = surface.pane.scrollback_rows();
+                let max_offset = total.saturating_sub(rows);
+                let new_offset = surface.scroll_offset as isize - lines;
+                surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
+            }
         }
     }
 
@@ -483,8 +494,7 @@ impl AmuxApp {
             surface.pane.feed_bytes(b"\x1b[2J\x1b[H");
             // 2. Erase scrollback buffer
             surface.pane.erase_scrollback();
-            surface.scroll_offset = 0;
-            surface.scroll_accum = 0.0;
+            surface.snap_scroll_to_bottom();
             // 3. Send Ctrl+L to the PTY so the shell redraws its prompt
             let _ = surface.pane.write_bytes(b"\x0c");
         }

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -138,10 +138,19 @@ impl TerminalSnapshot {
         let cursor_bg = color_to_f32(palette.cursor_bg);
         let cursor_fg = color_to_f32(palette.cursor_fg);
 
-        let total = backend.scrollback_rows();
-        let end = total.saturating_sub(scroll_offset);
-        let start = end.saturating_sub(rows);
-        let screen_rows = backend.read_cells_range(start, end);
+        let (screen_rows, start) = if backend.manages_own_scroll() {
+            // Backend manages viewport scrolling internally (e.g., libghostty).
+            // read_screen_cells returns the already-scrolled viewport.
+            let total = backend.scrollback_rows();
+            let vp_rows = backend.dimensions().1;
+            let vp_start = total.saturating_sub(vp_rows);
+            (backend.read_screen_cells(0), vp_start)
+        } else {
+            let total = backend.scrollback_rows();
+            let end = total.saturating_sub(scroll_offset);
+            let start = end.saturating_sub(rows);
+            (backend.read_cells_range(start, end), start)
+        };
 
         let mut cells = Vec::with_capacity(cols * rows);
         let mut cursor_text = String::new();

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -142,8 +142,7 @@ impl TerminalSnapshot {
             // Backend manages viewport scrolling internally (e.g., libghostty).
             // read_screen_cells returns the already-scrolled viewport.
             let total = backend.scrollback_rows();
-            let vp_rows = backend.dimensions().1;
-            let vp_start = total.saturating_sub(vp_rows);
+            let vp_start = total.saturating_sub(rows);
             (backend.read_screen_cells(0), vp_start)
         } else {
             let total = backend.scrollback_rows();

--- a/crates/amux-term/src/any_backend.rs
+++ b/crates/amux-term/src/any_backend.rs
@@ -165,6 +165,18 @@ impl TerminalBackend for AnyBackend {
         delegate!(self, read_cells_range, start_row: usize, end_row: usize)
     }
 
+    fn manages_own_scroll(&self) -> bool {
+        delegate!(self, manages_own_scroll)
+    }
+
+    fn scroll_viewport(&mut self, delta: isize) {
+        delegate!(self, scroll_viewport, delta: isize)
+    }
+
+    fn scroll_to_bottom(&mut self) {
+        delegate!(self, scroll_to_bottom)
+    }
+
     fn erase_scrollback(&mut self) {
         delegate!(self, erase_scrollback)
     }

--- a/crates/amux-term/src/backend.rs
+++ b/crates/amux-term/src/backend.rs
@@ -323,6 +323,25 @@ pub trait TerminalBackend {
     /// handle receiving fewer rows than requested.
     fn read_cells_range(&self, start_row: usize, end_row: usize) -> Vec<ScreenRow>;
 
+    // --- Scrolling ---
+
+    /// Whether this backend manages its own viewport scrolling.
+    /// When true, callers should use `scroll_viewport()` instead of tracking
+    /// `scroll_offset` externally. The render state / screen cells will
+    /// reflect the scrolled viewport automatically.
+    fn manages_own_scroll(&self) -> bool {
+        false
+    }
+
+    /// Scroll the viewport by `delta` lines (positive = scroll down / toward
+    /// bottom, negative = scroll up / toward history). Only meaningful when
+    /// `manages_own_scroll()` returns true.
+    fn scroll_viewport(&mut self, _delta: isize) {}
+
+    /// Snap the viewport to the bottom (most recent output). Only meaningful
+    /// when `manages_own_scroll()` returns true.
+    fn scroll_to_bottom(&mut self) {}
+
     // --- Terminal control ---
 
     /// Erase scrollback buffer, keeping visible screen.

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -483,17 +483,18 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
                     // cursor_visible=false and never recover after Claude Code
                     // toggles DECTCEM. Force visible=true until the root cause
                     // is identified (wezterm backend handles this correctly).
-                    // TODO(#133): investigate libghostty-vt DECTCEM handling
+                    // TODO(#135): investigate libghostty-vt DECTCEM handling
                     visible: true,
                 };
             }
         }
-        // Fallback to direct terminal query
+        // cursor_viewport() returned None — cursor is outside the visible
+        // viewport (e.g., scrolled into history). Hide it.
         CursorPos {
-            x: self.terminal.cursor_x().unwrap_or(0) as usize,
-            y: self.terminal.cursor_y().unwrap_or(0) as i64,
+            x: 0,
+            y: 0,
             shape: self.cached_cursor_shape,
-            visible: true, // see TODO(#133) above
+            visible: false,
         }
     }
 
@@ -809,11 +810,14 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
     fn scroll_viewport(&mut self, delta: isize) {
         use libghostty_vt::terminal::ScrollViewport;
         self.terminal.scroll_viewport(ScrollViewport::Delta(delta));
+        // Bump seqno so the GPU renderer's dirty check triggers a redraw.
+        self.seqno += 1;
     }
 
     fn scroll_to_bottom(&mut self) {
         use libghostty_vt::terminal::ScrollViewport;
         self.terminal.scroll_viewport(ScrollViewport::Bottom);
+        self.seqno += 1;
     }
 
     fn erase_scrollback(&mut self) {

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -802,6 +802,20 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         all_rows[rel_start..rel_end].to_vec()
     }
 
+    fn manages_own_scroll(&self) -> bool {
+        true
+    }
+
+    fn scroll_viewport(&mut self, delta: isize) {
+        use libghostty_vt::terminal::ScrollViewport;
+        self.terminal.scroll_viewport(ScrollViewport::Delta(delta));
+    }
+
+    fn scroll_to_bottom(&mut self) {
+        use libghostty_vt::terminal::ScrollViewport;
+        self.terminal.scroll_viewport(ScrollViewport::Bottom);
+    }
+
     fn erase_scrollback(&mut self) {
         // Send CSI 3 J (Erase Scrollback) to clear scrollback without
         // resetting the terminal. terminal.reset() would wipe screen too.


### PR DESCRIPTION
## Summary
- Add `manages_own_scroll()`, `scroll_viewport(delta)`, and `scroll_to_bottom()` to `TerminalBackend` trait
- Ghostty backend delegates to `terminal.scroll_viewport(Delta/Bottom)` instead of amux managing `scroll_offset` externally
- Snapshot's `from_backend()` uses `read_screen_cells(0)` when backend manages its own scroll
- Add `PaneSurface::snap_scroll_to_bottom()` helper to consolidate scroll-reset pattern across input handling

Closes #136

## Test plan
- [ ] Build with `--features libghostty`, run some commands that produce scrollback output
- [ ] Mouse wheel scroll up — should show history, not blank/disappearing text
- [ ] Mouse wheel scroll down — should return to bottom
- [ ] Type any key while scrolled — should snap to bottom
- [ ] PageUp/PageDown should scroll correctly
- [ ] Verify wezterm backend scrolling still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Terminal scrolling reworked so backends can manage scrolling themselves when supported.

* **Bug Fixes**
  * View now snaps to bottom on paste, text/IME commit, and key input to keep output visible.
  * Cursor is hidden when outside the visible viewport to avoid misplacement.
  * Selection/highlight alignment improved for backends that manage their own scroll.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->