### PR TITLE
Phase 1: unblock Windows build via libghostty-vt-sys patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,8 +2658,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libghostty-vt"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8afe5cc9ae303133220e530b28b7addbbf591160bb1564b88f7ee61387fee74"
+source = "git+https://github.com/daveowenatl/libghostty-rs?rev=cabcfb81cc3f4f20ef9b62312df6bb04c929abb5#cabcfb81cc3f4f20ef9b62312df6bb04c929abb5"
 dependencies = [
  "bitflags 2.11.0",
  "int-enum",
@@ -2669,8 +2668,7 @@ dependencies = [
 [[package]]
 name = "libghostty-vt-sys"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aee97068da1692162c4523d54843bdcb43fecf086a9ee412a3375817e433faca"
+source = "git+https://github.com/daveowenatl/libghostty-rs?rev=cabcfb81cc3f4f20ef9b62312df6bb04c929abb5#cabcfb81cc3f4f20ef9b62312df6bb04c929abb5"
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,3 +101,20 @@ amux-session = { path = "crates/amux-session" }
 amux-render-gpu = { path = "crates/amux-render-gpu" }
 amux-ghostty-config = { path = "crates/amux-ghostty-config" }
 amux-browser = { path = "crates/amux-browser" }
+
+# Patch libghostty-vt and libghostty-vt-sys to a fork that extends the build
+# script's artifact detection to Windows (MSVC + GNU targets). The crates.io
+# release hardcodes `libghostty-vt.so.0.1.0` as the expected shared library
+# filename, which panics on Windows because Zig emits `ghostty-vt.dll` +
+# `ghostty-vt.lib` instead. The fork cherry-picks the two unpublished
+# `feat/windows-ci` commits from upstream on top of upstream/master, with the
+# ghostty commit pinned back to `bebca84` (matching crates.io 0.1.1) to avoid
+# a newer ghostty xcframework build-step regression that breaks macOS.
+#
+# Upstream tracking: https://github.com/uzaaft/libghostty-rs branches
+# `feat/windows-ci` + `static-linking`. Plan: open a PR against upstream once
+# amux's Windows CI is green with this patch, then drop the patch block when
+# a new crates.io version ships.
+[patch.crates-io]
+libghostty-vt = { git = "https://github.com/daveowenatl/libghostty-rs", rev = "cabcfb81cc3f4f20ef9b62312df6bb04c929abb5" }
+libghostty-vt-sys = { git = "https://github.com/daveowenatl/libghostty-rs", rev = "cabcfb81cc3f4f20ef9b62312df6bb04c929abb5" }


### PR DESCRIPTION
## Phase 1 of the Windows gap-analysis plan

Opened as a **draft** because the whole point is to watch Windows CI. macOS and Linux were working before this PR; if they're still working *after* this PR and Windows goes green, phase 1 is done.

See \`~/.claude/plans/2026-04-11-windows-gap-analysis.md\` for the full gap analysis and 5-phase plan.

## Problem

\`libghostty-vt-sys v0.1.1\` (crates.io) hardcodes \`libghostty-vt.so.0.1.0\` as the expected shared library filename in its \`build.rs\` artifact assertion. On Windows, Zig emits \`ghostty-vt.dll\` + \`ghostty-vt.lib\` — the assertion panics with:

\`\`\`
thread 'main' panicked at ...\\libghostty-vt-sys-0.1.1\\build.rs:70:5:
expected shared library at ...\\ghostty-install\\lib\\libghostty-vt.so.0.1.0
\`\`\`

This has been the root cause of **every Windows CI failure on every amux PR** for the entire history of the Windows matrix, including all 5 PRs merged this session.

## Fix

\`[patch.crates-io]\` pointing \`libghostty-vt\` and \`libghostty-vt-sys\` at \`daveowenatl/libghostty-rs\` branch \`fix/windows-build\`. That branch:

1. Starts from upstream commit \`86338c1\` (the 0.1.1 version bump — same crate source as the published 0.1.1).
2. Cherry-picks the two unmerged \`feat/windows-ci\` commits from upstream:
   - \`a3986a9\` — extends \`build.rs\` with per-platform artifact candidate lists + Windows search dirs + Zig target triple mappings for x86_64/aarch64 Windows GNU/MSVC.
   - \`0397a2e\` — the Windows CI workflow matrix in the libghostty-rs repo itself (harmless in our consumption).

**Ghostty commit pin stays at \`bebca84\`** — same as the published 0.1.1. Upstream master has already bumped it forward to \`a1e75da\`, but that newer ghostty has a broken xcframework build step on macOS and a kitty-graphics symbol mismatch with the older Rust bindings. Sticking to \`bebca84\` avoids both.

## What ships

- \`Cargo.toml\`: new \`[patch.crates-io]\` block with explanatory comment
- \`Cargo.lock\`: updated to resolve libghostty-vt{,-sys} via the git dep

**Zero code changes to amux itself.**

## Local verification (macOS)

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo build --workspace\` — clean rebuild succeeds with patched crate (tested after \`cargo clean -p libghostty-vt-sys\`)
- [x] \`cargo test --workspace\` — all suites pass except the pre-existing \`amux-term::exit_status_reports_failure\` flake

## The real test

**This PR's purpose is to watch the Windows CI job.** Three possible outcomes:

1. ✅ **Windows goes green** → phase 1 complete, pivot to phase 2 (shell config + pwsh default)
2. ⚠️ **Windows fails with a different error** → the artifact detection is fixed but something else (ghostty zig build on Windows, link step, runtime DLL dependency, etc.) needs work. Iterate.
3. ❌ **Windows fails the same way** → patch didn't apply or resolved to the wrong SHA. Debug.

## Follow-up work (out of scope)

- Open an upstream PR against \`uzaaft/libghostty-rs\` with the windows-ci commits rebased onto current master (the \`feat/windows-ci\` branch is already there but stale vs master by 24 commits).
- Once upstream merges + publishes, drop the \`[patch.crates-io]\` block in amux.
- Phases 2–5 of the Windows gap analysis: default shell config, compiled Rust agent wrappers, polish, release workflow.

Refs #166 (the parent Windows platform issue — I should probably split Windows-platform tracking into its own meta-issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to use alternative sources for enhanced build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->