### PR TITLE
Semantic marks + Formatter API for scrollback capture (fixes #162)

### DIFF
--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -2,109 +2,8 @@
 
 use crate::*;
 
-/// Per-user scrollback temp directory with restrictive permissions.
-fn scrollback_temp_dir() -> std::path::PathBuf {
-    // Prefer XDG_RUNTIME_DIR (per-user, typically 0700) on Linux
-    if let Ok(runtime) = std::env::var("XDG_RUNTIME_DIR") {
-        return std::path::PathBuf::from(runtime).join("amux-scrollback");
-    }
-    // Fall back to user-specific subdir in system temp
-    let user = std::env::var("USER")
-        .or_else(|_| std::env::var("USERNAME"))
-        .unwrap_or_else(|_| "default".to_string());
-    std::env::temp_dir().join(format!("amux-scrollback-{user}"))
-}
-
-/// Write scrollback text to a temp file for shell-based replay.
-/// Returns the file path, or `None` on failure.
-fn write_scrollback_temp_file(text: &str) -> Option<std::path::PathBuf> {
-    let dir = scrollback_temp_dir();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::DirBuilderExt;
-        let mut builder = std::fs::DirBuilder::new();
-        builder.recursive(true).mode(0o700);
-        if builder.create(&dir).is_err() {
-            tracing::warn!("Failed to create scrollback temp dir");
-            return None;
-        }
-    }
-    #[cfg(not(unix))]
-    if std::fs::create_dir_all(&dir).is_err() {
-        tracing::warn!("Failed to create scrollback temp dir");
-        return None;
-    }
-
-    let filename = format!("{}.txt", uuid::Uuid::new_v4());
-    let path = dir.join(filename);
-
-    #[cfg(unix)]
-    {
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .mode(0o600)
-            .open(&path)
-        {
-            Ok(mut f) => {
-                if let Err(e) = f.write_all(text.as_bytes()) {
-                    tracing::warn!("Failed to write scrollback temp file: {e}");
-                    return None;
-                }
-                // Ensure file ends with newline so shell prompt appears on a new line
-                if !text.ends_with('\n') {
-                    let _ = f.write_all(b"\n");
-                }
-            }
-            Err(e) => {
-                tracing::warn!("Failed to create scrollback temp file: {e}");
-                return None;
-            }
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        let content = if text.ends_with('\n') {
-            text.to_string()
-        } else {
-            format!("{text}\n")
-        };
-        if let Err(e) = std::fs::write(&path, &content) {
-            tracing::warn!("Failed to write scrollback temp file: {e}");
-            return None;
-        }
-    }
-
-    Some(path)
-}
-
-/// Remove scrollback temp files older than 1 hour.
-fn cleanup_stale_scrollback_files() {
-    let dir = scrollback_temp_dir();
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return;
-    };
-    let Some(cutoff) =
-        std::time::SystemTime::now().checked_sub(std::time::Duration::from_secs(3600))
-    else {
-        return;
-    };
-    for entry in entries.flatten() {
-        if let Ok(meta) = entry.metadata() {
-            if let Ok(modified) = meta.modified() {
-                if modified < cutoff {
-                    let _ = std::fs::remove_file(entry.path());
-                }
-            }
-        }
-    }
-}
-
 pub(crate) fn run() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    cleanup_stale_scrollback_files();
 
     let mut app_config = config::load_app_config();
     let mut font_size = app_config.font_size;
@@ -611,24 +510,7 @@ pub(crate) fn spawn_surface(
     // Auto-inject shell integration (matching cmux's ZDOTDIR/PROMPT_COMMAND approach)
     shell::inject_shell_integration(&shell, &mut cmd);
 
-    // Write scrollback to temp file for shell-based replay.
-    // Only for shells with integration scripts that will replay and delete the file.
-    let shell_name = std::path::Path::new(&shell)
-        .file_name()
-        .and_then(|f| f.to_str())
-        .unwrap_or("");
-    if matches!(shell_name, "zsh" | "bash") {
-        if let Some(text) = scrollback {
-            if !text.is_empty() {
-                if let Some(path) = write_scrollback_temp_file(text) {
-                    cmd.env(
-                        "AMUX_RESTORE_SCROLLBACK_FILE",
-                        path.to_string_lossy().as_ref(),
-                    );
-                }
-            }
-        }
-    }
+    // Scrollback is restored via feed_bytes after spawn (below).
 
     let actual_cwd = if let Some(dir) = cwd {
         let path = std::path::Path::new(dir);
@@ -653,6 +535,16 @@ pub(crate) fn spawn_surface(
     // Apply amux theme colors to the ghostty backend (which otherwise
     // uses libghostty-vt's built-in defaults).
     ghostty_pane.set_palette(config.color_palette.clone());
+
+    // Restore saved scrollback by injecting directly into the terminal
+    // state machine before the reader thread starts.
+    if let Some(text) = scrollback {
+        if !text.is_empty() {
+            ghostty_pane.feed_bytes(text.as_bytes());
+            ghostty_pane.feed_bytes(b"\r\n");
+        }
+    }
+
     let mut pane: amux_term::AnyBackend = amux_term::AnyBackend::Ghostty(Box::new(ghostty_pane));
 
     let mut reader = pane.take_reader().expect("reader already taken");

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -458,10 +458,48 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
 
     fn read_scrollback_text(&self, _max_lines: usize) -> String {
         use libghostty_vt::fmt::{Format, Formatter, FormatterOptions};
+        use libghostty_vt::screen::RowSemanticPrompt;
 
+        // Step 1: iterate rows and find the index of the last non-prompt row.
+        // Each row's `semantic_prompt()` reflects OSC 133 marks emitted by the
+        // shell integration. The trailing prompt rows are the boundary where
+        // we should truncate.
+        let last_content_row = {
+            let mut rs = self.render_state.borrow_mut();
+            let snapshot = match rs.update(&self.terminal) {
+                Ok(s) => s,
+                Err(_) => return String::new(),
+            };
+            let mut row_iter = match RowIterator::new() {
+                Ok(r) => r,
+                Err(_) => return String::new(),
+            };
+            let mut row_iteration = match row_iter.update(&snapshot) {
+                Ok(r) => r,
+                Err(_) => return String::new(),
+            };
+
+            let mut idx: i32 = -1;
+            let mut last_content: i32 = -1;
+            while let Some(row) = row_iteration.next() {
+                idx += 1;
+                if let Ok(raw) = row.raw_row() {
+                    match raw.semantic_prompt() {
+                        Ok(RowSemanticPrompt::None) => last_content = idx,
+                        Ok(_) => {}                   // Prompt or Continuation — skip
+                        Err(_) => last_content = idx, // Unknown — keep
+                    }
+                } else {
+                    last_content = idx;
+                }
+            }
+            last_content
+        };
+
+        // Step 2: get the formatted VT output (preserves colors/styling).
         let opts = FormatterOptions {
             format: Format::Vt,
-            trim: true,
+            trim: false,
             unwrap: false,
         };
         let mut formatter = match Formatter::new(&self.terminal, opts) {
@@ -480,9 +518,18 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         };
         let text = String::from_utf8_lossy(&bytes).to_string();
 
-        // Strip content after the last command-finished mark (OSC 133;D).
-        // This excludes trailing prompts from the saved scrollback.
-        strip_trailing_prompts(&text)
+        // Step 3: take only the lines up to and including last_content_row.
+        // The Formatter outputs one line per terminal row when trim/unwrap
+        // are both false.
+        if last_content_row < 0 {
+            return String::new();
+        }
+        let keep = (last_content_row as usize) + 1;
+        let lines: Vec<&str> = text.lines().take(keep).collect();
+        let mut result = lines.join("\n");
+        // Trim trailing blank/whitespace lines (rows beyond actual content).
+        result = result.trim_end().to_string();
+        result
     }
 
     fn read_scrollback_text_range(&self, _start: usize, _end: usize) -> String {
@@ -686,35 +733,6 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
             events.push(event);
         }
         events
-    }
-}
-
-/// Strip trailing prompt content from VT-formatted scrollback.
-///
-/// Finds the last OSC 133;D (command finished) mark and truncates
-/// everything after it. This removes the trailing shell prompt that
-/// would otherwise duplicate when the shell draws a fresh prompt
-/// on restore.
-fn strip_trailing_prompts(text: &str) -> String {
-    // Look for the last occurrence of OSC 133;D (command finished).
-    // The mark format is: \x1b]133;D or \x1b]133;D;N (with exit code)
-    // terminated by BEL (\x07) or ST (\x1b\\).
-    if let Some(last_d) = text.rfind("\x1b]133;D") {
-        // Find the end of this OSC sequence (BEL or ST terminator)
-        let after_mark = &text[last_d..];
-        let end = after_mark
-            .find('\x07')
-            .map(|i| i + 1)
-            .or_else(|| after_mark.find("\x1b\\").map(|i| i + 2))
-            .unwrap_or(after_mark.len());
-
-        // Keep everything up to and including the 133;D mark
-        let truncated = &text[..last_d + end];
-        truncated.to_string()
-    } else {
-        // No semantic marks found — return as-is (shell integration
-        // may not be loaded, or no commands were run)
-        text.to_string()
     }
 }
 

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -251,146 +251,6 @@ where
 
     /// Build lines with ANSI SGR escape sequences for color/style preservation.
     /// Used by `read_scrollback_text` so session restore retains styling.
-    fn snapshot_lines_ansi(&self) -> Vec<String> {
-        use libghostty_vt::style::Underline as GhosttyUnderline;
-
-        let mut rs = self.render_state.borrow_mut();
-        let snapshot = match rs.update(&self.terminal) {
-            Ok(s) => s,
-            Err(_) => return Vec::new(),
-        };
-
-        let mut row_iter = match RowIterator::new() {
-            Ok(r) => r,
-            Err(_) => return Vec::new(),
-        };
-        let mut cell_iter = match CellIterator::new() {
-            Ok(c) => c,
-            Err(_) => return Vec::new(),
-        };
-        let mut row_iteration = match row_iter.update(&snapshot) {
-            Ok(r) => r,
-            Err(_) => return Vec::new(),
-        };
-
-        let default_style = libghostty_vt::style::Style::default();
-
-        let mut lines = Vec::new();
-        while let Some(row) = row_iteration.next() {
-            let mut line = String::new();
-            let mut col: usize = 0;
-            let mut visible_col: usize = 0;
-            let mut prev_style = default_style;
-            let mut prev_fg: Option<RgbColor> = None;
-            let mut prev_bg: Option<RgbColor> = None;
-
-            if let Ok(mut cell_iteration) = cell_iter.update(row) {
-                while let Some(cell) = cell_iteration.next() {
-                    let graphemes = cell.graphemes().unwrap_or_default();
-                    if graphemes.is_empty() {
-                        col += 1;
-                        continue;
-                    }
-
-                    // Pad with spaces up to this column.
-                    while visible_col < col {
-                        line.push(' ');
-                        visible_col += 1;
-                    }
-
-                    // Check if style changed.
-                    let cur_style = cell.style().unwrap_or(default_style);
-                    let cur_fg = cell.fg_color().ok().flatten();
-                    let cur_bg = cell.bg_color().ok().flatten();
-
-                    let style_changed =
-                        cur_style != prev_style || cur_fg != prev_fg || cur_bg != prev_bg;
-
-                    if style_changed {
-                        // Reset, then emit active attributes.
-                        line.push_str("\x1b[0");
-
-                        if cur_style.bold {
-                            line.push_str(";1");
-                        }
-                        if cur_style.faint {
-                            line.push_str(";2");
-                        }
-                        if cur_style.italic {
-                            line.push_str(";3");
-                        }
-                        match cur_style.underline {
-                            GhosttyUnderline::Single => line.push_str(";4"),
-                            GhosttyUnderline::Double => line.push_str(";21"),
-                            GhosttyUnderline::Curly => line.push_str(";4:3"),
-                            GhosttyUnderline::Dotted => line.push_str(";4:4"),
-                            GhosttyUnderline::Dashed => line.push_str(";4:5"),
-                            _ => {}
-                        }
-                        if cur_style.inverse {
-                            line.push_str(";7");
-                        }
-                        if cur_style.invisible {
-                            line.push_str(";8");
-                        }
-                        if cur_style.strikethrough {
-                            line.push_str(";9");
-                        }
-
-                        // Foreground color
-                        {
-                            use std::fmt::Write;
-                            if let Some(fg) = cur_fg {
-                                let _ = write!(line, ";38;2;{};{};{}", fg.r, fg.g, fg.b);
-                            }
-
-                            // Background color
-                            if let Some(bg) = cur_bg {
-                                let _ = write!(line, ";48;2;{};{};{}", bg.r, bg.g, bg.b);
-                            }
-
-                            // Underline color (SGR 58;2;R;G;B)
-                            if !matches!(cur_style.underline, GhosttyUnderline::None) {
-                                if let Some(uc) = resolve_style_color(
-                                    &cur_style.underline_color,
-                                    &self.cached_palette.colors,
-                                ) {
-                                    let _ = write!(
-                                        line,
-                                        ";58;2;{};{};{}",
-                                        (uc.0 * 255.0) as u8,
-                                        (uc.1 * 255.0) as u8,
-                                        (uc.2 * 255.0) as u8
-                                    );
-                                }
-                            }
-                        }
-
-                        line.push('m');
-
-                        prev_style = cur_style;
-                        prev_fg = cur_fg;
-                        prev_bg = cur_bg;
-                    }
-
-                    for ch in graphemes {
-                        line.push(ch);
-                    }
-                    col += 1;
-                    visible_col += 1;
-                }
-            }
-
-            // Reset at end of line if we had non-default attributes.
-            if prev_style != default_style || prev_fg.is_some() || prev_bg.is_some() {
-                line.push_str("\x1b[0m");
-            }
-
-            lines.push(line.trim_end().to_string());
-        }
-        lines
-    }
-
     /// Read screen text using the render state snapshot iterators.
     /// Takes &self via RefCell interior mutability.
     fn read_text_from_snapshot(&self) -> String {
@@ -596,52 +456,39 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         self.read_text_from_snapshot()
     }
 
-    fn read_scrollback_text(&self, max_lines: usize) -> String {
-        // libghostty-vt 0.1.x only exposes viewport via render state.
-        // PointCoordinate fields are private, so grid_ref can't reach scrollback.
-        let lines = self.snapshot_lines_ansi();
-        if max_lines > lines.len() {
-            tracing::warn!(
-                "read_scrollback_text({max_lines}) requested but only {} viewport lines available \
-                 (ghostty backend cannot read scrollback history)",
-                lines.len()
-            );
-        }
-        let total = lines.len();
-        let start = total.saturating_sub(max_lines);
-        let mut selected: Vec<&str> = lines[start..].iter().map(|s| s.as_str()).collect();
-        while selected.last().is_some_and(|l| l.is_empty()) {
-            selected.pop();
-        }
-        selected.join("\n")
+    fn read_scrollback_text(&self, _max_lines: usize) -> String {
+        use libghostty_vt::fmt::{Format, Formatter, FormatterOptions};
+
+        let opts = FormatterOptions {
+            format: Format::Vt,
+            trim: true,
+            unwrap: false,
+        };
+        let mut formatter = match Formatter::new(&self.terminal, opts) {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::warn!("Failed to create formatter: {e:?}");
+                return String::new();
+            }
+        };
+        let bytes = match formatter.format_alloc::<()>(None) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!("Failed to format terminal: {e:?}");
+                return String::new();
+            }
+        };
+        let text = String::from_utf8_lossy(&bytes).to_string();
+
+        // Strip content after the last command-finished mark (OSC 133;D).
+        // This excludes trailing prompts from the saved scrollback.
+        strip_trailing_prompts(&text)
     }
 
-    fn read_scrollback_text_range(&self, start: usize, end: usize) -> String {
-        // libghostty-vt 0.1.x only exposes viewport via render state.
-        let lines = self.snapshot_lines_ansi();
-        let viewport_total = self.terminal.total_rows().unwrap_or(0);
-        let viewport_rows = lines.len();
-        let viewport_start = viewport_total.saturating_sub(viewport_rows);
-
-        if start < viewport_start || end > viewport_total {
-            tracing::warn!(
-                "read_scrollback_text_range({start}..{end}) extends beyond viewport \
-                 ({viewport_start}..{viewport_total}), results may be incomplete \
-                 (ghostty backend cannot read scrollback history)"
-            );
-        }
-
-        // Map physical row range to viewport-relative indices.
-        let s = start.saturating_sub(viewport_start).min(viewport_rows);
-        let e = end.saturating_sub(viewport_start).min(viewport_rows);
-        if s >= e {
-            return String::new();
-        }
-        let mut selected: Vec<&str> = lines[s..e].iter().map(|s| s.as_str()).collect();
-        while selected.last().is_some_and(|l| l.is_empty()) {
-            selected.pop();
-        }
-        selected.join("\n")
+    fn read_scrollback_text_range(&self, _start: usize, _end: usize) -> String {
+        // With the Formatter API we get the full screen content.
+        // Range-based access isn't supported — return the full output.
+        self.read_scrollback_text(usize::MAX)
     }
 
     fn search_scrollback(&self, query: &str) -> Vec<(usize, usize, usize)> {
@@ -839,6 +686,35 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
             events.push(event);
         }
         events
+    }
+}
+
+/// Strip trailing prompt content from VT-formatted scrollback.
+///
+/// Finds the last OSC 133;D (command finished) mark and truncates
+/// everything after it. This removes the trailing shell prompt that
+/// would otherwise duplicate when the shell draws a fresh prompt
+/// on restore.
+fn strip_trailing_prompts(text: &str) -> String {
+    // Look for the last occurrence of OSC 133;D (command finished).
+    // The mark format is: \x1b]133;D or \x1b]133;D;N (with exit code)
+    // terminated by BEL (\x07) or ST (\x1b\\).
+    if let Some(last_d) = text.rfind("\x1b]133;D") {
+        // Find the end of this OSC sequence (BEL or ST terminator)
+        let after_mark = &text[last_d..];
+        let end = after_mark
+            .find('\x07')
+            .map(|i| i + 1)
+            .or_else(|| after_mark.find("\x1b\\").map(|i| i + 2))
+            .unwrap_or(after_mark.len());
+
+        // Keep everything up to and including the 133;D mark
+        let truncated = &text[..last_d + end];
+        truncated.to_string()
+    } else {
+        // No semantic marks found — return as-is (shell integration
+        // may not be loaded, or no commands were run)
+        text.to_string()
     }
 }
 

--- a/resources/shell-integration/amux-bash-integration.bash
+++ b/resources/shell-integration/amux-bash-integration.bash
@@ -8,21 +8,6 @@
 _AMUX_CMD="${AMUX_BIN:-amux}"
 
 # ---------------------------------------------------------------------------
-# Session scrollback restore (one-shot, runs before first prompt)
-# ---------------------------------------------------------------------------
-_amux_restore_scrollback_once() {
-    local path="${AMUX_RESTORE_SCROLLBACK_FILE:-}"
-    [ -n "$path" ] || return 0
-    unset AMUX_RESTORE_SCROLLBACK_FILE
-
-    if [ -r "$path" ]; then
-        command cat < "$path" 2>/dev/null || true
-        command rm -f "$path" >/dev/null 2>&1 || true
-    fi
-}
-_amux_restore_scrollback_once
-
-# ---------------------------------------------------------------------------
 # Throttle state
 # ---------------------------------------------------------------------------
 _AMUX_PWD_LAST=""

--- a/resources/shell-integration/amux-bash-integration.bash
+++ b/resources/shell-integration/amux-bash-integration.bash
@@ -145,6 +145,13 @@ _amux_start_pr_poll() {
 # PROMPT_COMMAND hook
 # ---------------------------------------------------------------------------
 _amux_prompt_command() {
+    local _amux_exit=$?
+
+    # OSC 133;D — command finished (with exit code)
+    printf '\e]133;D;%s\a' "$_amux_exit"
+    # OSC 133;A — prompt starts
+    printf '\e]133;A\a'
+
     local now
     now="$(date +%s)"
     local pwd="$PWD"
@@ -201,6 +208,11 @@ _amux_preexec_trap() {
     # Only trigger for interactive commands, not PROMPT_COMMAND itself
     [[ "$BASH_COMMAND" == "_amux_prompt_command" ]] && return
     [[ "$BASH_COMMAND" == "$PROMPT_COMMAND" ]] && return
+
+    # OSC 133;B — command input finished
+    printf '\e]133;B\a'
+    # OSC 133;C — command output starts
+    printf '\e]133;C\a'
 
     local cmd="$BASH_COMMAND"
     case "$cmd" in

--- a/resources/shell-integration/amux-zsh-integration.zsh
+++ b/resources/shell-integration/amux-zsh-integration.zsh
@@ -8,21 +8,6 @@
 typeset -g _AMUX_CMD="${AMUX_BIN:-amux}"
 
 # ---------------------------------------------------------------------------
-# Session scrollback restore (one-shot, runs before first prompt)
-# ---------------------------------------------------------------------------
-_amux_restore_scrollback_once() {
-    local path="${AMUX_RESTORE_SCROLLBACK_FILE:-}"
-    [[ -n "$path" ]] || return 0
-    unset AMUX_RESTORE_SCROLLBACK_FILE
-
-    if [[ -r "$path" ]]; then
-        command cat < "$path" 2>/dev/null || true
-        command rm -f "$path" >/dev/null 2>&1 || true
-    fi
-}
-_amux_restore_scrollback_once
-
-# ---------------------------------------------------------------------------
 # Throttle state
 # ---------------------------------------------------------------------------
 typeset -g _AMUX_PWD_LAST=""

--- a/resources/shell-integration/amux-zsh-integration.zsh
+++ b/resources/shell-integration/amux-zsh-integration.zsh
@@ -228,6 +228,11 @@ _amux_start_head_watch() {
 # Hook: preexec (before command runs)
 # ---------------------------------------------------------------------------
 _amux_preexec() {
+    # OSC 133;B — command input finished (user pressed Enter)
+    printf '\e]133;B\a'
+    # OSC 133;C — command output starts
+    printf '\e]133;C\a'
+
     # Force git refresh after git-related commands
     local cmd="${1## }"
     case "$cmd" in
@@ -244,7 +249,13 @@ _amux_preexec() {
 # Hook: precmd (before prompt)
 # ---------------------------------------------------------------------------
 _amux_precmd() {
+    local _amux_exit=$?
     _amux_stop_head_watch
+
+    # OSC 133;D — command finished (with exit code)
+    printf '\e]133;D;%s\a' "$_amux_exit"
+    # OSC 133;A — prompt starts
+    printf '\e]133;A\a'
 
     local now=$EPOCHSECONDS
     local pwd="$PWD"


### PR DESCRIPTION
## Summary

Use libghostty-vt's semantic prompt metadata (populated by OSC 133 marks from shell integration) to exclude trailing prompts from saved scrollback. Replaces the previous heuristic approach with actual semantic data.

## How it works

### Save path
1. **Shell integration emits OSC 133 marks** — `precmd` emits `\e]133;A` (prompt start) + `\e]133;D;N` (last command finished), `preexec` emits `\e]133;B` (input done) + `\e]133;C` (output starts). This populates libghostty-vt's per-row `semantic_prompt` metadata.
2. **Iterate rows via `RowIteration::raw_row().semantic_prompt()`** — find the index of the last row whose semantic state is `None` (i.e., not a prompt)
3. **Use the Formatter** with `trim: false, unwrap: false` to get the full VT-formatted text (one line per terminal row)
4. **Keep only the first N lines** where N is `last_non_prompt_row + 1`
5. **Trim trailing whitespace** to clean up

### Restore path
- Unchanged — uses `feed_bytes()` to inject the saved scrollback directly into the terminal state machine before the reader thread starts.

## Investigation findings

Several approaches were explored before landing on this one:

1. **PTY-based restore via temp file + shell cat** (cmux's approach) — implemented but didn't render reliably due to a timing issue between shell execution and the reader thread startup. Reverted.

2. **Strip trailing prompts via OSC 133 marks in formatter output** — discovered the Ghostty Formatter (Zig source in `src/terminal/formatter.zig`) **stores** semantic prompt metadata but **never emits** OSC 133 marks during VT export. Confirmed via debug dump (`has_133A=false has_133B=false has_133C=false has_133D=false`). Approach abandoned.

3. **Heuristic prompt detection** — strip trailing lines that look like prompts. Fragile across prompt formats. Replaced once we found the row-level semantic API.

4. **Row::semantic_prompt() via raw_row()** ← **shipped approach**. The `RowIteration::raw_row()` method returns a `Row` whose `semantic_prompt()` reflects the OSC 133 state. Found in libghostty-vt 0.1.1 — no patches or forks needed.

## Files changed

- `crates/amux-term/src/ghostty_pane.rs` — replaced heuristic `strip_trailing_prompts` with row-level semantic iteration
- `resources/shell-integration/amux-zsh-integration.zsh` — emit OSC 133;A/B/C/D in precmd/preexec
- `resources/shell-integration/amux-bash-integration.bash` — same for bash

## Edge cases handled

- **Tabs with no commands run** — fall through to '≤2 meaningful lines = save empty' path, preventing prompt stacking on empty terminals
- **Tabs without OSC 133 instrumentation** — `semantic_prompt()` returns `None` for all rows, so all rows are kept (no false truncation)
- **Old session files** — no marks, no truncation, content preserved as-is

## Test plan
- [ ] `cargo clippy --workspace -- -D warnings && cargo fmt --check && cargo test --workspace`
- [ ] Open new tab, run `ls`, quit, relaunch — restored content shows the `ls` output without duplicate trailing prompt
- [ ] Open new tab, don't run any command, quit, relaunch — fresh terminal, no stacking
- [ ] Run multiple commands across multiple restores — no prompts accumulate

## Related

- Closes #162 (semantic marks for scrollback capture)
- Builds on #160 (PTY-based restore — reverted to feed_bytes after testing)
- Builds on #163 (wezterm removal) — single backend simplifies the implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reworked scrollback formatting to use a centralized formatter, producing cleaner, more consistent scrollback output and trimming trailing whitespace.

* **New Features**
  * Shell integrations now emit richer prompt/command lifecycle markers (command start, input finished, output start, and completion with exit code) for improved session metadata.

* **Bug Fixes**
  * Removed temp-file based scrollback restore and now injects scrollback directly into the terminal to simplify session restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->