### PR TITLE
Fix reverse video rendering and restore cursor visibility (refs #135)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libgtk-3-dev
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/crates/amux-render-gpu/Cargo.toml
+++ b/crates/amux-render-gpu/Cargo.toml
@@ -16,3 +16,6 @@ tracing = { workspace = true }
 image = { workspace = true }
 wezterm-surface = { workspace = true }
 amux-term = { workspace = true }
+
+[dev-dependencies]
+url = { workspace = true }

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -551,3 +551,150 @@ fn decode_images(seen: HashMap<[u8; 32], Arc<ImageData>>) -> Vec<DecodedImage> {
 fn dim_color(c: [f32; 4], factor: f32) -> [f32; 4] {
     [c[0] * factor, c[1] * factor, c[2] * factor, c[3]]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use amux_term::backend::*;
+    use amux_term::osc::NotificationEvent;
+    use amux_term::pane::{AdvanceResult, SequenceNo, TermError};
+    use std::io::Read as IoRead;
+    use url::Url;
+
+    /// Minimal mock backend for snapshot tests.
+    struct MockBackend {
+        cells: Vec<ScreenRow>,
+        palette: Palette,
+    }
+
+    impl TerminalBackend for MockBackend {
+        fn advance(&mut self) -> AdvanceResult {
+            AdvanceResult::Eof
+        }
+        fn resize(&mut self, _cols: u16, _rows: u16) -> Result<(), TermError> {
+            Ok(())
+        }
+        fn write_bytes(&mut self, _data: &[u8]) -> Result<(), TermError> {
+            Ok(())
+        }
+        fn feed_bytes(&mut self, _data: &[u8]) {}
+        fn take_reader(&mut self) -> Option<Box<dyn IoRead + Send>> {
+            None
+        }
+        fn title(&self) -> &str {
+            ""
+        }
+        fn working_dir(&self) -> Option<&Url> {
+            None
+        }
+        fn dimensions(&self) -> (usize, usize) {
+            (80, 1)
+        }
+        fn cursor(&self) -> CursorPos {
+            CursorPos::default()
+        }
+        fn palette(&self) -> Palette {
+            self.palette.clone()
+        }
+        fn is_alt_screen_active(&self) -> bool {
+            false
+        }
+        fn bracketed_paste_enabled(&self) -> bool {
+            false
+        }
+        fn child_pid(&self) -> Option<u32> {
+            None
+        }
+        fn is_alive(&mut self) -> bool {
+            false
+        }
+        fn exit_status(&mut self) -> Option<ProcessExit> {
+            None
+        }
+        fn changed_lines(&self) -> Vec<StableRow> {
+            Vec::new()
+        }
+        fn mark_rendered(&mut self) {}
+        fn current_seqno(&self) -> SequenceNo {
+            0
+        }
+        fn rendered_seqno(&self) -> SequenceNo {
+            0
+        }
+        fn scrollback_rows(&self) -> usize {
+            self.cells.len()
+        }
+        fn read_screen_lines(&self, _spec: &str, _ansi: bool) -> String {
+            String::new()
+        }
+        fn read_screen_text(&self) -> String {
+            String::new()
+        }
+        fn read_scrollback_text(&self, _max: usize) -> String {
+            String::new()
+        }
+        fn read_scrollback_text_range(&self, _start: usize, _end: usize) -> String {
+            String::new()
+        }
+        fn search_scrollback(&self, _query: &str) -> Vec<(usize, usize, usize)> {
+            Vec::new()
+        }
+        fn read_screen_cells(&self, _offset: usize) -> Vec<ScreenRow> {
+            self.cells.clone()
+        }
+        fn read_cells_range(&self, start: usize, end: usize) -> Vec<ScreenRow> {
+            self.cells[start..end.min(self.cells.len())].to_vec()
+        }
+        fn erase_scrollback(&mut self) {}
+        fn focus_changed(&mut self, _focused: bool) {}
+        fn drain_notifications(&self) -> Vec<NotificationEvent> {
+            Vec::new()
+        }
+    }
+
+    #[test]
+    fn from_backend_swaps_fg_bg_when_reverse() {
+        let fg = Color(1.0, 0.0, 0.0, 1.0); // red
+        let bg = Color(0.0, 0.0, 1.0, 1.0); // blue
+
+        let normal_cell = ScreenCell {
+            text: "A".to_string(),
+            fg,
+            bg,
+            bold: false,
+            italic: false,
+            underline: UnderlineStyle::None,
+            underline_color: None,
+            strikethrough: false,
+            faint: false,
+            reverse: false,
+            hyperlink_url: None,
+        };
+        let reverse_cell = ScreenCell {
+            text: "B".to_string(),
+            fg,
+            bg,
+            reverse: true,
+            ..normal_cell.clone()
+        };
+        let row = ScreenRow {
+            cells: vec![normal_cell, reverse_cell],
+            wrapped: false,
+        };
+        let backend = MockBackend {
+            cells: vec![row],
+            palette: Palette::default(),
+        };
+
+        let snap =
+            TerminalSnapshot::from_backend(&backend, 2, 1, 0, true, None, 0, 0, Vec::new(), None);
+
+        // Normal cell: fg=red, bg=blue (unchanged)
+        assert_eq!(snap.cells[0].fg, [1.0, 0.0, 0.0, 1.0]);
+        assert_eq!(snap.cells[0].bg, [0.0, 0.0, 1.0, 1.0]);
+
+        // Reverse cell: fg and bg should be swapped
+        assert_eq!(snap.cells[1].fg, [0.0, 0.0, 1.0, 1.0]); // was bg (blue)
+        assert_eq!(snap.cells[1].bg, [1.0, 0.0, 0.0, 1.0]); // was fg (red)
+    }
+}

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -162,8 +162,13 @@ impl TerminalSnapshot {
                     break;
                 }
 
-                let mut fg = color_to_f32(cell.fg);
-                let mut bg = color_to_f32(cell.bg);
+                let (fg_color, bg_color) = if cell.reverse {
+                    (cell.bg, cell.fg)
+                } else {
+                    (cell.fg, cell.bg)
+                };
+                let mut fg = color_to_f32(fg_color);
+                let mut bg = color_to_f32(bg_color);
 
                 // Apply selection highlighting (swap fg/bg)
                 let stable_row = start + row_idx;

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -474,22 +474,15 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         let mut rs = self.render_state.borrow_mut();
         if let Ok(snapshot) = rs.update(&self.terminal) {
             if let Ok(Some(vp)) = snapshot.cursor_viewport() {
+                let visible = snapshot.cursor_visible().unwrap_or(true);
                 return CursorPos {
                     x: vp.x as usize,
                     y: vp.y as i64,
                     shape: self.cached_cursor_shape,
-                    // Work around libghostty-vt cursor visibility tracking:
-                    // both render state and direct terminal query report
-                    // cursor_visible=false and never recover after Claude Code
-                    // toggles DECTCEM. Force visible=true until the root cause
-                    // is identified (wezterm backend handles this correctly).
-                    // TODO(#135): investigate libghostty-vt DECTCEM handling
-                    visible: true,
+                    visible,
                 };
             }
         }
-        // cursor_viewport() returned None — cursor is outside the visible
-        // viewport (e.g., scrolled into history). Hide it.
         CursorPos {
             x: 0,
             y: 0,

--- a/crates/amux-term/tests/ghostty_integration.rs
+++ b/crates/amux-term/tests/ghostty_integration.rs
@@ -14,6 +14,18 @@ use amux_term::backend::TerminalBackend;
 use amux_term::ghostty_pane::GhosttyPane;
 use amux_term::pane::AdvanceResult;
 
+/// Helper: create a raw Terminal + RenderState pair for direct VT API tests.
+fn new_terminal_and_render_state() -> (libghostty_vt::Terminal, libghostty_vt::RenderState) {
+    let terminal = libghostty_vt::Terminal::new(libghostty_vt::TerminalOptions {
+        cols: 80,
+        rows: 24,
+        max_scrollback: 10000,
+    })
+    .expect("terminal creation failed");
+    let render_state = libghostty_vt::RenderState::new().expect("render state creation failed");
+    (terminal, render_state)
+}
+
 /// Helper: spawn a GhosttyPane running a bash script, advance until EOF or timeout.
 fn spawn_and_run(script: &str) -> Box<GhosttyPane<'static, 'static>> {
     let mut cmd = CommandBuilder::new("bash");
@@ -76,7 +88,7 @@ fn screen_text_contains_output() {
 #[test]
 fn feed_bytes_renders_to_screen() {
     let mut cmd = CommandBuilder::new("sleep");
-    cmd.arg("10");
+    cmd.arg("1");
     let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
 
     // Feed bytes directly into the VT state machine (bypass PTY)
@@ -185,7 +197,7 @@ fn search_scrollback_case_insensitive() {
 #[test]
 fn is_alive_while_running() {
     let mut cmd = CommandBuilder::new("sleep");
-    cmd.arg("10");
+    cmd.arg("1");
     let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
     assert!(pane.is_alive(), "expected process to be alive");
 }
@@ -193,7 +205,7 @@ fn is_alive_while_running() {
 #[test]
 fn cursor_visible_after_show_hide_sequence() {
     let mut cmd = CommandBuilder::new("sleep");
-    cmd.arg("10");
+    cmd.arg("1");
     let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
 
     // Cursor should be visible initially
@@ -220,7 +232,7 @@ fn cursor_visible_after_show_hide_sequence() {
 #[test]
 fn cursor_visible_after_rapid_toggle() {
     let mut cmd = CommandBuilder::new("sleep");
-    cmd.arg("10");
+    cmd.arg("1");
     let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
 
     // Simulate rapid DECTCEM toggling like Claude Code does
@@ -250,16 +262,7 @@ fn cursor_visible_after_rapid_toggle() {
 #[test]
 fn cursor_visible_raw_api_after_rapid_toggle() {
     // Test the raw libghostty-vt API directly, bypassing the workaround
-    use libghostty_vt::{RenderState, Terminal, TerminalOptions};
-
-    let mut terminal = Terminal::new(TerminalOptions {
-        cols: 80,
-        rows: 24,
-        max_scrollback: 10000,
-    })
-    .expect("terminal creation failed");
-
-    let mut render_state = RenderState::new().expect("render state creation failed");
+    let (mut terminal, mut render_state) = new_terminal_and_render_state();
 
     // Initial state: cursor should be visible
     let snap = render_state.update(&terminal).expect("update failed");
@@ -330,16 +333,7 @@ fn cursor_visible_raw_api_after_rapid_toggle() {
 #[test]
 fn cursor_visible_split_sequence() {
     // Test if splitting an escape sequence across two vt_write calls causes issues
-    use libghostty_vt::{RenderState, Terminal, TerminalOptions};
-
-    let mut terminal = Terminal::new(TerminalOptions {
-        cols: 80,
-        rows: 24,
-        max_scrollback: 10000,
-    })
-    .expect("terminal creation failed");
-
-    let mut render_state = RenderState::new().expect("render state creation failed");
+    let (mut terminal, mut render_state) = new_terminal_and_render_state();
 
     // Hide cursor with complete sequence
     terminal.vt_write(b"\x1b[?25l");
@@ -363,16 +357,7 @@ fn cursor_visible_split_sequence() {
 #[test]
 fn cursor_visible_truncated_in_buffer() {
     // Test if a truncated escape sequence at buffer boundary causes permanent state corruption
-    use libghostty_vt::{RenderState, Terminal, TerminalOptions};
-
-    let mut terminal = Terminal::new(TerminalOptions {
-        cols: 80,
-        rows: 24,
-        max_scrollback: 10000,
-    })
-    .expect("terminal creation failed");
-
-    let mut render_state = RenderState::new().expect("render state creation failed");
+    let (mut terminal, mut render_state) = new_terminal_and_render_state();
 
     // Simulate a buffer read that cuts the escape sequence mid-way:
     // "\x1b[?25l" followed by text, then "\x1b[?25" cut off, then "h" in next buffer

--- a/crates/amux-term/tests/ghostty_integration.rs
+++ b/crates/amux-term/tests/ghostty_integration.rs
@@ -191,6 +191,214 @@ fn is_alive_while_running() {
 }
 
 #[test]
+fn cursor_visible_after_show_hide_sequence() {
+    let mut cmd = CommandBuilder::new("sleep");
+    cmd.arg("10");
+    let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
+
+    // Cursor should be visible initially
+    let cursor = pane.cursor();
+    assert!(cursor.visible, "cursor should be visible initially");
+
+    // Send DECTCEM hide: CSI ? 25 l
+    pane.feed_bytes(b"\x1b[?25l");
+    let cursor = pane.cursor();
+    assert!(
+        !cursor.visible,
+        "cursor should be hidden after hide sequence"
+    );
+
+    // Send DECTCEM show: CSI ? 25 h
+    pane.feed_bytes(b"\x1b[?25h");
+    let cursor = pane.cursor();
+    assert!(
+        cursor.visible,
+        "cursor should be visible after show sequence"
+    );
+}
+
+#[test]
+fn cursor_visible_after_rapid_toggle() {
+    let mut cmd = CommandBuilder::new("sleep");
+    cmd.arg("10");
+    let mut pane = GhosttyPane::spawn(80, 24, cmd).expect("spawn failed");
+
+    // Simulate rapid DECTCEM toggling like Claude Code does
+    for _ in 0..50 {
+        pane.feed_bytes(b"\x1b[?25l"); // hide
+        pane.feed_bytes(b"\x1b[?25h"); // show
+    }
+
+    let cursor = pane.cursor();
+    assert!(
+        cursor.visible,
+        "cursor should be visible after rapid show/hide toggling"
+    );
+
+    // Now test: hide, then do some output, then show
+    pane.feed_bytes(b"\x1b[?25l");
+    pane.feed_bytes(b"some output here\r\n");
+    pane.feed_bytes(b"\x1b[?25h");
+
+    let cursor = pane.cursor();
+    assert!(
+        cursor.visible,
+        "cursor should be visible after hide-output-show pattern"
+    );
+}
+
+#[test]
+fn cursor_visible_raw_api_after_rapid_toggle() {
+    // Test the raw libghostty-vt API directly, bypassing the workaround
+    use libghostty_vt::{RenderState, Terminal, TerminalOptions};
+
+    let mut terminal = Terminal::new(TerminalOptions {
+        cols: 80,
+        rows: 24,
+        max_scrollback: 10000,
+    })
+    .expect("terminal creation failed");
+
+    let mut render_state = RenderState::new().expect("render state creation failed");
+
+    // Initial state: cursor should be visible
+    let snap = render_state.update(&terminal).expect("update failed");
+    let visible = snap.cursor_visible().expect("cursor_visible failed");
+    assert!(visible, "cursor should be visible initially (raw API)");
+
+    // Simple hide
+    terminal.vt_write(b"\x1b[?25l");
+    let snap = render_state.update(&terminal).expect("update failed");
+    let visible = snap.cursor_visible().expect("cursor_visible failed");
+    assert!(!visible, "cursor should be hidden after hide (raw API)");
+
+    // Simple show
+    terminal.vt_write(b"\x1b[?25h");
+    let snap = render_state.update(&terminal).expect("update failed");
+    let visible = snap.cursor_visible().expect("cursor_visible failed");
+    assert!(
+        visible,
+        "cursor should be visible after show (raw API) — FAILS if DECTCEM bug exists"
+    );
+
+    // Rapid toggling
+    for _ in 0..100 {
+        terminal.vt_write(b"\x1b[?25l");
+        terminal.vt_write(b"\x1b[?25h");
+    }
+    let snap = render_state.update(&terminal).expect("update failed");
+    let visible = snap.cursor_visible().expect("cursor_visible failed");
+    assert!(
+        visible,
+        "cursor should be visible after 100 rapid toggles (raw API)"
+    );
+
+    // Rapid toggling with interleaved output (closer to Claude Code pattern)
+    for i in 0..50 {
+        terminal.vt_write(b"\x1b[?25l");
+        terminal.vt_write(format!("line {i}\r\n").as_bytes());
+        terminal.vt_write(b"\x1b[?25h");
+    }
+    let snap = render_state.update(&terminal).expect("update failed");
+    let visible = snap.cursor_visible().expect("cursor_visible failed");
+    assert!(
+        visible,
+        "cursor should be visible after toggle-with-output pattern (raw API)"
+    );
+
+    // Batched writes — multiple sequences in one vt_write call
+    for _ in 0..50 {
+        terminal.vt_write(b"\x1b[?25lwriting stuff\r\n\x1b[?25h");
+    }
+    let snap = render_state.update(&terminal).expect("update failed");
+    let visible = snap.cursor_visible().expect("cursor_visible failed");
+    assert!(
+        visible,
+        "cursor should be visible after batched toggle-with-output (raw API)"
+    );
+
+    // Test: what does terminal.is_cursor_visible() say vs render state?
+    let terminal_visible = terminal
+        .is_cursor_visible()
+        .expect("is_cursor_visible failed");
+    assert_eq!(
+        visible, terminal_visible,
+        "render state and terminal should agree on cursor visibility"
+    );
+}
+
+#[test]
+fn cursor_visible_split_sequence() {
+    // Test if splitting an escape sequence across two vt_write calls causes issues
+    use libghostty_vt::{RenderState, Terminal, TerminalOptions};
+
+    let mut terminal = Terminal::new(TerminalOptions {
+        cols: 80,
+        rows: 24,
+        max_scrollback: 10000,
+    })
+    .expect("terminal creation failed");
+
+    let mut render_state = RenderState::new().expect("render state creation failed");
+
+    // Hide cursor with complete sequence
+    terminal.vt_write(b"\x1b[?25l");
+    let snap = render_state.update(&terminal).expect("update failed");
+    assert!(
+        !snap.cursor_visible().expect("cursor_visible failed"),
+        "cursor should be hidden"
+    );
+
+    // Show cursor with SPLIT sequence — ESC[ in one call, ?25h in another
+    terminal.vt_write(b"\x1b[");
+    terminal.vt_write(b"?25h");
+    let snap = render_state.update(&terminal).expect("update failed");
+    let visible = snap.cursor_visible().expect("cursor_visible failed");
+    assert!(
+        visible,
+        "cursor should be visible after split show sequence — FAILS if split causes bug"
+    );
+}
+
+#[test]
+fn cursor_visible_truncated_in_buffer() {
+    // Test if a truncated escape sequence at buffer boundary causes permanent state corruption
+    use libghostty_vt::{RenderState, Terminal, TerminalOptions};
+
+    let mut terminal = Terminal::new(TerminalOptions {
+        cols: 80,
+        rows: 24,
+        max_scrollback: 10000,
+    })
+    .expect("terminal creation failed");
+
+    let mut render_state = RenderState::new().expect("render state creation failed");
+
+    // Simulate a buffer read that cuts the escape sequence mid-way:
+    // "\x1b[?25l" followed by text, then "\x1b[?25" cut off, then "h" in next buffer
+    terminal.vt_write(b"\x1b[?25l");
+    terminal.vt_write(b"some text\r\n");
+    terminal.vt_write(b"\x1b[?25"); // truncated — missing 'h'
+    terminal.vt_write(b"h"); // rest of sequence in next buffer
+
+    let snap = render_state.update(&terminal).expect("update failed");
+    let visible = snap.cursor_visible().expect("cursor_visible failed");
+    assert!(
+        visible,
+        "cursor should be visible after truncated-then-completed sequence"
+    );
+
+    // Verify terminal agrees
+    let terminal_visible = terminal
+        .is_cursor_visible()
+        .expect("is_cursor_visible failed");
+    assert!(
+        terminal_visible,
+        "terminal should also report visible after truncated-then-completed sequence"
+    );
+}
+
+#[test]
 fn seqno_increments_on_advance() {
     let mut cmd = CommandBuilder::new("bash");
     cmd.args(["--norc", "--noprofile", "-c", "printf 'x\\n'; exit 0"]);

--- a/crates/amux-term/tests/ghostty_integration.rs
+++ b/crates/amux-term/tests/ghostty_integration.rs
@@ -299,7 +299,8 @@ fn cursor_visible_raw_api_after_rapid_toggle() {
     // Rapid toggling with interleaved output (closer to Claude Code pattern)
     for i in 0..50 {
         terminal.vt_write(b"\x1b[?25l");
-        terminal.vt_write(format!("line {i}\r\n").as_bytes());
+        let line = format!("line {i}\r\n");
+        terminal.vt_write(line.as_bytes());
         terminal.vt_write(b"\x1b[?25h");
     }
     let snap = render_state.update(&terminal).expect("update failed");


### PR DESCRIPTION
## Summary

- **Root cause**: `TerminalSnapshot::from_backend()` ignored the `reverse` (SGR 7) cell attribute, reading fg/bg colors without swapping them. TUI apps like Claude Code draw their software cursor as a reverse-video cell — this rendered identically to the background in the ghostty backend, making the cursor invisible.
- **Fix**: Swap fg/bg in `from_backend()` when `cell.reverse` is true (2-line fix in snapshot.rs)
- **Removed workaround**: `GhosttyPane::cursor()` no longer forces `visible: true` — proper DECTCEM tracking is restored now that the real issue is fixed
- **Added tests**: 5 new DECTCEM cursor visibility tests for the libghostty-vt backend covering simple show/hide, rapid toggling, raw API, split sequences, and truncated buffer boundaries

## Investigation trail

The cursor was reported invisible in #135 and a `visible: true` workaround was added in #134. Investigation revealed:
1. libghostty-vt's DECTCEM tracking works correctly (all synthetic tests pass)
2. Claude Code intentionally hides the hardware cursor and draws its own via reverse video
3. The wezterm backend also reports `cursor_visible=false` with Claude Code — but its `from_screen` path applies reverse video correctly via `resolve_color`
4. The `from_backend` path (used by ghostty) was missing the reverse swap

This also fixes all other reverse-video rendering (vim status bars, selected text, etc.) for the ghostty backend.

## Test plan
- [x] Cursor visible at Claude Code input prompt with ghostty backend
- [x] Reverse video cells render correctly (fg/bg swapped)
- [x] `cargo test -p amux-term --features libghostty -- cursor_visible` (5 tests pass)
- [x] `cargo clippy --workspace -- -D warnings && cargo fmt --check`
- [x] `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color handling so reverse-video cells swap foreground/background before highlighting
  * Improved cursor visibility detection so the displayed cursor accurately reflects terminal state

* **Tests**
  * Added unit and extensive integration tests for cursor visibility, rapid toggles, split/truncated escapes, and visibility cross-checks
  * Shortened long sleep intervals and added a helper for VT render-state tests

* **Chores**
  * Added a dev dependency for testing/environment setup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->