### PR TITLE
PTY-based scrollback restore via shell integration (fixes #160)

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -459,10 +459,16 @@ impl AmuxApp {
                                         &raw,
                                         amux_session::MAX_SCROLLBACK_BYTES,
                                     );
-                                    if truncated.len() == raw.len() {
+                                    let text = if truncated.len() == raw.len() {
                                         raw
                                     } else {
                                         truncated.to_string()
+                                    };
+                                    // Wrap with SGR reset to prevent attribute bleed on restore
+                                    if text.is_empty() {
+                                        text
+                                    } else {
+                                        format!("\x1b[0m{text}\x1b[0m")
                                     }
                                 };
                                 let (cols, rows) = sf.pane.dimensions();

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -2,42 +2,46 @@
 
 use crate::*;
 
-/// Strip ANSI escape sequences from a string, returning only visible text.
-fn strip_ansi(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars();
-    while let Some(c) = chars.next() {
-        if c == '\x1b' {
-            // Skip CSI sequences (\x1b[...m etc.) and OSC sequences
-            if let Some(next) = chars.next() {
-                if next == '[' {
-                    // CSI: consume until final byte in 0x40..=0x7E range
-                    for c2 in chars.by_ref() {
-                        if ('@'..='~').contains(&c2) {
-                            break;
-                        }
-                    }
-                } else if next == ']' {
-                    // OSC: consume until ST (\x1b\\) or BEL (\x07)
-                    let mut prev = next;
-                    for c2 in chars.by_ref() {
-                        if c2 == '\x07' || (prev == '\x1b' && c2 == '\\') {
-                            break;
-                        }
-                        prev = c2;
-                    }
-                }
-                // else: two-char escape like \x1b( — already consumed
-            }
-        } else {
-            out.push(c);
+/// Write scrollback text to a temp file for shell-based replay.
+/// Returns the file path, or `None` on failure.
+fn write_scrollback_temp_file(text: &str) -> Option<std::path::PathBuf> {
+    let dir = std::env::temp_dir().join("amux-scrollback");
+    if std::fs::create_dir_all(&dir).is_err() {
+        tracing::warn!("Failed to create scrollback temp dir");
+        return None;
+    }
+    let filename = format!("{}.txt", uuid::Uuid::new_v4());
+    let path = dir.join(filename);
+    match std::fs::write(&path, text) {
+        Ok(()) => Some(path),
+        Err(e) => {
+            tracing::warn!("Failed to write scrollback temp file: {e}");
+            None
         }
     }
-    out
+}
+
+/// Remove scrollback temp files older than 1 hour.
+fn cleanup_stale_scrollback_files() {
+    let dir = std::env::temp_dir().join("amux-scrollback");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return;
+    };
+    let cutoff = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+    for entry in entries.flatten() {
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(modified) = meta.modified() {
+                if modified < cutoff {
+                    let _ = std::fs::remove_file(entry.path());
+                }
+            }
+        }
+    }
 }
 
 pub(crate) fn run() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
+    cleanup_stale_scrollback_files();
 
     let mut app_config = config::load_app_config();
     let mut font_size = app_config.font_size;
@@ -547,6 +551,18 @@ pub(crate) fn spawn_surface(
     // Auto-inject shell integration (matching cmux's ZDOTDIR/PROMPT_COMMAND approach)
     shell::inject_shell_integration(&shell, &mut cmd);
 
+    // Write scrollback to temp file for shell-based replay
+    if let Some(text) = scrollback {
+        if !text.is_empty() {
+            if let Some(path) = write_scrollback_temp_file(text) {
+                cmd.env(
+                    "AMUX_RESTORE_SCROLLBACK_FILE",
+                    path.to_string_lossy().as_ref(),
+                );
+            }
+        }
+    }
+
     let actual_cwd = if let Some(dir) = cwd {
         let path = std::path::Path::new(dir);
         if path.is_dir() {
@@ -580,30 +596,6 @@ pub(crate) fn spawn_surface(
             amux_term::AnyBackend::Wezterm(Box::new(wez_pane))
         }
     };
-
-    // Inject saved terminal state before starting the reader thread.
-    // feed_bytes writes directly to the terminal state machine, not through the PTY.
-    if let Some(text) = scrollback {
-        if !text.is_empty() {
-            // Strip trailing lines whose visible text (after removing ANSI
-            // escape sequences) is empty or whitespace-only.
-            let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
-            let lines: Vec<&str> = normalized.split('\n').collect();
-            let trimmed: Vec<&str> = lines
-                .into_iter()
-                .rev()
-                .skip_while(|line| strip_ansi(line).trim().is_empty())
-                .collect::<Vec<_>>()
-                .into_iter()
-                .rev()
-                .collect();
-            let buffer = trimmed.join("\r\n");
-            if !buffer.is_empty() {
-                pane.feed_bytes(buffer.as_bytes());
-                pane.feed_bytes(b"\r\n");
-            }
-        }
-    }
 
     let mut reader = pane.take_reader().expect("reader already taken");
     let (byte_tx, byte_rx) = mpsc::sync_channel::<Vec<u8>>(64);

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -2,32 +2,95 @@
 
 use crate::*;
 
+/// Per-user scrollback temp directory with restrictive permissions.
+fn scrollback_temp_dir() -> std::path::PathBuf {
+    // Prefer XDG_RUNTIME_DIR (per-user, typically 0700) on Linux
+    if let Ok(runtime) = std::env::var("XDG_RUNTIME_DIR") {
+        return std::path::PathBuf::from(runtime).join("amux-scrollback");
+    }
+    // Fall back to user-specific subdir in system temp
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "default".to_string());
+    std::env::temp_dir().join(format!("amux-scrollback-{user}"))
+}
+
 /// Write scrollback text to a temp file for shell-based replay.
 /// Returns the file path, or `None` on failure.
 fn write_scrollback_temp_file(text: &str) -> Option<std::path::PathBuf> {
-    let dir = std::env::temp_dir().join("amux-scrollback");
+    let dir = scrollback_temp_dir();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        let mut builder = std::fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700);
+        if builder.create(&dir).is_err() {
+            tracing::warn!("Failed to create scrollback temp dir");
+            return None;
+        }
+    }
+    #[cfg(not(unix))]
     if std::fs::create_dir_all(&dir).is_err() {
         tracing::warn!("Failed to create scrollback temp dir");
         return None;
     }
+
     let filename = format!("{}.txt", uuid::Uuid::new_v4());
     let path = dir.join(filename);
-    match std::fs::write(&path, text) {
-        Ok(()) => Some(path),
-        Err(e) => {
-            tracing::warn!("Failed to write scrollback temp file: {e}");
-            None
+
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+        {
+            Ok(mut f) => {
+                if let Err(e) = f.write_all(text.as_bytes()) {
+                    tracing::warn!("Failed to write scrollback temp file: {e}");
+                    return None;
+                }
+                // Ensure file ends with newline so shell prompt appears on a new line
+                if !text.ends_with('\n') {
+                    let _ = f.write_all(b"\n");
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to create scrollback temp file: {e}");
+                return None;
+            }
         }
     }
+    #[cfg(not(unix))]
+    {
+        let content = if text.ends_with('\n') {
+            text.to_string()
+        } else {
+            format!("{text}\n")
+        };
+        if let Err(e) = std::fs::write(&path, &content) {
+            tracing::warn!("Failed to write scrollback temp file: {e}");
+            return None;
+        }
+    }
+
+    Some(path)
 }
 
 /// Remove scrollback temp files older than 1 hour.
 fn cleanup_stale_scrollback_files() {
-    let dir = std::env::temp_dir().join("amux-scrollback");
+    let dir = scrollback_temp_dir();
     let Ok(entries) = std::fs::read_dir(&dir) else {
         return;
     };
-    let cutoff = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+    let Some(cutoff) =
+        std::time::SystemTime::now().checked_sub(std::time::Duration::from_secs(3600))
+    else {
+        return;
+    };
     for entry in entries.flatten() {
         if let Ok(meta) = entry.metadata() {
             if let Ok(modified) = meta.modified() {
@@ -551,14 +614,21 @@ pub(crate) fn spawn_surface(
     // Auto-inject shell integration (matching cmux's ZDOTDIR/PROMPT_COMMAND approach)
     shell::inject_shell_integration(&shell, &mut cmd);
 
-    // Write scrollback to temp file for shell-based replay
-    if let Some(text) = scrollback {
-        if !text.is_empty() {
-            if let Some(path) = write_scrollback_temp_file(text) {
-                cmd.env(
-                    "AMUX_RESTORE_SCROLLBACK_FILE",
-                    path.to_string_lossy().as_ref(),
-                );
+    // Write scrollback to temp file for shell-based replay.
+    // Only for shells with integration scripts that will replay and delete the file.
+    let shell_name = std::path::Path::new(&shell)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("");
+    if matches!(shell_name, "zsh" | "bash") {
+        if let Some(text) = scrollback {
+            if !text.is_empty() {
+                if let Some(path) = write_scrollback_temp_file(text) {
+                    cmd.env(
+                        "AMUX_RESTORE_SCROLLBACK_FILE",
+                        path.to_string_lossy().as_ref(),
+                    );
+                }
             }
         }
     }

--- a/resources/shell-integration/amux-bash-integration.bash
+++ b/resources/shell-integration/amux-bash-integration.bash
@@ -8,6 +8,21 @@
 _AMUX_CMD="${AMUX_BIN:-amux}"
 
 # ---------------------------------------------------------------------------
+# Session scrollback restore (one-shot, runs before first prompt)
+# ---------------------------------------------------------------------------
+_amux_restore_scrollback_once() {
+    local path="${AMUX_RESTORE_SCROLLBACK_FILE:-}"
+    [ -n "$path" ] || return 0
+    unset AMUX_RESTORE_SCROLLBACK_FILE
+
+    if [ -r "$path" ]; then
+        /bin/cat -- "$path" 2>/dev/null || true
+        /bin/rm -f -- "$path" >/dev/null 2>&1 || true
+    fi
+}
+_amux_restore_scrollback_once
+
+# ---------------------------------------------------------------------------
 # Throttle state
 # ---------------------------------------------------------------------------
 _AMUX_PWD_LAST=""

--- a/resources/shell-integration/amux-bash-integration.bash
+++ b/resources/shell-integration/amux-bash-integration.bash
@@ -16,8 +16,8 @@ _amux_restore_scrollback_once() {
     unset AMUX_RESTORE_SCROLLBACK_FILE
 
     if [ -r "$path" ]; then
-        /bin/cat -- "$path" 2>/dev/null || true
-        /bin/rm -f -- "$path" >/dev/null 2>&1 || true
+        command cat < "$path" 2>/dev/null || true
+        command rm -f "$path" >/dev/null 2>&1 || true
     fi
 }
 _amux_restore_scrollback_once

--- a/resources/shell-integration/amux-zsh-integration.zsh
+++ b/resources/shell-integration/amux-zsh-integration.zsh
@@ -16,8 +16,8 @@ _amux_restore_scrollback_once() {
     unset AMUX_RESTORE_SCROLLBACK_FILE
 
     if [[ -r "$path" ]]; then
-        /bin/cat -- "$path" 2>/dev/null || true
-        /bin/rm -f -- "$path" >/dev/null 2>&1 || true
+        command cat < "$path" 2>/dev/null || true
+        command rm -f "$path" >/dev/null 2>&1 || true
     fi
 }
 _amux_restore_scrollback_once

--- a/resources/shell-integration/amux-zsh-integration.zsh
+++ b/resources/shell-integration/amux-zsh-integration.zsh
@@ -8,6 +8,21 @@
 typeset -g _AMUX_CMD="${AMUX_BIN:-amux}"
 
 # ---------------------------------------------------------------------------
+# Session scrollback restore (one-shot, runs before first prompt)
+# ---------------------------------------------------------------------------
+_amux_restore_scrollback_once() {
+    local path="${AMUX_RESTORE_SCROLLBACK_FILE:-}"
+    [[ -n "$path" ]] || return 0
+    unset AMUX_RESTORE_SCROLLBACK_FILE
+
+    if [[ -r "$path" ]]; then
+        /bin/cat -- "$path" 2>/dev/null || true
+        /bin/rm -f -- "$path" >/dev/null 2>&1 || true
+    fi
+}
+_amux_restore_scrollback_once
+
+# ---------------------------------------------------------------------------
 # Throttle state
 # ---------------------------------------------------------------------------
 typeset -g _AMUX_PWD_LAST=""


### PR DESCRIPTION
## Summary

Replace `feed_bytes()` scrollback injection with cmux-style PTY-based restore: write scrollback to a temp file, pass via `AMUX_RESTORE_SCROLLBACK_FILE` env var, and let the shell's integration script `cat` it through the PTY.

## Why

The old `feed_bytes()` approach bypassed the shell entirely, causing:
- PROMPT_SP ghost artifacts (PR #150)
- SGR state bleed requiring workarounds
- Unnatural interaction with shell prompt drawing

The new approach lets the shell control the terminal state throughout. The restored content arrives through the normal PTY pipeline, and the shell draws a fresh prompt below it.

## Changes

- **Save path** (`main.rs`): Wraps scrollback with `\e[0m` prefix/suffix to prevent SGR attribute bleed
- **Restore path** (`startup.rs`): Writes scrollback to `$TMPDIR/amux-scrollback/{uuid}.txt`, sets `AMUX_RESTORE_SCROLLBACK_FILE` env var on the spawned shell, removes `feed_bytes()` entirely
- **Shell integration** (`amux-zsh-integration.zsh`, `amux-bash-integration.bash`): Added `_amux_restore_scrollback_once` — reads env var, cats file, deletes file, unsets var
- **Cleanup**: Stale temp files (>1 hour) cleaned up on startup
- **Removed**: `strip_ansi()` helper (no longer needed)

## Design (matching cmux)

1. Shell starts → integration script runs before first prompt
2. Script reads `AMUX_RESTORE_SCROLLBACK_FILE`, cats the file through PTY
3. Terminal processes the bytes normally (colors, formatting preserved)
4. Script deletes temp file and unsets env var (one-shot, no re-injection)
5. Shell draws fresh prompt below restored content

## Test plan
- [ ] `cargo clippy --workspace -- -D warnings && cargo fmt --check && cargo test --workspace`
- [ ] Restore session with scrollback — content appears above fresh prompt
- [ ] No PROMPT_SP artifacts on restored prompt lines
- [ ] Empty tabs restore cleanly (no scrollback file written)
- [ ] Stale temp files cleaned up on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable scrollback restoration on session resume, including correct handling of terminal formatting boundaries.

* **New Features**
  * One-shot shell-side restore that emits saved scrollback early during shell startup.

* **Refactor**
  * Shifted restoration flow to shell-based replay for more consistent session replay behavior.

* **Chores**
  * Writes session scrollback to secure temporary files and automatically cleans up stale files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->