### PR TITLE
PowerShell 7 shell integration (fixes #166)

### DIFF
--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -782,13 +782,9 @@ pub(crate) fn spawn_surface(
     // Auto-inject shell integration (matching cmux's ZDOTDIR/PROMPT_COMMAND approach)
     shell::inject_shell_integration(&shell, &mut cmd);
 
-    // Write scrollback to temp file for shell-based replay.
-    // Only for shells with integration scripts that will replay and delete the file.
-    let shell_name = std::path::Path::new(&shell)
-        .file_name()
-        .and_then(|f| f.to_str())
-        .unwrap_or("");
-    if matches!(shell_name, "zsh" | "bash") {
+    // Write scrollback to temp file for shell-based replay. Only for shells
+    // with integration scripts that know to read and delete the file.
+    if shell::has_shell_integration(&shell) {
         if let Some(text) = scrollback {
             if !text.is_empty() {
                 if let Some(path) = write_scrollback_temp_file(text) {

--- a/crates/amux-core/src/shell.rs
+++ b/crates/amux-core/src/shell.rs
@@ -17,14 +17,32 @@ pub fn default_shell() -> String {
     }
 }
 
+/// Normalize a shell file name to its stem. On Windows the shell binary is
+/// typically reported as `pwsh.exe`, `bash.exe`, `cmd.exe`; on Unix it's
+/// just `zsh`, `bash`, etc. Using the stem lets the match arm below work
+/// identically on both platforms.
+fn shell_stem(shell: &str) -> &str {
+    std::path::Path::new(shell)
+        .file_stem()
+        .and_then(|f| f.to_str())
+        .unwrap_or("")
+}
+
+/// Returns true if the given shell binary should get scrollback restore and
+/// other integration-driven features (git reporting, OSC 133 marks, etc.).
+/// Callers gate their integration-specific plumbing on this so a user with
+/// cmd.exe or an unrecognized shell still gets a working terminal.
+pub fn has_shell_integration(shell: &str) -> bool {
+    matches!(shell_stem(shell), "zsh" | "bash" | "pwsh")
+}
+
 /// Write shell integration files to ~/.config/amux/shell/ and set env vars to
-/// auto-inject them. For zsh: ZDOTDIR override. For bash: PROMPT_COMMAND bootstrap.
+/// auto-inject them. For zsh: ZDOTDIR override. For bash: PROMPT_COMMAND
+/// bootstrap. For pwsh: a `-NoLogo -NoExit -Command` bootstrap that loads the
+/// user's $PROFILE first then dot-sources our integration script.
 /// Matching cmux's approach — no user dotfile modification required.
 pub fn inject_shell_integration(shell: &str, cmd: &mut CommandBuilder) {
-    let shell_name = std::path::Path::new(shell)
-        .file_name()
-        .and_then(|f| f.to_str())
-        .unwrap_or("");
+    let shell_name = shell_stem(shell);
 
     let Some(integration_dir) = ensure_shell_integration_dir() else {
         return;
@@ -69,6 +87,24 @@ pub fn inject_shell_integration(shell: &str, cmd: &mut CommandBuilder) {
             };
             cmd.env("PROMPT_COMMAND", &bootstrap);
         }
+        "pwsh" => {
+            // PowerShell 7+ has no ZDOTDIR equivalent. The only reliable
+            // zero-user-config injection point is `-Command`. The bootstrap
+            // loads the user's $PROFILE first (so any prompt override they
+            // define is in place), then dot-sources our integration so we
+            // can wrap their prompt.
+            //
+            // Escape apostrophes in the script path for the single-quoted
+            // PowerShell string literal below. PowerShell escapes `'` inside
+            // a single-quoted string as `''`.
+            let pwsh_script = integration_dir.join("amux-pwsh-integration.ps1");
+            let escaped_path = pwsh_script.to_string_lossy().replace('\'', "''");
+            let bootstrap = format!("if (Test-Path $PROFILE) {{ . $PROFILE }}; . '{escaped_path}'");
+            cmd.arg("-NoLogo");
+            cmd.arg("-NoExit");
+            cmd.arg("-Command");
+            cmd.arg(bootstrap);
+        }
         _ => {}
     }
 }
@@ -109,6 +145,10 @@ fn ensure_shell_integration_dir() -> Option<std::path::PathBuf> {
         (
             "amux-bash-integration.bash",
             include_str!("../../../resources/shell-integration/amux-bash-integration.bash"),
+        ),
+        (
+            "amux-pwsh-integration.ps1",
+            include_str!("../../../resources/shell-integration/amux-pwsh-integration.ps1"),
         ),
     ];
 
@@ -191,6 +231,81 @@ pub fn install_agent_wrappers_at(bin_dir: &std::path::Path) -> Option<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn shell_stem_strips_extensions_and_directories() {
+        // Bare names (no path, no extension) — portable across platforms.
+        assert_eq!(shell_stem("pwsh"), "pwsh");
+        assert_eq!(shell_stem("bash"), "bash");
+        assert_eq!(shell_stem(""), "");
+        // Extensions strip on both platforms; Path::file_stem is extension-aware
+        // regardless of directory separators.
+        assert_eq!(shell_stem("bash.exe"), "bash");
+        assert_eq!(shell_stem("pwsh.exe"), "pwsh");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_stem_on_unix_handles_absolute_paths() {
+        assert_eq!(shell_stem("/bin/bash"), "bash");
+        assert_eq!(shell_stem("/usr/bin/zsh"), "zsh");
+        assert_eq!(shell_stem("/opt/homebrew/bin/pwsh"), "pwsh");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn shell_stem_on_windows_handles_backslash_paths() {
+        assert_eq!(
+            shell_stem("C:\\Program Files\\PowerShell\\7\\pwsh.exe"),
+            "pwsh"
+        );
+        assert_eq!(shell_stem("C:\\Windows\\System32\\cmd.exe"), "cmd");
+        // Forward-slash Windows paths are accepted by the std Path APIs on
+        // Windows too, so users pointing at `C:/.../pwsh.exe` still resolve.
+        assert_eq!(shell_stem("C:/Program Files/PowerShell/7/pwsh.exe"), "pwsh");
+    }
+
+    #[test]
+    fn has_shell_integration_covers_supported_shells_by_stem() {
+        // Bare-name forms (what file_stem on a bare name returns) — these
+        // must always match regardless of host platform.
+        assert!(has_shell_integration("bash"));
+        assert!(has_shell_integration("zsh"));
+        assert!(has_shell_integration("pwsh"));
+        assert!(has_shell_integration("bash.exe"));
+        assert!(has_shell_integration("pwsh.exe"));
+
+        // Explicitly NOT supported: cmd.exe, fish, Windows PowerShell 5.1,
+        // sh, ksh. These return a functional terminal pane without scrollback
+        // restore or status hooks.
+        assert!(!has_shell_integration("cmd.exe"));
+        assert!(!has_shell_integration("sh"));
+        assert!(!has_shell_integration("fish"));
+        assert!(!has_shell_integration("powershell.exe"));
+        assert!(!has_shell_integration(""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn has_shell_integration_with_unix_absolute_paths() {
+        assert!(has_shell_integration("/bin/bash"));
+        assert!(has_shell_integration("/usr/bin/zsh"));
+        assert!(has_shell_integration("/opt/homebrew/bin/pwsh"));
+        assert!(!has_shell_integration("/bin/sh"));
+        assert!(!has_shell_integration("/usr/bin/fish"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn has_shell_integration_with_windows_paths() {
+        assert!(has_shell_integration(
+            "C:\\Program Files\\PowerShell\\7\\pwsh.exe"
+        ));
+        assert!(!has_shell_integration("C:\\Windows\\System32\\cmd.exe"));
+        assert!(!has_shell_integration(
+            "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+        ));
+    }
 
     #[test]
     fn install_agent_wrappers_at_writes_all_wrappers() {

--- a/resources/shell-integration/amux-pwsh-integration.ps1
+++ b/resources/shell-integration/amux-pwsh-integration.ps1
@@ -166,8 +166,20 @@ function global:prompt {
 # ---------------------------------------------------------------------------
 # Cleanup on shell exit
 # ---------------------------------------------------------------------------
-Register-EngineEvent -SourceIdentifier PowerShell.Exiting -SupportEvent -Action {
-    if ($script:AmuxBin) {
-        try { & $script:AmuxBin set-git --clear *>&1 | Out-Null } catch {}
-    }
-} | Out-Null
+#
+# Pass the resolved amux binary path via -MessageData so the action block
+# can read it from $Event.MessageData. Using $script:AmuxBin directly inside
+# the action block is unreliable: the block is stored and executed later
+# when the engine exit event fires, and the `script:` scope prefix inside
+# a Register-EngineEvent -Action scriptblock is not guaranteed to resolve
+# to this script's top-level scope. Passing via -MessageData makes the
+# capture explicit and independent of scope semantics.
+Register-EngineEvent -SourceIdentifier PowerShell.Exiting `
+    -SupportEvent `
+    -MessageData $script:AmuxBin `
+    -Action {
+        $amuxBin = $Event.MessageData
+        if ($amuxBin) {
+            try { & $amuxBin set-git --clear *>&1 | Out-Null } catch {}
+        }
+    } | Out-Null

--- a/resources/shell-integration/amux-pwsh-integration.ps1
+++ b/resources/shell-integration/amux-pwsh-integration.ps1
@@ -1,0 +1,173 @@
+# amux shell integration for PowerShell 7+
+#
+# This script is auto-sourced by a bootstrap command amux passes to `pwsh`
+# via `-Command` when spawning a shell inside an amux pane. The bootstrap
+# loads the user's $PROFILE first (so any prompt override they define is
+# in place), then dot-sources this file so we can wrap that prompt.
+#
+# Features:
+# - One-shot scrollback restore from $env:AMUX_RESTORE_SCROLLBACK_FILE
+# - OSC 133 semantic prompt marks (D = command finished, A = prompt start)
+# - CWD reporting to the sidebar on directory change
+# - Git branch + dirty status reporting, throttled to ~3s
+# - Exit cleanup (clear git state when the shell exits)
+#
+# Features intentionally deferred to follow-ups (see issue #166):
+# - PR polling (would require Start-Job; adds runspace overhead)
+# - Preexec hooks (force git refresh after git commands) — handled partially
+#   by the 3s throttle until PSReadLine-based preexec is viable
+# - OSC 133 B/C marks (input done / output start) — used by some terminals
+#   for command-boundary features, not required for amux's save-side prompt
+#   row trimming
+
+# Guard: only activate inside an amux pane.
+if (-not $env:AMUX_SOCKET_PATH) { return }
+
+# Resolve the amux CLI binary. AMUX_BIN is set by amux-app; fall back to
+# whatever pwsh resolves via PATH. We cache this once at source time so
+# every prompt call doesn't re-walk PATH.
+$script:AmuxBin = $null
+if ($env:AMUX_BIN -and (Test-Path -LiteralPath $env:AMUX_BIN)) {
+    $script:AmuxBin = $env:AMUX_BIN
+} else {
+    $cmd = Get-Command amux -ErrorAction SilentlyContinue
+    if ($cmd) { $script:AmuxBin = $cmd.Source }
+}
+
+# ---------------------------------------------------------------------------
+# Session scrollback restore (one-shot, runs before first prompt)
+# ---------------------------------------------------------------------------
+if ($env:AMUX_RESTORE_SCROLLBACK_FILE) {
+    $scrollbackFile = $env:AMUX_RESTORE_SCROLLBACK_FILE
+    # Clear the env var immediately so a nested shell can't double-restore.
+    Remove-Item Env:AMUX_RESTORE_SCROLLBACK_FILE -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $scrollbackFile) {
+        try {
+            # Use Get-Content -Raw + [Console]::Write to emit the saved
+            # scrollback verbatim, with no added encoding or formatting —
+            # analogous to the `/bin/cat` call in the bash/zsh integration.
+            $content = Get-Content -Raw -LiteralPath $scrollbackFile -ErrorAction Stop
+            [Console]::Write($content)
+        } catch {
+            # Restore is best-effort; a failure must not block the shell.
+        }
+        Remove-Item -LiteralPath $scrollbackFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Throttle state
+# ---------------------------------------------------------------------------
+$script:AmuxPwdLast = $null
+$script:AmuxGitLastPwd = $null
+$script:AmuxGitLastRun = [datetime]::MinValue
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Invoke the amux CLI swallowing stdout, stderr, and any terminating errors.
+# Shell integration must never fail visibly to the user.
+function script:Invoke-AmuxQuiet {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]] $Remaining)
+    if (-not $script:AmuxBin) { return }
+    try {
+        & $script:AmuxBin @Remaining *>&1 | Out-Null
+    } catch {
+        # Intentionally swallow.
+    }
+}
+
+# Return @{ Branch = <string or $null>; Dirty = <bool> } for the given repo
+# path. Runs two git subprocesses; uses `branch --show-current` for branch
+# and `status --porcelain -uno` + a first-match check for dirty.
+function script:Get-AmuxGitState {
+    param([string]$RepoPath)
+    $result = @{ Branch = $null; Dirty = $false }
+    try {
+        $branch = (& git -C $RepoPath branch --show-current 2>$null)
+        if ($null -ne $branch) { $branch = $branch.Trim() }
+        if (-not [string]::IsNullOrEmpty($branch)) {
+            $result.Branch = $branch
+            $first = & git -C $RepoPath status --porcelain -uno 2>$null | Select-Object -First 1
+            $result.Dirty = -not [string]::IsNullOrEmpty($first)
+        }
+    } catch {
+        # git not installed or not a repo — treat as "no branch".
+    }
+    return $result
+}
+
+# Report current git state to the sidebar.
+function script:Update-AmuxGit {
+    param([string]$RepoPath)
+    $state = Get-AmuxGitState -RepoPath $RepoPath
+    if ($state.Branch) {
+        if ($state.Dirty) {
+            Invoke-AmuxQuiet set-git --branch $state.Branch --dirty
+        } else {
+            Invoke-AmuxQuiet set-git --branch $state.Branch
+        }
+    } else {
+        Invoke-AmuxQuiet set-git --clear
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Prompt override
+# ---------------------------------------------------------------------------
+
+# Save whatever prompt function is currently defined (the built-in default
+# or the user's $PROFILE override, since the bootstrap loads $PROFILE first)
+# so our override can chain to it.
+$script:AmuxOriginalPrompt = $function:prompt
+
+function global:prompt {
+    # Preserve $LASTEXITCODE — our helper calls would otherwise clobber it
+    # before the original prompt function gets to read it.
+    $lastExit = $global:LASTEXITCODE
+    if ($null -eq $lastExit) { $lastExit = 0 }
+
+    # OSC 133;D — command finished (with exit code). `e is ESC, `a is BEL.
+    # Matching the bash/zsh format used in amux-bash-integration.bash.
+    [Console]::Write("`e]133;D;$lastExit`a")
+    # OSC 133;A — prompt starts.
+    [Console]::Write("`e]133;A`a")
+
+    $pwdStr = $PWD.Path
+
+    # CWD: report on change.
+    if ($pwdStr -ne $script:AmuxPwdLast) {
+        $script:AmuxPwdLast = $pwdStr
+        Invoke-AmuxQuiet set-cwd $pwdStr
+    }
+
+    # Git branch: refresh on directory change or every ~3 seconds.
+    $now = Get-Date
+    $shouldGit = $false
+    if ($pwdStr -ne $script:AmuxGitLastPwd) {
+        $shouldGit = $true
+    } elseif (($now - $script:AmuxGitLastRun).TotalSeconds -ge 3) {
+        $shouldGit = $true
+    }
+    if ($shouldGit) {
+        $script:AmuxGitLastPwd = $pwdStr
+        $script:AmuxGitLastRun = $now
+        Update-AmuxGit -RepoPath $pwdStr
+    }
+
+    # Restore $LASTEXITCODE and chain to whatever prompt function existed
+    # before we overrode. The chained prompt is responsible for producing
+    # the actual prompt string the user sees.
+    $global:LASTEXITCODE = $lastExit
+    & $script:AmuxOriginalPrompt
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup on shell exit
+# ---------------------------------------------------------------------------
+Register-EngineEvent -SourceIdentifier PowerShell.Exiting -SupportEvent -Action {
+    if ($script:AmuxBin) {
+        try { & $script:AmuxBin set-git --clear *>&1 | Out-Null } catch {}
+    }
+} | Out-Null


### PR DESCRIPTION
## Summary

Brings Windows and cross-platform \`pwsh\` users up to parity with \`zsh\`/\`bash\` on shell integration: scrollback restore, CWD reporting, git branch + dirty reporting, and OSC 133 semantic prompt marks. No modification of the user's \`\$PROFILE\` — amux injects via the \`-Command\` bootstrap, matching our "zero user config" principle.

Before this PR, pwsh matched the \`_ => {}\` fallthrough in \`inject_shell_integration\`. Windows users got a working terminal but no scrollback restore, no git pill, no semantic marks.

## How it works

PowerShell has no ZDOTDIR equivalent, so auto-injection uses the only reliable zero-user-config point: \`-Command\`. amux spawns pwsh as:

\`\`\`
pwsh -NoLogo -NoExit -Command "if (Test-Path \$PROFILE) { . \$PROFILE }; . '<integration-script>'"
\`\`\`

Order matters — the user's \`\$PROFILE\` loads first so their prompt override (if any) is in place, then the integration script dot-sources and wraps that prompt by saving \`\$function:prompt\` into a module-scoped variable and calling it from our override.

## Ships

- **\`resources/shell-integration/amux-pwsh-integration.ps1\`** — new ~170 line script with scrollback restore, prompt override, CWD + git reporting, exit cleanup
- **\`crates/amux-core/src/shell.rs\`** — new \`shell_stem\` helper (portable stem extraction), new \`has_shell_integration\` public helper, new \`"pwsh"\` branch in \`inject_shell_integration\`, 6 new unit tests covering portable and platform-gated paths
- **\`crates/amux-app/src/startup.rs\`** — uses the new \`has_shell_integration\` helper instead of a duplicate \`matches!\` list

## What doesn't ship (deferred)

Called out in the file header and the issue:
- **PR polling** — would require \`Start-Job\` which adds runspace overhead. bash/zsh versions do this with simple \`&\` + \`disown\`; PowerShell's equivalent is heavier.
- **Preexec hooks** (force git refresh after git commands) — partially covered by the 3s throttle. Real preexec via PSReadLine is viable but error-prone around multiline input and history navigation.
- **OSC 133 B/C marks** (input finished, output start) — not needed for amux's save-side prompt row trimming, which only requires \`A\` and \`D\`. Some terminals use B/C for command-boundary selection features; can add later.

## Non-goals

- **Windows PowerShell 5.1** (\`powershell.exe\`) — legacy, maintenance mode, different escape sequence handling. Explicitly excluded from \`has_shell_integration\`.
- **\`cmd.exe\`** — no prompt customization mechanism, no real hook API.
- **Windows default-shell detection** — \`default_shell()\` still returns \`\$COMSPEC\`. Preferring \`pwsh\` when available on Windows is a follow-up; users who want pwsh today configure amux explicitly.

## Test plan

Automated:
- [x] 6 new \`shell::tests\` unit tests: portable \`shell_stem\` + platform-gated Unix/Windows variants; portable \`has_shell_integration\` + platform-gated variants
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` — fully green

Manual (blocked on a Windows machine, pending for post-merge QA):
- [ ] Windows native: launch amux with pwsh as default shell
- [ ] Windows Git Bash path detection (user has pwsh installed but uses bash)
- [ ] macOS with pwsh installed via \`brew install powershell\`
- [ ] Linux with pwsh installed
- [ ] Scrollback restore produces identical bytes via \`[Console]::Write\`
- [ ] CWD reports on \`Set-Location\` (alias \`cd\`)
- [ ] Git branch reports correctly and clears when leaving a repo
- [ ] OSC 133 marks visible in libghostty-vt \`semantic_prompt\` detection (used by amux's scrollback-save prompt row trimming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)