### PR TITLE
Clean up session restore with VT state snapshots (refs #139)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "amux-term",
  "anyhow",
  "arboard",
+ "base64 0.22.1",
  "chrono",
  "dirs",
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ license = "MIT"
 repository = "https://github.com/yourusername/amux"
 
 [workspace.dependencies]
+# Encoding
+base64 = "0.22"
+
 # Terminal engine
 wezterm-term = { git = "https://github.com/wezterm/wezterm", rev = "05343b387085842b434d267f91b6b0ec157e4331" }
 wezterm-surface = { git = "https://github.com/wezterm/wezterm", rev = "05343b387085842b434d267f91b6b0ec157e4331" }
@@ -46,7 +49,6 @@ cosmic-text = "0.12"
 
 # Image decoding
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "ico"] }
-base64 = "0.22"
 
 # GPU rendering
 wgpu = "24.0"

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -21,6 +21,7 @@ eframe = { workspace = true }
 egui = { workspace = true }
 arboard = { workspace = true }
 anyhow = { workspace = true }
+base64 = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 portable-pty = { workspace = true }

--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -731,6 +731,7 @@ impl AmuxApp {
                                 sf_id,
                                 cwd.as_deref(),
                                 None,
+                                None,
                             ) {
                                 Ok(surface) => {
                                     let managed = self

--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -701,9 +701,9 @@ impl AmuxApp {
                             .and_then(|s| s.parse::<PaneId>().ok())
                             .unwrap_or(self.focused_pane_id());
 
-                        // Validate pane exists before spawning a surface
-                        if !self.panes.contains_key(&target_pane) {
-                            Response::err(req.id.clone(), "not_found", "pane not found")
+                        // Validate pane exists and is a terminal before spawning a surface
+                        if !matches!(self.panes.get(&target_pane), Some(PaneEntry::Terminal(_))) {
+                            Response::err(req.id.clone(), "not_found", "terminal pane not found")
                         } else {
                             // Find the workspace that owns this pane
                             let ws_id = self

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -425,17 +425,27 @@ impl AmuxApp {
                                         .map(|p| p.to_string_lossy().to_string())
                                         .or_else(|| sf.pane.child_pid().and_then(get_cwd_from_pid))
                                 });
-                                let raw_scrollback = sf
-                                    .pane
-                                    .read_scrollback_text(amux_session::MAX_SCROLLBACK_LINES);
-                                let truncated = amux_session::truncate_scrollback(
-                                    &raw_scrollback,
-                                    amux_session::MAX_SCROLLBACK_BYTES,
-                                );
-                                let scrollback = if truncated.len() == raw_scrollback.len() {
-                                    raw_scrollback
+                                // Prefer VT state snapshot (exact terminal state
+                                // reconstruction) over text-based scrollback.
+                                let scrollback_vt = sf.pane.vt_state_snapshot().map(|bytes| {
+                                    use base64::Engine;
+                                    base64::engine::general_purpose::STANDARD.encode(&bytes)
+                                });
+                                let scrollback = if scrollback_vt.is_none() {
+                                    let raw = sf
+                                        .pane
+                                        .read_scrollback_text(amux_session::MAX_SCROLLBACK_LINES);
+                                    let truncated = amux_session::truncate_scrollback(
+                                        &raw,
+                                        amux_session::MAX_SCROLLBACK_BYTES,
+                                    );
+                                    if truncated.len() == raw.len() {
+                                        raw
+                                    } else {
+                                        truncated.to_string()
+                                    }
                                 } else {
-                                    truncated.to_string()
+                                    String::new()
                                 };
                                 let (cols, rows) = sf.pane.dimensions();
                                 amux_session::SavedSurface {
@@ -443,6 +453,7 @@ impl AmuxApp {
                                     title: sf.pane.title().to_string(),
                                     working_dir,
                                     scrollback,
+                                    scrollback_vt,
                                     cols: cols as u16,
                                     rows: rows as u16,
                                     git_branch: sf.metadata.git_branch.clone(),

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -427,10 +427,16 @@ impl AmuxApp {
                                 });
                                 // Prefer VT state snapshot (exact terminal state
                                 // reconstruction) over text-based scrollback.
-                                let scrollback_vt = sf.pane.vt_state_snapshot().map(|bytes| {
-                                    use base64::Engine;
-                                    base64::engine::general_purpose::STANDARD.encode(&bytes)
-                                });
+                                let scrollback_vt = sf
+                                    .pane
+                                    .vt_state_snapshot()
+                                    .filter(|bytes| {
+                                        bytes.len() <= amux_session::MAX_SCROLLBACK_BYTES
+                                    })
+                                    .map(|bytes| {
+                                        use base64::Engine;
+                                        base64::engine::general_purpose::STANDARD.encode(&bytes)
+                                    });
                                 let scrollback = if scrollback_vt.is_none() {
                                     let raw = sf
                                         .pane

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -535,6 +535,7 @@ impl AmuxApp {
                             sf_id,
                             cwd.as_deref(),
                             None,
+                            None,
                         ) {
                             if let Some(PaneEntry::Terminal(m)) = self.panes.get_mut(&pane_id) {
                                 let insert_at = (m.active_tab_idx + 1).min(m.tabs.len());

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -2,6 +2,40 @@
 
 use crate::*;
 
+/// Strip ANSI escape sequences from a string, returning only visible text.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // Skip CSI sequences (\x1b[...m etc.) and OSC sequences
+            if let Some(next) = chars.next() {
+                if next == '[' {
+                    // CSI: consume until a letter in @-~ range
+                    for c2 in chars.by_ref() {
+                        if c2.is_ascii_alphabetic() || c2 == '~' || c2 == '@' {
+                            break;
+                        }
+                    }
+                } else if next == ']' {
+                    // OSC: consume until ST (\x1b\\) or BEL (\x07)
+                    let mut prev = next;
+                    for c2 in chars.by_ref() {
+                        if c2 == '\x07' || (prev == '\x1b' && c2 == '\\') {
+                            break;
+                        }
+                        prev = c2;
+                    }
+                }
+                // else: two-char escape like \x1b( — already consumed
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 pub(crate) fn run() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
@@ -217,7 +251,18 @@ pub(crate) fn fresh_startup(
     config: &Arc<AmuxTermConfig>,
 ) -> anyhow::Result<StartupState> {
     let initial_pane_id: PaneId = 0;
-    let surface = spawn_surface(80, 24, ipc_addr, socket_token, config, 0, 0, None, None)?;
+    let surface = spawn_surface(
+        80,
+        24,
+        ipc_addr,
+        socket_token,
+        config,
+        0,
+        0,
+        None,
+        None,
+        None,
+    )?;
 
     let managed = PaneEntry::Terminal(ManagedPane {
         tabs: vec![managed_pane::TabEntry::Terminal(Box::new(surface))],
@@ -294,6 +339,7 @@ pub(crate) fn restore_session(
                 } else {
                     Some(saved_sf.scrollback.as_str())
                 };
+                let scrollback_vt = saved_sf.scrollback_vt.as_deref();
 
                 match spawn_surface(
                     saved_sf.cols,
@@ -305,6 +351,7 @@ pub(crate) fn restore_session(
                     saved_sf.id,
                     cwd,
                     scrollback,
+                    scrollback_vt,
                 ) {
                     Ok(mut surface) => {
                         // Restore git/PR metadata from session
@@ -471,6 +518,7 @@ pub(crate) fn spawn_surface(
     surface_id: u64,
     cwd: Option<&str>,
     scrollback: Option<&str>,
+    scrollback_vt: Option<&str>,
 ) -> anyhow::Result<PaneSurface> {
     let shell = shell::default_shell();
     let mut cmd = CommandBuilder::new(&shell);
@@ -541,17 +589,38 @@ pub(crate) fn spawn_surface(
         }
     };
 
-    // Inject scrollback text before starting the reader thread.
+    // Inject saved terminal state before starting the reader thread.
     // feed_bytes writes directly to the terminal state machine, not through the PTY.
-    if let Some(text) = scrollback {
-        if !text.is_empty() {
-            // Convert \n to \r\n for terminal processing, avoiding extra trailing blank line.
-            let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
-            let trimmed = normalized.trim_end_matches('\n');
-            let buffer = trimmed.replace('\n', "\r\n");
-            if !buffer.is_empty() {
-                pane.feed_bytes(buffer.as_bytes());
-                pane.feed_bytes(b"\r\n");
+    let mut restored = false;
+    if let Some(vt_b64) = scrollback_vt {
+        if !vt_b64.is_empty() {
+            use base64::Engine;
+            if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(vt_b64) {
+                pane.feed_bytes(&bytes);
+                restored = true;
+            }
+        }
+    }
+    if !restored {
+        if let Some(text) = scrollback {
+            if !text.is_empty() {
+                // Strip trailing lines whose visible text (after removing ANSI
+                // escape sequences) is empty or whitespace-only.
+                let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+                let lines: Vec<&str> = normalized.split('\n').collect();
+                let trimmed: Vec<&str> = lines
+                    .into_iter()
+                    .rev()
+                    .skip_while(|line| strip_ansi(line).trim().is_empty())
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect();
+                let buffer = trimmed.join("\r\n");
+                if !buffer.is_empty() {
+                    pane.feed_bytes(buffer.as_bytes());
+                    pane.feed_bytes(b"\r\n");
+                }
             }
         }
     }

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -11,9 +11,9 @@ fn strip_ansi(s: &str) -> String {
             // Skip CSI sequences (\x1b[...m etc.) and OSC sequences
             if let Some(next) = chars.next() {
                 if next == '[' {
-                    // CSI: consume until a letter in @-~ range
+                    // CSI: consume until final byte in 0x40..=0x7E range
                     for c2 in chars.by_ref() {
-                        if c2.is_ascii_alphabetic() || c2 == '~' || c2 == '@' {
+                        if ('@'..='~').contains(&c2) {
                             break;
                         }
                     }
@@ -595,9 +595,14 @@ pub(crate) fn spawn_surface(
     if let Some(vt_b64) = scrollback_vt {
         if !vt_b64.is_empty() {
             use base64::Engine;
-            if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(vt_b64) {
-                pane.feed_bytes(&bytes);
-                restored = true;
+            match base64::engine::general_purpose::STANDARD.decode(vt_b64) {
+                Ok(bytes) => {
+                    pane.feed_bytes(&bytes);
+                    restored = true;
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to decode scrollback_vt base64: {e}");
+                }
             }
         }
     }

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -52,6 +52,7 @@ impl AmuxApp {
             sf_id,
             cwd.as_deref(),
             None,
+            None,
         ) {
             Ok(surface) => {
                 let pane_id = self.next_pane_id;
@@ -90,6 +91,7 @@ impl AmuxApp {
             ws_id,
             sf_id,
             cwd.as_deref(),
+            None,
             None,
         ) {
             Ok(surface) => {
@@ -144,6 +146,7 @@ impl AmuxApp {
             ws_id,
             sf_id,
             cwd.as_deref(),
+            None,
             None,
         ) {
             Ok(surface) => {
@@ -382,6 +385,7 @@ impl AmuxApp {
             ws_id,
             sf_id,
             cwd.as_deref(),
+            None,
             None,
         ) {
             Ok(new_surface) => {

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -355,6 +355,26 @@ mod tests {
     }
 
     #[test]
+    fn round_trip_serde_with_scrollback_vt() {
+        let mut session = minimal_session();
+        session.workspaces[0].panes.get_mut(&0).unwrap().surfaces[0].scrollback_vt =
+            Some("dGVzdA==".to_string()); // base64("test")
+        let json = serde_json::to_string(&session).unwrap();
+        assert!(json.contains("scrollback_vt"));
+        let restored: SessionData = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            restored.workspaces[0].panes[&0].surfaces[0].scrollback_vt,
+            Some("dGVzdA==".to_string())
+        );
+
+        // Verify skip_serializing_if works: None should not appear in JSON
+        let mut session2 = minimal_session();
+        session2.workspaces[0].panes.get_mut(&0).unwrap().surfaces[0].scrollback_vt = None;
+        let json2 = serde_json::to_string(&session2).unwrap();
+        assert!(!json2.contains("scrollback_vt"));
+    }
+
+    #[test]
     fn load_missing_file_returns_none() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("session.json");

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -144,6 +144,11 @@ pub struct SavedSurface {
     pub working_dir: Option<String>,
     #[serde(default)]
     pub scrollback: String,
+    /// VT state snapshot (base64-encoded byte stream from ghostty formatter).
+    /// When present, preferred over `scrollback` for session restore — produces
+    /// an exact reconstruction of terminal state without trailing blank lines.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scrollback_vt: Option<String>,
     pub cols: u16,
     pub rows: u16,
     #[serde(default)]
@@ -302,6 +307,7 @@ mod tests {
                     pr_title: None,
                     pr_state: None,
                     user_title: None,
+                    scrollback_vt: None,
                 }],
                 active_surface_idx: 0,
                 browser: None,

--- a/crates/amux-term/src/any_backend.rs
+++ b/crates/amux-term/src/any_backend.rs
@@ -157,6 +157,10 @@ impl TerminalBackend for AnyBackend {
         delegate!(self, search_scrollback, query: &str)
     }
 
+    fn vt_state_snapshot(&self) -> Option<Vec<u8>> {
+        delegate!(self, vt_state_snapshot)
+    }
+
     fn read_screen_cells(&self, scroll_offset: usize) -> Vec<ScreenRow> {
         delegate!(self, read_screen_cells, scroll_offset: usize)
     }

--- a/crates/amux-term/src/backend.rs
+++ b/crates/amux-term/src/backend.rs
@@ -323,6 +323,16 @@ pub trait TerminalBackend {
     /// handle receiving fewer rows than requested.
     fn read_cells_range(&self, start_row: usize, end_row: usize) -> Vec<ScreenRow>;
 
+    /// Serialize the full terminal state (screen content + modes + cursor) as a
+    /// VT escape sequence byte stream. When fed back to `feed_bytes` on a new
+    /// terminal of the same size, it reconstructs the visual state exactly.
+    ///
+    /// Returns `None` if the backend doesn't support VT state serialization.
+    /// Currently only the libghostty backend supports this.
+    fn vt_state_snapshot(&self) -> Option<Vec<u8>> {
+        None
+    }
+
     // --- Scrolling ---
 
     /// Whether this backend manages its own viewport scrolling.

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -649,6 +649,82 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         selected.join("\n")
     }
 
+    fn vt_state_snapshot(&self) -> Option<Vec<u8>> {
+        use libghostty_vt::ffi;
+
+        // SAFETY: Terminal's first field is Object<GhosttyTerminal> whose first
+        // field is NonNull<GhosttyTerminal>. Both are #[repr(Rust)] but NonNull
+        // is guaranteed to have the same layout as *mut T. We read the pointer
+        // without taking ownership. This is sound as long as libghostty-vt's
+        // Terminal struct layout doesn't change (pinned to 0.1.1).
+        let terminal_ptr: ffi::GhosttyTerminal_ptr = unsafe {
+            let ptr_to_terminal = &*self.terminal as *const _ as *const *mut ffi::GhosttyTerminal;
+            *ptr_to_terminal
+        };
+
+        let mut formatter: ffi::GhosttyFormatter_ptr = std::ptr::null_mut();
+        let screen_extra = ffi::GhosttyFormatterScreenExtra {
+            size: std::mem::size_of::<ffi::GhosttyFormatterScreenExtra>(),
+            cursor: true,
+            style: true,
+            hyperlink: true,
+            protection: false,
+            kitty_keyboard: true,
+            charsets: true,
+        };
+        let terminal_extra = ffi::GhosttyFormatterTerminalExtra {
+            size: std::mem::size_of::<ffi::GhosttyFormatterTerminalExtra>(),
+            palette: false,
+            modes: true,
+            scrolling_region: true,
+            tabstops: false, // tabstop restore moves cursor after CUP
+            pwd: true,
+            keyboard: true,
+            screen: screen_extra,
+        };
+        let opts = ffi::GhosttyFormatterTerminalOptions {
+            size: std::mem::size_of::<ffi::GhosttyFormatterTerminalOptions>(),
+            emit: ffi::GhosttyFormatterFormat_GHOSTTY_FORMATTER_FORMAT_VT,
+            unwrap: false,
+            trim: true,
+            extra: terminal_extra,
+        };
+
+        let result = unsafe {
+            ffi::ghostty_formatter_terminal_new(
+                std::ptr::null(),
+                &mut formatter,
+                terminal_ptr,
+                opts,
+            )
+        };
+        if result != ffi::GhosttyResult_GHOSTTY_SUCCESS {
+            tracing::warn!("ghostty_formatter_terminal_new failed: {result}");
+            return None;
+        }
+
+        let mut out_ptr: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let result = unsafe {
+            ffi::ghostty_formatter_format_alloc(
+                formatter,
+                std::ptr::null(),
+                &mut out_ptr,
+                &mut out_len,
+            )
+        };
+        unsafe { ffi::ghostty_formatter_free(formatter) };
+
+        if result != ffi::GhosttyResult_GHOSTTY_SUCCESS || out_ptr.is_null() {
+            tracing::warn!("ghostty_formatter_format_alloc failed: {result}");
+            return None;
+        }
+
+        let bytes = unsafe { std::slice::from_raw_parts(out_ptr, out_len) }.to_vec();
+        unsafe { ffi::ghostty_free(std::ptr::null(), out_ptr, out_len) };
+        Some(bytes)
+    }
+
     fn search_scrollback(&self, query: &str) -> Vec<(usize, usize, usize)> {
         if query.is_empty() {
             return Vec::new();

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -653,14 +653,20 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         use libghostty_vt::ffi;
 
         // SAFETY: Terminal's first field is Object<GhosttyTerminal> whose first
-        // field is NonNull<GhosttyTerminal>. Both are #[repr(Rust)] but NonNull
-        // is guaranteed to have the same layout as *mut T. We read the pointer
-        // without taking ownership. This is sound as long as libghostty-vt's
-        // Terminal struct layout doesn't change (pinned to 0.1.1).
+        // field is NonNull<GhosttyTerminal>. NonNull<T> is guaranteed to have
+        // the same layout as *mut T. We read the pointer without taking ownership.
+        //
+        // WARNING: Terminal is #[repr(Rust)] so this relies on the current field
+        // ordering in libghostty-vt 0.1.x. If the crate is updated, verify the
+        // layout hasn't changed (or request a public `as_raw()` accessor upstream).
         let terminal_ptr: ffi::GhosttyTerminal_ptr = unsafe {
             let ptr_to_terminal = &*self.terminal as *const _ as *const *mut ffi::GhosttyTerminal;
             *ptr_to_terminal
         };
+        if terminal_ptr.is_null() {
+            tracing::warn!("vt_state_snapshot: terminal_ptr is null — layout may have changed");
+            return None;
+        }
 
         let mut formatter: ffi::GhosttyFormatter_ptr = std::ptr::null_mut();
         let screen_extra = ffi::GhosttyFormatterScreenExtra {
@@ -700,6 +706,10 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         };
         if result != ffi::GhosttyResult_GHOSTTY_SUCCESS {
             tracing::warn!("ghostty_formatter_terminal_new failed: {result}");
+            // On failure the out-param is unset, but guard against partial init.
+            if !formatter.is_null() {
+                unsafe { ffi::ghostty_formatter_free(formatter) };
+            }
             return None;
         }
 


### PR DESCRIPTION
## Summary
- Ghostty backend now serializes full terminal state via `ghostty_formatter_terminal_new` / `ghostty_formatter_format_alloc` FFI, stored as base64-encoded VT escape sequences in `scrollback_vt`
- Wezterm backend falls back to text-based restore with trailing blank lines stripped (ANSI-aware)
- Empty tabs no longer produce walls of empty prompt lines on session restore

## Implementation
- `TerminalBackend::vt_state_snapshot()` trait method (default `None`)
- `GhosttyPane::vt_state_snapshot()` uses libghostty-vt TerminalFormatter FFI
- Save path prefers VT snapshot (base64); falls back to text scrollback
- Restore path prefers `scrollback_vt`; falls back to trimmed text
- `strip_ansi()` helper for accurate blank-line detection in wezterm path

## Test plan
- [ ] Restore session with ghostty backend — verify clean terminal state (cursor position, colors, modes preserved)
- [ ] Restore session with wezterm backend — verify no trailing blank prompt lines
- [ ] Tabs with history retain their scrollback content
- [ ] New/empty tabs restore cleanly without empty prompt walls
- [ ] `cargo clippy --workspace -- -D warnings && cargo fmt --check && cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session persistence now captures and restores terminal visual state (screen content, cursor, modes) for higher-fidelity session restore.
  * Backends can provide VM-style terminal snapshots to improve restored appearance when available.

* **Bug Fixes**
  * Restore now trims empty/whitespace-only trailing lines when falling back to text scrollback, reducing spurious blank lines on restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->