### PR TITLE
Customizable keybindings and color palette config (fixes #152, #155)

### DIFF
--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -1,8 +1,100 @@
 //! Keyboard, mouse, clipboard, copy-mode, and selection input handling.
 
+use std::collections::HashMap;
+
+use amux_core::config::{self, Action};
 use amux_term::TerminalBackend;
 
 use crate::*;
+
+/// Check if a [`KeyCombo`] matches the current egui key event state.
+fn combo_matches(combo: &config::KeyCombo, modifiers: &egui::Modifiers, key: &egui::Key) -> bool {
+    // Check modifiers
+    #[cfg(target_os = "macos")]
+    let cmd_ok = combo.cmd == (modifiers.mac_cmd || modifiers.command);
+    #[cfg(not(target_os = "macos"))]
+    let cmd_ok = combo.cmd == modifiers.ctrl;
+
+    let shift_ok = combo.shift == modifiers.shift;
+    let alt_ok = combo.alt == modifiers.alt;
+
+    #[cfg(target_os = "macos")]
+    let ctrl_ok = combo.ctrl == modifiers.ctrl;
+    #[cfg(not(target_os = "macos"))]
+    let ctrl_ok = true; // ctrl is consumed by cmd_ok on non-macOS
+
+    if !(cmd_ok && shift_ok && alt_ok && ctrl_ok) {
+        return false;
+    }
+
+    // Match key name
+    let key_name = &combo.key;
+    match key {
+        egui::Key::A => key_name == "a",
+        egui::Key::B => key_name == "b",
+        egui::Key::C => key_name == "c",
+        egui::Key::D => key_name == "d",
+        egui::Key::E => key_name == "e",
+        egui::Key::F => key_name == "f",
+        egui::Key::G => key_name == "g",
+        egui::Key::H => key_name == "h",
+        egui::Key::I => key_name == "i",
+        egui::Key::J => key_name == "j",
+        egui::Key::K => key_name == "k",
+        egui::Key::L => key_name == "l",
+        egui::Key::M => key_name == "m",
+        egui::Key::N => key_name == "n",
+        egui::Key::O => key_name == "o",
+        egui::Key::P => key_name == "p",
+        egui::Key::Q => key_name == "q",
+        egui::Key::R => key_name == "r",
+        egui::Key::S => key_name == "s",
+        egui::Key::T => key_name == "t",
+        egui::Key::U => key_name == "u",
+        egui::Key::V => key_name == "v",
+        egui::Key::W => key_name == "w",
+        egui::Key::X => key_name == "x",
+        egui::Key::Y => key_name == "y",
+        egui::Key::Z => key_name == "z",
+        egui::Key::Num0 => key_name == "0",
+        egui::Key::Num1 => key_name == "1",
+        egui::Key::Num2 => key_name == "2",
+        egui::Key::Num3 => key_name == "3",
+        egui::Key::Num4 => key_name == "4",
+        egui::Key::Num5 => key_name == "5",
+        egui::Key::Num6 => key_name == "6",
+        egui::Key::Num7 => key_name == "7",
+        egui::Key::Num8 => key_name == "8",
+        egui::Key::Num9 => key_name == "9",
+        egui::Key::Tab => key_name == "tab",
+        egui::Key::Enter => key_name == "enter",
+        egui::Key::Escape => key_name == "escape",
+        egui::Key::ArrowLeft => key_name == "left",
+        egui::Key::ArrowRight => key_name == "right",
+        egui::Key::ArrowUp => key_name == "up",
+        egui::Key::ArrowDown => key_name == "down",
+        egui::Key::PageUp => key_name == "pageup",
+        egui::Key::PageDown => key_name == "pagedown",
+        egui::Key::OpenBracket => key_name == "[",
+        egui::Key::CloseBracket => key_name == "]",
+        egui::Key::Space => key_name == "space",
+        egui::Key::Backspace => key_name == "backspace",
+        egui::Key::Delete => key_name == "delete",
+        _ => false,
+    }
+}
+
+/// Check if a specific [`Action`] in the resolved keybindings matches the current event.
+fn action_matches(
+    keybindings: &HashMap<Action, config::KeyCombo>,
+    action: Action,
+    modifiers: &egui::Modifiers,
+    key: &egui::Key,
+) -> bool {
+    keybindings
+        .get(&action)
+        .is_some_and(|combo| combo_matches(combo, modifiers, key))
+}
 
 impl AmuxApp {
     // --- Shortcuts ---
@@ -58,29 +150,63 @@ impl AmuxApp {
                 ..
             } = event
             {
-                #[cfg(target_os = "macos")]
-                let is_cmd = modifiers.mac_cmd || modifiers.command;
-                #[cfg(not(target_os = "macos"))]
-                let is_cmd = modifiers.ctrl;
+                // Pre-compute all action matches so the immutable borrow of
+                // self.keybindings is released before any &mut self calls.
+                let is_copy = action_matches(&self.keybindings, Action::Copy, modifiers, key);
+                let is_paste = action_matches(&self.keybindings, Action::Paste, modifiers, key);
+                let is_find = action_matches(&self.keybindings, Action::Find, modifiers, key);
+                let is_select_all =
+                    action_matches(&self.keybindings, Action::SelectAll, modifiers, key);
+                let is_copy_mode =
+                    action_matches(&self.keybindings, Action::CopyMode, modifiers, key);
+                let is_toggle_sidebar =
+                    action_matches(&self.keybindings, Action::ToggleSidebar, modifiers, key);
+                let is_new_browser_tab =
+                    action_matches(&self.keybindings, Action::NewBrowserTab, modifiers, key);
+                let is_new_workspace =
+                    action_matches(&self.keybindings, Action::NewWorkspace, modifiers, key);
+                let is_new_tab = action_matches(&self.keybindings, Action::NewTab, modifiers, key);
+                let is_next_workspace =
+                    action_matches(&self.keybindings, Action::NextWorkspace, modifiers, key);
+                let is_prev_workspace =
+                    action_matches(&self.keybindings, Action::PrevWorkspace, modifiers, key);
+                let is_next_tab =
+                    action_matches(&self.keybindings, Action::NextTab, modifiers, key);
+                let is_prev_tab =
+                    action_matches(&self.keybindings, Action::PrevTab, modifiers, key);
+                let is_split_right =
+                    action_matches(&self.keybindings, Action::SplitRight, modifiers, key);
+                let is_split_down =
+                    action_matches(&self.keybindings, Action::SplitDown, modifiers, key);
+                let is_close_pane =
+                    action_matches(&self.keybindings, Action::ClosePane, modifiers, key);
+                let is_nav_left =
+                    action_matches(&self.keybindings, Action::NavigateLeft, modifiers, key);
+                let is_nav_right =
+                    action_matches(&self.keybindings, Action::NavigateRight, modifiers, key);
+                let is_nav_up =
+                    action_matches(&self.keybindings, Action::NavigateUp, modifiers, key);
+                let is_nav_down =
+                    action_matches(&self.keybindings, Action::NavigateDown, modifiers, key);
+                let is_zoom_toggle =
+                    action_matches(&self.keybindings, Action::ZoomToggle, modifiers, key);
+                let is_devtools =
+                    action_matches(&self.keybindings, Action::DevTools, modifiers, key);
+                let is_notification_panel =
+                    action_matches(&self.keybindings, Action::NotificationPanel, modifiers, key);
+                let is_jump_to_unread =
+                    action_matches(&self.keybindings, Action::JumpToUnread, modifiers, key);
+                let is_clear_scrollback =
+                    action_matches(&self.keybindings, Action::ClearScrollback, modifiers, key);
 
                 // --- Terminal-specific shortcuts (skipped when browser tab active) ---
                 if !browser_active {
-                    // Copy: Cmd+C (with selection) / Cmd+Shift+C (always copy)
-                    #[cfg(target_os = "macos")]
-                    let is_copy = is_cmd && (*key == egui::Key::C);
-                    #[cfg(not(target_os = "macos"))]
-                    let is_copy = modifiers.ctrl && modifiers.shift && (*key == egui::Key::C);
-
+                    // Copy
                     if is_copy && self.copy_selection() {
                         return true;
                     }
 
-                    // Paste: Cmd+V (macOS) / Ctrl+Shift+V (other)
-                    #[cfg(target_os = "macos")]
-                    let is_paste = is_cmd && !modifiers.shift && *key == egui::Key::V;
-                    #[cfg(not(target_os = "macos"))]
-                    let is_paste = modifiers.ctrl && modifiers.shift && *key == egui::Key::V;
-
+                    // Paste
                     if is_paste {
                         if let Ok(mut clipboard) = arboard::Clipboard::new() {
                             if let Ok(text) = clipboard.get_text() {
@@ -116,8 +242,8 @@ impl AmuxApp {
                         }
                     }
 
-                    // Find: Cmd+F (macOS) / Ctrl+Shift+F (other)
-                    if is_cmd && !modifiers.shift && *key == egui::Key::F {
+                    // Find
+                    if is_find {
                         let pane_id = self.focused_pane_id();
                         self.find_state = Some(FindState {
                             query: String::new(),
@@ -129,20 +255,14 @@ impl AmuxApp {
                         return true;
                     }
 
-                    // Select all: Cmd+A
-                    #[cfg(target_os = "macos")]
-                    if is_cmd && !modifiers.shift && *key == egui::Key::A {
-                        self.select_all_visible();
-                        return true;
-                    }
-                    #[cfg(not(target_os = "macos"))]
-                    if modifiers.ctrl && modifiers.shift && *key == egui::Key::A {
+                    // Select all
+                    if is_select_all {
                         self.select_all_visible();
                         return true;
                     }
 
-                    // Enter copy mode: Cmd+Shift+X (macOS) / Ctrl+Shift+X (other)
-                    if is_cmd && modifiers.shift && *key == egui::Key::X {
+                    // Enter copy mode
+                    if is_copy_mode {
                         self.enter_copy_mode();
                         return true;
                     }
@@ -161,12 +281,7 @@ impl AmuxApp {
                         });
 
                     if let Some(bid) = browser_id {
-                        // Paste: Cmd+V / Ctrl+V — read clipboard and inject into webview
-                        #[cfg(target_os = "macos")]
-                        let is_paste = is_cmd && !modifiers.shift && *key == egui::Key::V;
-                        #[cfg(not(target_os = "macos"))]
-                        let is_paste = modifiers.ctrl && !modifiers.shift && *key == egui::Key::V;
-
+                        // Paste
                         if is_paste {
                             if let Ok(mut clipboard) = arboard::Clipboard::new() {
                                 if let Ok(text) = clipboard.get_text() {
@@ -180,13 +295,7 @@ impl AmuxApp {
                             return true;
                         }
 
-                        // Select all: Cmd+A (macOS) / Ctrl+A (other)
-                        #[cfg(target_os = "macos")]
-                        let is_select_all = is_cmd && !modifiers.shift && *key == egui::Key::A;
-                        #[cfg(not(target_os = "macos"))]
-                        let is_select_all =
-                            modifiers.ctrl && !modifiers.shift && *key == egui::Key::A;
-
+                        // Select all
                         if is_select_all {
                             if let Some(PaneEntry::Browser(b)) = self.panes.get(&bid) {
                                 b.evaluate_script("document.execCommand('selectAll')");
@@ -194,12 +303,7 @@ impl AmuxApp {
                             return true;
                         }
 
-                        // Copy: Cmd+C / Ctrl+C
-                        #[cfg(target_os = "macos")]
-                        let is_copy = is_cmd && *key == egui::Key::C;
-                        #[cfg(not(target_os = "macos"))]
-                        let is_copy = modifiers.ctrl && *key == egui::Key::C;
-
+                        // Copy
                         if is_copy {
                             if let Some(PaneEntry::Browser(b)) = self.panes.get(&bid) {
                                 b.evaluate_script("document.execCommand('copy')");
@@ -207,9 +311,12 @@ impl AmuxApp {
                             return true;
                         }
 
-                        // Cut: Cmd+X (macOS) / Ctrl+X (other)
+                        // Cut: uses the Copy combo key with no shift distinction;
+                        // browser cut is Cmd+X / Ctrl+X — hardcoded since there is
+                        // no CopyMode-style action for Cut.
                         #[cfg(target_os = "macos")]
-                        let is_cut = is_cmd && *key == egui::Key::X;
+                        let is_cut =
+                            (modifiers.mac_cmd || modifiers.command) && *key == egui::Key::X;
                         #[cfg(not(target_os = "macos"))]
                         let is_cut = modifiers.ctrl && *key == egui::Key::X;
 
@@ -224,60 +331,33 @@ impl AmuxApp {
 
                 // --- Amux chrome shortcuts (always active) ---
 
-                // Toggle sidebar: Cmd+B / Ctrl+B
-                #[cfg(target_os = "macos")]
-                if is_cmd && !modifiers.shift && *key == egui::Key::B {
-                    self.sidebar.visible = !self.sidebar.visible;
-                    return true;
-                }
-                #[cfg(not(target_os = "macos"))]
-                if modifiers.ctrl && !modifiers.shift && *key == egui::Key::B {
+                // Toggle sidebar
+                if is_toggle_sidebar {
                     self.sidebar.visible = !self.sidebar.visible;
                     return true;
                 }
 
-                // New browser tab: Cmd+Shift+L (macOS) / Ctrl+Shift+L (other)
-                if is_cmd && modifiers.shift && *key == egui::Key::L {
+                // New browser tab
+                if is_new_browser_tab {
                     let pane_id = self.focused_pane_id();
                     self.queue_browser_pane(pane_id, DEFAULT_BROWSER_URL.to_string());
                     return true;
                 }
 
-                // New workspace: Cmd+N / Ctrl+Shift+N
-                #[cfg(target_os = "macos")]
-                if is_cmd && !modifiers.shift && *key == egui::Key::N {
-                    self.create_workspace(None);
-                    return true;
-                }
-                #[cfg(not(target_os = "macos"))]
-                if modifiers.ctrl && modifiers.shift && *key == egui::Key::N {
+                // New workspace
+                if is_new_workspace {
                     self.create_workspace(None);
                     return true;
                 }
 
-                // New tab in focused pane: Cmd+T / Ctrl+Shift+T
-                #[cfg(target_os = "macos")]
-                if is_cmd && !modifiers.shift && *key == egui::Key::T {
-                    self.add_surface_to_focused_pane();
-                    return true;
-                }
-                #[cfg(not(target_os = "macos"))]
-                if modifiers.ctrl && modifiers.shift && *key == egui::Key::T {
+                // New tab in focused pane
+                if is_new_tab {
                     self.add_surface_to_focused_pane();
                     return true;
                 }
 
-                // Next workspace: Cmd+Shift+]
-                #[cfg(target_os = "macos")]
-                if is_cmd && modifiers.shift && *key == egui::Key::CloseBracket {
-                    if self.workspaces.len() > 1 {
-                        self.active_workspace_idx =
-                            (self.active_workspace_idx + 1) % self.workspaces.len();
-                    }
-                    return true;
-                }
-                #[cfg(not(target_os = "macos"))]
-                if modifiers.ctrl && modifiers.shift && *key == egui::Key::CloseBracket {
+                // Next workspace
+                if is_next_workspace {
                     if self.workspaces.len() > 1 {
                         self.active_workspace_idx =
                             (self.active_workspace_idx + 1) % self.workspaces.len();
@@ -285,20 +365,8 @@ impl AmuxApp {
                     return true;
                 }
 
-                // Prev workspace: Cmd+Shift+[
-                #[cfg(target_os = "macos")]
-                if is_cmd && modifiers.shift && *key == egui::Key::OpenBracket {
-                    if self.workspaces.len() > 1 {
-                        self.active_workspace_idx = if self.active_workspace_idx == 0 {
-                            self.workspaces.len() - 1
-                        } else {
-                            self.active_workspace_idx - 1
-                        };
-                    }
-                    return true;
-                }
-                #[cfg(not(target_os = "macos"))]
-                if modifiers.ctrl && modifiers.shift && *key == egui::Key::OpenBracket {
+                // Prev workspace
+                if is_prev_workspace {
                     if self.workspaces.len() > 1 {
                         self.active_workspace_idx = if self.active_workspace_idx == 0 {
                             self.workspaces.len() - 1
@@ -309,9 +377,9 @@ impl AmuxApp {
                     return true;
                 }
 
-                // Jump to workspace 1-9 (Cmd+9 = last workspace)
+                // Jump to workspace 1-9 (Cmd+9 = last workspace) — always fixed
                 #[cfg(target_os = "macos")]
-                let is_jump_mod = is_cmd && !modifiers.shift;
+                let is_jump_mod = (modifiers.mac_cmd || modifiers.command) && !modifiers.shift;
                 #[cfg(not(target_os = "macos"))]
                 let is_jump_mod = modifiers.ctrl && !modifiers.shift;
 
@@ -339,8 +407,8 @@ impl AmuxApp {
                     }
                 }
 
-                // Next tab in focused pane: Ctrl+Tab
-                if modifiers.ctrl && !modifiers.shift && *key == egui::Key::Tab {
+                // Next tab in focused pane
+                if is_next_tab {
                     if let Some(PaneEntry::Terminal(managed)) =
                         self.panes.get_mut(&self.focused_pane_id())
                     {
@@ -352,8 +420,8 @@ impl AmuxApp {
                     return true;
                 }
 
-                // Prev tab in focused pane: Ctrl+Shift+Tab
-                if modifiers.ctrl && modifiers.shift && *key == egui::Key::Tab {
+                // Prev tab in focused pane
+                if is_prev_tab {
                     if let Some(PaneEntry::Terminal(managed)) =
                         self.panes.get_mut(&self.focused_pane_id())
                     {
@@ -371,64 +439,41 @@ impl AmuxApp {
 
                 // --- Pane shortcuts ---
 
-                // Split right: Cmd+D (macOS) / Ctrl+Shift+D (other)
-                #[cfg(target_os = "macos")]
-                if is_cmd && !modifiers.shift && *key == egui::Key::D {
+                // Split right
+                if is_split_right {
                     return self.do_split(SplitDirection::Horizontal);
                 }
-                #[cfg(not(target_os = "macos"))]
-                if is_cmd && *key == egui::Key::D {
-                    return self.do_split(SplitDirection::Horizontal);
-                }
-                // Split down: Cmd+Shift+D (macOS) / Ctrl+Shift+Down (other)
-                #[cfg(target_os = "macos")]
-                if is_cmd && modifiers.shift && *key == egui::Key::D {
-                    return self.do_split(SplitDirection::Vertical);
-                }
-                #[cfg(not(target_os = "macos"))]
-                if modifiers.ctrl && modifiers.shift && *key == egui::Key::ArrowDown {
+
+                // Split down
+                if is_split_down {
                     return self.do_split(SplitDirection::Vertical);
                 }
 
-                // Close: Cmd+W — cascade: tab -> pane -> workspace
-                if is_cmd && *key == egui::Key::W {
+                // Close pane (cascade: tab -> pane -> workspace)
+                if is_close_pane {
                     return self.do_close_cascade();
                 }
 
-                // Navigate: Option+Cmd+Arrow / Ctrl+Alt+Arrow
-                #[cfg(target_os = "macos")]
-                let is_nav = is_cmd && modifiers.alt;
-                #[cfg(not(target_os = "macos"))]
-                let is_nav = modifiers.ctrl && modifiers.alt;
-
-                if is_nav {
-                    let dir = match key {
-                        egui::Key::ArrowLeft => Some(NavDirection::Left),
-                        egui::Key::ArrowRight => Some(NavDirection::Right),
-                        egui::Key::ArrowUp => Some(NavDirection::Up),
-                        egui::Key::ArrowDown => Some(NavDirection::Down),
-                        _ => None,
-                    };
-                    if let Some(dir) = dir {
-                        return self.do_navigate(dir);
-                    }
+                // Navigate
+                if is_nav_left {
+                    return self.do_navigate(NavDirection::Left);
+                }
+                if is_nav_right {
+                    return self.do_navigate(NavDirection::Right);
+                }
+                if is_nav_up {
+                    return self.do_navigate(NavDirection::Up);
+                }
+                if is_nav_down {
+                    return self.do_navigate(NavDirection::Down);
                 }
 
-                // Zoom toggle: Cmd+Shift+Enter / Ctrl+Shift+Enter
-                #[cfg(target_os = "macos")]
-                let is_zoom = is_cmd && modifiers.shift && *key == egui::Key::Enter;
-                #[cfg(not(target_os = "macos"))]
-                let is_zoom = modifiers.ctrl && modifiers.shift && *key == egui::Key::Enter;
-
-                if is_zoom {
+                // Zoom toggle
+                if is_zoom_toggle {
                     return self.do_toggle_zoom();
                 }
 
-                // DevTools: Cmd+Option+I (macOS) / Ctrl+Shift+I (Windows)
-                #[cfg(target_os = "macos")]
-                let is_devtools = is_cmd && modifiers.alt && *key == egui::Key::I;
-                #[cfg(not(target_os = "macos"))]
-                let is_devtools = modifiers.ctrl && modifiers.shift && *key == egui::Key::I;
+                // DevTools
                 if is_devtools {
                     let pane_id = self.focused_pane_id();
                     if let Some(PaneEntry::Terminal(managed)) = self.panes.get(&pane_id) {
@@ -441,26 +486,26 @@ impl AmuxApp {
                     }
                 }
 
-                // Notification panel: Cmd+I / Ctrl+I
-                if is_cmd && !modifiers.shift && *key == egui::Key::I {
+                // Notification panel
+                if is_notification_panel {
                     self.show_notification_panel = !self.show_notification_panel;
                     return true;
                 }
 
-                // Jump to latest unread: Cmd+Shift+U / Ctrl+Shift+U
-                if is_cmd && modifiers.shift && *key == egui::Key::U {
+                // Jump to latest unread
+                if is_jump_to_unread {
                     self.jump_to_latest_unread();
                     return true;
                 }
 
                 if !browser_active {
-                    // Clear scrollback: Cmd+K (macOS) / Ctrl+Shift+K (other)
-                    if is_cmd && !modifiers.shift && *key == egui::Key::K {
+                    // Clear scrollback
+                    if is_clear_scrollback {
                         self.do_clear_scrollback();
                         return true;
                     }
 
-                    // Scroll
+                    // Scroll — always fixed (Shift+PageUp/Down)
                     if modifiers.shift && *key == egui::Key::PageUp {
                         return self.do_scroll(-1);
                     }

--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -9,11 +9,14 @@ use crate::*;
 
 /// Check if a [`KeyCombo`] matches the current egui key event state.
 fn combo_matches(combo: &config::KeyCombo, modifiers: &egui::Modifiers, key: &egui::Key) -> bool {
-    // Check modifiers
+    // Check modifiers.
+    // On macOS, "cmd" maps to mac_cmd/command and "ctrl" maps to ctrl independently.
+    // On other platforms, both "cmd" and "ctrl" map to the Ctrl key (the platform
+    // command key), so we merge them: either combo.cmd or combo.ctrl must match.
     #[cfg(target_os = "macos")]
     let cmd_ok = combo.cmd == (modifiers.mac_cmd || modifiers.command);
     #[cfg(not(target_os = "macos"))]
-    let cmd_ok = combo.cmd == modifiers.ctrl;
+    let cmd_ok = (combo.cmd || combo.ctrl) == modifiers.ctrl;
 
     let shift_ok = combo.shift == modifiers.shift;
     let alt_ok = combo.alt == modifiers.alt;

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -142,6 +142,8 @@ struct AmuxApp {
     app_focused: bool,
     /// Persisted application configuration.
     app_config: AppConfig,
+    /// Resolved keybindings: user overrides merged with platform defaults.
+    keybindings: HashMap<config::Action, config::KeyCombo>,
     /// Cross-platform system notification sender.
     system_notifier: system_notify::SystemNotifier,
     /// Cached badge count to avoid redundant dock badge updates every frame.

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -77,6 +77,9 @@ pub(crate) fn run() -> anyhow::Result<()> {
     // Apply user color overrides from [colors] config section
     theme.apply_color_config(&app_config.colors);
 
+    // Resolve keybindings: user overrides merged with platform defaults.
+    let keybindings = app_config.keybindings.resolved();
+
     // FontConfig is only consumed by the GPU renderer; gate to avoid unused
     // warnings in non-GPU builds. Created after theme loading so Ghostty
     // font overrides are picked up.
@@ -206,6 +209,7 @@ pub(crate) fn run() -> anyhow::Result<()> {
                 rename_modal: None,
                 app_focused: true,
                 app_config,
+                keybindings,
                 system_notifier: system_notify::SystemNotifier::new(),
                 last_badge_count: 0,
                 cursor_blink_since: Instant::now(),

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -52,7 +52,7 @@ pub(crate) fn run() -> anyhow::Result<()> {
     let (ipc_rx, ipc_addr, event_broadcaster) = amux_ipc::start_server(socket_token.clone())?;
     tracing::info!("IPC server: {}", ipc_addr);
 
-    let theme = match app_config.theme_source.as_str() {
+    let mut theme = match app_config.theme_source.as_str() {
         "ghostty" => {
             if let Some(ghostty_cfg) = amux_ghostty_config::GhosttyConfig::load() {
                 // Override font settings from Ghostty config if present.
@@ -73,6 +73,9 @@ pub(crate) fn run() -> anyhow::Result<()> {
         }
         _ => theme::Theme::default(),
     };
+
+    // Apply user color overrides from [colors] config section
+    theme.apply_color_config(&app_config.colors);
 
     // FontConfig is only consumed by the GPU renderer; gate to avoid unused
     // warnings in non-GPU builds. Created after theme loading so Ghostty

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use amux_core::config;
 use egui::Color32;
 use wezterm_term::color::SrgbaTuple;
 
@@ -144,21 +145,76 @@ impl Theme {
         }
 
         // Derive chrome colors from terminal background for a cohesive look.
-        let [br, bg, bb] = terminal.background;
         let accent = default.chrome.accent;
-        let chrome = ChromeColors {
-            sidebar_bg: darken_rgb(br, bg, bb, 0.15),
-            sidebar_active_bg: accent,
-            tab_bar_bg: None, // falls back to terminal background
-            titlebar_bg: None,
-            tab_active_bg: Color32::from_rgb(br, bg, bb), // match terminal background
-            tab_bar_border: lighten_rgb(br, bg, bb, 0.15),
-            tab_border: lighten_rgb(br, bg, bb, 0.15),
-            divider: lighten_rgb(br, bg, bb, 0.18),
-            accent,
-        };
+        let chrome = ChromeColors::from_background(terminal.background, accent);
 
         Self { terminal, chrome }
+    }
+}
+
+impl ChromeColors {
+    /// Derive chrome colors from a terminal background RGB value.
+    /// Uses the same algorithm as `Theme::from_ghostty`.
+    fn from_background(bg: [u8; 3], accent: Color32) -> Self {
+        let [br, bg_g, bb] = bg;
+        Self {
+            sidebar_bg: darken_rgb(br, bg_g, bb, 0.15),
+            sidebar_active_bg: accent,
+            tab_bar_bg: None,
+            titlebar_bg: None,
+            tab_active_bg: Color32::from_rgb(br, bg_g, bb),
+            tab_bar_border: lighten_rgb(br, bg_g, bb, 0.15),
+            tab_border: lighten_rgb(br, bg_g, bb, 0.15),
+            divider: lighten_rgb(br, bg_g, bb, 0.18),
+            accent,
+        }
+    }
+}
+
+impl Theme {
+    /// Apply user color overrides from config.
+    pub fn apply_color_config(&mut self, colors: &config::ColorsConfig) {
+        if let Some(ref hex) = colors.foreground {
+            if let Some(rgb) = config::ColorsConfig::parse_hex(hex) {
+                self.terminal.foreground = rgb;
+            }
+        }
+        if let Some(ref hex) = colors.background {
+            if let Some(rgb) = config::ColorsConfig::parse_hex(hex) {
+                self.terminal.background = rgb;
+                // Re-derive chrome colors from new background
+                self.chrome = ChromeColors::from_background(rgb, self.chrome.accent);
+            }
+        }
+        if let Some(ref hex) = colors.cursor_fg {
+            if let Some(rgb) = config::ColorsConfig::parse_hex(hex) {
+                self.terminal.cursor_fg = rgb;
+            }
+        }
+        if let Some(ref hex) = colors.cursor_bg {
+            if let Some(rgb) = config::ColorsConfig::parse_hex(hex) {
+                self.terminal.cursor_bg = rgb;
+            }
+        }
+        if let Some(ref hex) = colors.selection_fg {
+            if let Some(rgb) = config::ColorsConfig::parse_hex(hex) {
+                self.terminal.selection_fg = rgb;
+            }
+        }
+        if let Some(ref hex) = colors.selection_bg {
+            if let Some(rgb) = config::ColorsConfig::parse_hex(hex) {
+                self.terminal.selection_bg = rgb;
+            }
+        }
+        // Apply palette overrides (indices 0-15)
+        for (i, hex) in colors.palette.iter().enumerate() {
+            if i >= 16 {
+                break;
+            }
+            if let Some(rgb) = config::ColorsConfig::parse_hex(hex) {
+                self.terminal.ansi[i] = rgb;
+            }
+        }
     }
 }
 

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -5,6 +5,37 @@ pub const DEFAULT_FONT_FAMILY: &str = "IBM Plex Mono";
 /// Default font size — must match `amux_term::DEFAULT_FONT_SIZE`.
 pub const DEFAULT_FONT_SIZE: f32 = 14.0;
 
+/// Custom color palette configuration.
+/// Colors are specified as hex strings: "#rrggbb" or "rrggbb".
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(default)]
+pub struct ColorsConfig {
+    pub foreground: Option<String>,
+    pub background: Option<String>,
+    pub cursor_fg: Option<String>,
+    pub cursor_bg: Option<String>,
+    pub selection_fg: Option<String>,
+    pub selection_bg: Option<String>,
+    /// ANSI colors 0-15. Index maps to color number.
+    /// e.g. palette = ["#000000", "#cc0000", ...] for colors 0, 1, etc.
+    #[serde(default)]
+    pub palette: Vec<String>,
+}
+
+impl ColorsConfig {
+    /// Parse a hex color string like "#rrggbb" or "rrggbb" into [u8; 3].
+    pub fn parse_hex(s: &str) -> Option<[u8; 3]> {
+        let s = s.strip_prefix('#').unwrap_or(s);
+        if s.len() != 6 {
+            return None;
+        }
+        let r = u8::from_str_radix(&s[0..2], 16).ok()?;
+        let g = u8::from_str_radix(&s[2..4], 16).ok()?;
+        let b = u8::from_str_radix(&s[4..6], 16).ok()?;
+        Some([r, g, b])
+    }
+}
+
 #[derive(Debug, serde::Deserialize)]
 #[serde(default)]
 pub struct AppConfig {
@@ -20,6 +51,8 @@ pub struct AppConfig {
     pub theme_source: String,
     pub notifications: NotificationConfig,
     pub browser: BrowserConfig,
+    #[serde(default)]
+    pub colors: ColorsConfig,
 }
 
 impl Default for AppConfig {
@@ -31,6 +64,7 @@ impl Default for AppConfig {
             theme_source: "default".to_owned(),
             notifications: NotificationConfig::default(),
             browser: BrowserConfig::default(),
+            colors: ColorsConfig::default(),
         }
     }
 }
@@ -227,5 +261,21 @@ mod tests {
         assert!(!is_url_like("example\t.com"));
         assert!(!is_url_like("example\n.com"));
         assert!(!is_url_like("hello\tworld"));
+    }
+
+    #[test]
+    fn parse_hex_with_hash() {
+        assert_eq!(ColorsConfig::parse_hex("#ff0000"), Some([255, 0, 0]));
+    }
+
+    #[test]
+    fn parse_hex_without_hash() {
+        assert_eq!(ColorsConfig::parse_hex("00ff00"), Some([0, 255, 0]));
+    }
+
+    #[test]
+    fn parse_hex_invalid() {
+        assert_eq!(ColorsConfig::parse_hex("xyz"), None);
+        assert_eq!(ColorsConfig::parse_hex("#ff"), None);
     }
 }

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -100,7 +100,12 @@ impl KeyCombo {
         // The last segment is always the key.
         let (modifier_parts, key_parts) = parts.split_at(parts.len() - 1);
         let key = key_parts[0].trim().to_lowercase();
-        if key.is_empty() {
+        if key.is_empty()
+            || matches!(
+                key.as_str(),
+                "cmd" | "super" | "meta" | "shift" | "alt" | "option" | "ctrl" | "control"
+            )
+        {
             return None;
         }
 

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -1,5 +1,7 @@
 //! Application configuration loaded from config.toml.
 
+use std::collections::HashMap;
+
 /// Default font family — must match `amux_term::DEFAULT_FONT_FAMILY`.
 pub const DEFAULT_FONT_FAMILY: &str = "IBM Plex Mono";
 /// Default font size — must match `amux_term::DEFAULT_FONT_SIZE`.
@@ -36,6 +38,336 @@ impl ColorsConfig {
     }
 }
 
+/// Bindable keyboard actions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Action {
+    Copy,
+    Paste,
+    Find,
+    SelectAll,
+    CopyMode,
+    ToggleSidebar,
+    NewBrowserTab,
+    NewWorkspace,
+    NewTab,
+    NextWorkspace,
+    PrevWorkspace,
+    NextTab,
+    PrevTab,
+    SplitRight,
+    SplitDown,
+    ClosePane,
+    NavigateLeft,
+    NavigateRight,
+    NavigateUp,
+    NavigateDown,
+    ZoomToggle,
+    DevTools,
+    NotificationPanel,
+    JumpToUnread,
+    ClearScrollback,
+}
+
+/// A keyboard shortcut: modifier flags + key name.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KeyCombo {
+    /// Cmd on macOS, Ctrl on others.
+    pub cmd: bool,
+    pub shift: bool,
+    pub alt: bool,
+    /// Always Ctrl (even on macOS).
+    pub ctrl: bool,
+    /// Lowercase key name: "c", "v", "f", "tab", "enter", etc.
+    pub key: String,
+}
+
+impl KeyCombo {
+    /// Parse a key combo string like `"cmd+shift+t"`, `"ctrl+c"`, `"cmd+alt+left"`.
+    /// Returns `None` if the string is empty or has no key after modifiers.
+    pub fn parse(s: &str) -> Option<Self> {
+        let parts: Vec<&str> = s.split('+').collect();
+        if parts.is_empty() {
+            return None;
+        }
+
+        let mut cmd = false;
+        let mut shift = false;
+        let mut alt = false;
+        let mut ctrl = false;
+
+        // All segments except the last are modifier candidates.
+        // The last segment is always the key.
+        let (modifier_parts, key_parts) = parts.split_at(parts.len() - 1);
+        let key = key_parts[0].trim().to_lowercase();
+        if key.is_empty() {
+            return None;
+        }
+
+        for part in modifier_parts {
+            match part.trim().to_lowercase().as_str() {
+                "cmd" | "super" | "meta" => cmd = true,
+                "shift" => shift = true,
+                "alt" | "option" => alt = true,
+                "ctrl" | "control" => ctrl = true,
+                _ => {}
+            }
+        }
+
+        Some(KeyCombo {
+            cmd,
+            shift,
+            alt,
+            ctrl,
+            key,
+        })
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for KeyCombo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        KeyCombo::parse(&s)
+            .ok_or_else(|| serde::de::Error::custom(format!("invalid key combo: {s:?}")))
+    }
+}
+
+/// User-customizable keybindings. Each field is an optional override;
+/// if None, the platform default is used.
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(default)]
+pub struct KeybindingsConfig {
+    pub copy: Option<KeyCombo>,
+    pub paste: Option<KeyCombo>,
+    pub find: Option<KeyCombo>,
+    pub select_all: Option<KeyCombo>,
+    pub copy_mode: Option<KeyCombo>,
+    pub toggle_sidebar: Option<KeyCombo>,
+    pub new_browser_tab: Option<KeyCombo>,
+    pub new_workspace: Option<KeyCombo>,
+    pub new_tab: Option<KeyCombo>,
+    pub next_workspace: Option<KeyCombo>,
+    pub prev_workspace: Option<KeyCombo>,
+    pub next_tab: Option<KeyCombo>,
+    pub prev_tab: Option<KeyCombo>,
+    pub split_right: Option<KeyCombo>,
+    pub split_down: Option<KeyCombo>,
+    pub close_pane: Option<KeyCombo>,
+    pub navigate_left: Option<KeyCombo>,
+    pub navigate_right: Option<KeyCombo>,
+    pub navigate_up: Option<KeyCombo>,
+    pub navigate_down: Option<KeyCombo>,
+    pub zoom_toggle: Option<KeyCombo>,
+    pub devtools: Option<KeyCombo>,
+    pub notification_panel: Option<KeyCombo>,
+    pub jump_to_unread: Option<KeyCombo>,
+    pub clear_scrollback: Option<KeyCombo>,
+}
+
+impl KeybindingsConfig {
+    /// Return resolved keybindings: user overrides merged with platform defaults.
+    pub fn resolved(&self) -> HashMap<Action, KeyCombo> {
+        let mut map = Self::platform_defaults();
+        if let Some(k) = &self.copy {
+            map.insert(Action::Copy, k.clone());
+        }
+        if let Some(k) = &self.paste {
+            map.insert(Action::Paste, k.clone());
+        }
+        if let Some(k) = &self.find {
+            map.insert(Action::Find, k.clone());
+        }
+        if let Some(k) = &self.select_all {
+            map.insert(Action::SelectAll, k.clone());
+        }
+        if let Some(k) = &self.copy_mode {
+            map.insert(Action::CopyMode, k.clone());
+        }
+        if let Some(k) = &self.toggle_sidebar {
+            map.insert(Action::ToggleSidebar, k.clone());
+        }
+        if let Some(k) = &self.new_browser_tab {
+            map.insert(Action::NewBrowserTab, k.clone());
+        }
+        if let Some(k) = &self.new_workspace {
+            map.insert(Action::NewWorkspace, k.clone());
+        }
+        if let Some(k) = &self.new_tab {
+            map.insert(Action::NewTab, k.clone());
+        }
+        if let Some(k) = &self.next_workspace {
+            map.insert(Action::NextWorkspace, k.clone());
+        }
+        if let Some(k) = &self.prev_workspace {
+            map.insert(Action::PrevWorkspace, k.clone());
+        }
+        if let Some(k) = &self.next_tab {
+            map.insert(Action::NextTab, k.clone());
+        }
+        if let Some(k) = &self.prev_tab {
+            map.insert(Action::PrevTab, k.clone());
+        }
+        if let Some(k) = &self.split_right {
+            map.insert(Action::SplitRight, k.clone());
+        }
+        if let Some(k) = &self.split_down {
+            map.insert(Action::SplitDown, k.clone());
+        }
+        if let Some(k) = &self.close_pane {
+            map.insert(Action::ClosePane, k.clone());
+        }
+        if let Some(k) = &self.navigate_left {
+            map.insert(Action::NavigateLeft, k.clone());
+        }
+        if let Some(k) = &self.navigate_right {
+            map.insert(Action::NavigateRight, k.clone());
+        }
+        if let Some(k) = &self.navigate_up {
+            map.insert(Action::NavigateUp, k.clone());
+        }
+        if let Some(k) = &self.navigate_down {
+            map.insert(Action::NavigateDown, k.clone());
+        }
+        if let Some(k) = &self.zoom_toggle {
+            map.insert(Action::ZoomToggle, k.clone());
+        }
+        if let Some(k) = &self.devtools {
+            map.insert(Action::DevTools, k.clone());
+        }
+        if let Some(k) = &self.notification_panel {
+            map.insert(Action::NotificationPanel, k.clone());
+        }
+        if let Some(k) = &self.jump_to_unread {
+            map.insert(Action::JumpToUnread, k.clone());
+        }
+        if let Some(k) = &self.clear_scrollback {
+            map.insert(Action::ClearScrollback, k.clone());
+        }
+        map
+    }
+
+    fn platform_defaults() -> HashMap<Action, KeyCombo> {
+        let mut m = HashMap::new();
+        #[cfg(target_os = "macos")]
+        {
+            m.insert(Action::Copy, KeyCombo::parse("cmd+c").unwrap());
+            m.insert(Action::Paste, KeyCombo::parse("cmd+v").unwrap());
+            m.insert(Action::Find, KeyCombo::parse("cmd+f").unwrap());
+            m.insert(Action::SelectAll, KeyCombo::parse("cmd+a").unwrap());
+            m.insert(Action::CopyMode, KeyCombo::parse("cmd+shift+x").unwrap());
+            m.insert(Action::ToggleSidebar, KeyCombo::parse("cmd+b").unwrap());
+            m.insert(
+                Action::NewBrowserTab,
+                KeyCombo::parse("cmd+shift+l").unwrap(),
+            );
+            m.insert(Action::NewWorkspace, KeyCombo::parse("cmd+n").unwrap());
+            m.insert(Action::NewTab, KeyCombo::parse("cmd+t").unwrap());
+            m.insert(
+                Action::NextWorkspace,
+                KeyCombo::parse("cmd+shift+]").unwrap(),
+            );
+            m.insert(
+                Action::PrevWorkspace,
+                KeyCombo::parse("cmd+shift+[").unwrap(),
+            );
+            m.insert(Action::NextTab, KeyCombo::parse("ctrl+tab").unwrap());
+            m.insert(Action::PrevTab, KeyCombo::parse("ctrl+shift+tab").unwrap());
+            m.insert(Action::SplitRight, KeyCombo::parse("cmd+d").unwrap());
+            m.insert(Action::SplitDown, KeyCombo::parse("cmd+shift+d").unwrap());
+            m.insert(Action::ClosePane, KeyCombo::parse("cmd+w").unwrap());
+            m.insert(
+                Action::NavigateLeft,
+                KeyCombo::parse("cmd+alt+left").unwrap(),
+            );
+            m.insert(
+                Action::NavigateRight,
+                KeyCombo::parse("cmd+alt+right").unwrap(),
+            );
+            m.insert(Action::NavigateUp, KeyCombo::parse("cmd+alt+up").unwrap());
+            m.insert(
+                Action::NavigateDown,
+                KeyCombo::parse("cmd+alt+down").unwrap(),
+            );
+            m.insert(
+                Action::ZoomToggle,
+                KeyCombo::parse("cmd+shift+enter").unwrap(),
+            );
+            m.insert(Action::DevTools, KeyCombo::parse("cmd+alt+i").unwrap());
+            m.insert(Action::NotificationPanel, KeyCombo::parse("cmd+i").unwrap());
+            m.insert(
+                Action::JumpToUnread,
+                KeyCombo::parse("cmd+shift+u").unwrap(),
+            );
+            m.insert(Action::ClearScrollback, KeyCombo::parse("cmd+k").unwrap());
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            m.insert(Action::Copy, KeyCombo::parse("ctrl+shift+c").unwrap());
+            m.insert(Action::Paste, KeyCombo::parse("ctrl+shift+v").unwrap());
+            m.insert(Action::Find, KeyCombo::parse("ctrl+f").unwrap());
+            m.insert(Action::SelectAll, KeyCombo::parse("ctrl+shift+a").unwrap());
+            m.insert(Action::CopyMode, KeyCombo::parse("ctrl+shift+x").unwrap());
+            m.insert(Action::ToggleSidebar, KeyCombo::parse("ctrl+b").unwrap());
+            m.insert(
+                Action::NewBrowserTab,
+                KeyCombo::parse("ctrl+shift+l").unwrap(),
+            );
+            m.insert(
+                Action::NewWorkspace,
+                KeyCombo::parse("ctrl+shift+n").unwrap(),
+            );
+            m.insert(Action::NewTab, KeyCombo::parse("ctrl+shift+t").unwrap());
+            m.insert(
+                Action::NextWorkspace,
+                KeyCombo::parse("ctrl+shift+]").unwrap(),
+            );
+            m.insert(
+                Action::PrevWorkspace,
+                KeyCombo::parse("ctrl+shift+[").unwrap(),
+            );
+            m.insert(Action::NextTab, KeyCombo::parse("ctrl+tab").unwrap());
+            m.insert(Action::PrevTab, KeyCombo::parse("ctrl+shift+tab").unwrap());
+            m.insert(Action::SplitRight, KeyCombo::parse("ctrl+d").unwrap());
+            m.insert(Action::SplitDown, KeyCombo::parse("ctrl+shift+d").unwrap());
+            m.insert(Action::ClosePane, KeyCombo::parse("ctrl+w").unwrap());
+            m.insert(
+                Action::NavigateLeft,
+                KeyCombo::parse("ctrl+alt+left").unwrap(),
+            );
+            m.insert(
+                Action::NavigateRight,
+                KeyCombo::parse("ctrl+alt+right").unwrap(),
+            );
+            m.insert(Action::NavigateUp, KeyCombo::parse("ctrl+alt+up").unwrap());
+            m.insert(
+                Action::NavigateDown,
+                KeyCombo::parse("ctrl+alt+down").unwrap(),
+            );
+            m.insert(
+                Action::ZoomToggle,
+                KeyCombo::parse("ctrl+shift+enter").unwrap(),
+            );
+            m.insert(Action::DevTools, KeyCombo::parse("ctrl+shift+i").unwrap());
+            m.insert(
+                Action::NotificationPanel,
+                KeyCombo::parse("ctrl+i").unwrap(),
+            );
+            m.insert(
+                Action::JumpToUnread,
+                KeyCombo::parse("ctrl+shift+u").unwrap(),
+            );
+            m.insert(
+                Action::ClearScrollback,
+                KeyCombo::parse("ctrl+shift+k").unwrap(),
+            );
+        }
+        m
+    }
+}
+
 #[derive(Debug, serde::Deserialize)]
 #[serde(default)]
 pub struct AppConfig {
@@ -53,6 +385,8 @@ pub struct AppConfig {
     pub browser: BrowserConfig,
     #[serde(default)]
     pub colors: ColorsConfig,
+    #[serde(default)]
+    pub keybindings: KeybindingsConfig,
 }
 
 impl Default for AppConfig {
@@ -65,6 +399,7 @@ impl Default for AppConfig {
             notifications: NotificationConfig::default(),
             browser: BrowserConfig::default(),
             colors: ColorsConfig::default(),
+            keybindings: KeybindingsConfig::default(),
         }
     }
 }
@@ -277,5 +612,89 @@ mod tests {
     fn parse_hex_invalid() {
         assert_eq!(ColorsConfig::parse_hex("xyz"), None);
         assert_eq!(ColorsConfig::parse_hex("#ff"), None);
+    }
+
+    #[test]
+    fn key_combo_parse_simple() {
+        let combo = KeyCombo::parse("cmd+c").unwrap();
+        assert!(combo.cmd);
+        assert!(!combo.shift);
+        assert!(!combo.alt);
+        assert!(!combo.ctrl);
+        assert_eq!(combo.key, "c");
+    }
+
+    #[test]
+    fn key_combo_parse_multi_modifier() {
+        let combo = KeyCombo::parse("cmd+shift+t").unwrap();
+        assert!(combo.cmd);
+        assert!(combo.shift);
+        assert!(!combo.alt);
+        assert!(!combo.ctrl);
+        assert_eq!(combo.key, "t");
+    }
+
+    #[test]
+    fn key_combo_parse_ctrl_only() {
+        let combo = KeyCombo::parse("ctrl+tab").unwrap();
+        assert!(!combo.cmd);
+        assert!(!combo.shift);
+        assert!(!combo.alt);
+        assert!(combo.ctrl);
+        assert_eq!(combo.key, "tab");
+    }
+
+    #[test]
+    fn key_combo_parse_special_keys() {
+        let combo = KeyCombo::parse("cmd+alt+left").unwrap();
+        assert!(combo.cmd);
+        assert!(!combo.shift);
+        assert!(combo.alt);
+        assert!(!combo.ctrl);
+        assert_eq!(combo.key, "left");
+    }
+
+    #[test]
+    fn key_combo_parse_invalid_empty() {
+        assert!(KeyCombo::parse("").is_none());
+    }
+
+    #[test]
+    fn key_combo_parse_bracket_keys() {
+        let combo = KeyCombo::parse("cmd+shift+]").unwrap();
+        assert!(combo.cmd);
+        assert!(combo.shift);
+        assert_eq!(combo.key, "]");
+    }
+
+    #[test]
+    fn key_combo_serde_roundtrip() {
+        // Verify deserialization via serde works
+        let toml_str = r#"copy = "cmd+c""#;
+        let cfg: KeybindingsConfig = toml::from_str(toml_str).unwrap();
+        let combo = cfg.copy.unwrap();
+        assert!(combo.cmd);
+        assert_eq!(combo.key, "c");
+    }
+
+    #[test]
+    fn keybindings_resolved_has_all_defaults() {
+        let cfg = KeybindingsConfig::default();
+        let resolved = cfg.resolved();
+        // On any platform, Copy should have a default.
+        assert!(resolved.contains_key(&Action::Copy));
+        assert!(resolved.contains_key(&Action::Paste));
+        assert!(resolved.contains_key(&Action::NewTab));
+    }
+
+    #[test]
+    fn keybindings_resolved_user_override() {
+        let toml_str = r#"copy = "ctrl+shift+y""#;
+        let cfg: KeybindingsConfig = toml::from_str(toml_str).unwrap();
+        let resolved = cfg.resolved();
+        let copy = resolved.get(&Action::Copy).unwrap();
+        assert!(copy.ctrl);
+        assert!(copy.shift);
+        assert_eq!(copy.key, "y");
     }
 }


### PR DESCRIPTION
## Summary

Two config features in one PR:

### Keybindings (#152)
- `[keybindings]` section in `config.toml` — 25 rebindable actions
- Platform-aware defaults (Cmd on macOS, Ctrl on Linux/Windows)
- String format: `"cmd+shift+t"`, `"ctrl+c"`, etc.
- All hardcoded key checks in `input.rs` replaced with config lookups
- Non-configurable: Escape, copy-mode vim keys, workspace jump 1-9, scroll

Example:
```toml
[keybindings]
copy = "cmd+c"
paste = "cmd+v"
split_right = "cmd+d"
new_tab = "cmd+t"
```

### Color Palette (#155)
- `[colors]` section in `config.toml` — hex colors for fg, bg, cursor, selection, ANSI 0-15
- Overrides applied on top of base theme (Tokyo Night or Ghostty import)
- Chrome colors auto-derived from custom background

Example:
```toml
[colors]
foreground = "#c0caf5"
background = "#1a1b26"
cursor_bg = "#f7768e"
palette = ["#15161e", "#f7768e", "#9ece6a", "#e0af68", "#7aa2f7", "#bb9af7", "#7dcfff", "#a9b1d6", "#414868", "#f7768e", "#9ece6a", "#e0af68", "#7aa2f7", "#bb9af7", "#7dcfff", "#c0caf5"]
```

## Test plan
- [ ] `cargo clippy --workspace -- -D warnings && cargo fmt --check && cargo test --workspace`
- [ ] Default keybindings unchanged (no config = same behavior as before)
- [ ] Custom keybinding in config.toml overrides default
- [ ] Custom colors in config.toml override theme
- [ ] macOS and non-macOS defaults are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable keyboard shortcuts for all major actions with platform-aware defaults.
  * Customizable color configuration for foreground, background, cursor, selection, and ANSI palette.

* **Improvements**
  * More consistent, responsive shortcut handling and platform mapping; color overrides are applied at startup.

* **Tests**
  * Added unit tests for hex color parsing, key-combo parsing, and keybinding resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->