### PR TITLE
Windows phase 2: default shell config + pwsh preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ font_family = "JetBrains Mono"
 font_size = 13.0
 theme = "dark"            # dark | light | system
 
+# Shell to spawn in new panes. Accepts a bare name ("pwsh", "bash", "fish")
+# that amux resolves against PATH, or an absolute path.
+# When unset, amux uses $SHELL on Unix and prefers pwsh.exe on Windows if
+# installed, otherwise falls back to $COMSPEC (cmd.exe).
+# shell = "pwsh"
+
 [notifications]
 sound = true
 system_notifications = true

--- a/README.md
+++ b/README.md
@@ -244,17 +244,17 @@ amux does **not** restore live process state (active Claude Code / Gemini / Code
 Config lives at `~/.config/amux/config.toml` (or `%APPDATA%\amux\config.toml` on Windows):
 
 ```toml
-[appearance]
-sidebar_width = 220
-font_family = "JetBrains Mono"
-font_size = 13.0
-theme = "dark"            # dark | light | system
-
 # Shell to spawn in new panes. Accepts a bare name ("pwsh", "bash", "fish")
 # that amux resolves against PATH, or an absolute path.
 # When unset, amux uses $SHELL on Unix and prefers pwsh.exe on Windows if
 # installed, otherwise falls back to $COMSPEC (cmd.exe).
 # shell = "pwsh"
+
+[appearance]
+sidebar_width = 220
+font_family = "JetBrains Mono"
+font_size = 13.0
+theme = "dark"            # dark | light | system
 
 [notifications]
 sound = true

--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -779,6 +779,7 @@ impl AmuxApp {
                                 sf_id,
                                 cwd.as_deref(),
                                 None,
+                                self.app_config.shell.as_deref(),
                             ) {
                                 Ok(surface) => {
                                     let managed = self

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -536,6 +536,7 @@ impl AmuxApp {
                             sf_id,
                             cwd.as_deref(),
                             None,
+                            self.app_config.shell.as_deref(),
                         ) {
                             if let Some(PaneEntry::Terminal(m)) = self.panes.get_mut(&pane_id) {
                                 let insert_at = (m.active_tab_idx + 1).min(m.tabs.len());

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -787,11 +787,19 @@ pub(crate) fn spawn_surface(
 
     // Prepend amux bin dir (containing claude wrapper) to PATH so hooks are
     // injected at runtime via --settings, scoped to amux sessions only.
+    // PATH uses `;` as a separator on Windows, `:` everywhere else —
+    // hardcoding `:` would collapse the entire Windows PATH into a single
+    // entry and make the wrapper PATH prepend a no-op.
     if let Some(bin_dir) = shell::ensure_agent_wrapper_dir() {
         let current_path = std::env::var("PATH").unwrap_or_default();
         let bin_str = bin_dir.to_string_lossy();
-        if !current_path.split(':').any(|d| d == bin_str.as_ref()) {
-            let sep = if current_path.is_empty() { "" } else { ":" };
+        let sep_char = if cfg!(windows) { ';' } else { ':' };
+        if !current_path.split(sep_char).any(|d| d == bin_str.as_ref()) {
+            let sep = if current_path.is_empty() {
+                String::new()
+            } else {
+                sep_char.to_string()
+            };
             cmd.env("PATH", format!("{bin_str}{sep}{current_path}"));
         }
     }

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -356,10 +356,11 @@ pub(crate) fn run() -> anyhow::Result<()> {
         }
     };
 
+    let shell_override = app_config.shell.as_deref();
     let state = if let Some(session) = restored {
-        restore_session(&session, &ipc_addr, &socket_token, &config)
+        restore_session(&session, &ipc_addr, &socket_token, &config, shell_override)
     } else {
-        fresh_startup(&ipc_addr, &socket_token, &config)?
+        fresh_startup(&ipc_addr, &socket_token, &config, shell_override)?
     };
 
     // Force dark appearance on macOS so the title bar matches the app's dark chrome.
@@ -491,9 +492,21 @@ pub(crate) fn fresh_startup(
     ipc_addr: &amux_ipc::IpcAddr,
     socket_token: &str,
     config: &Arc<AmuxTermConfig>,
+    shell_override: Option<&str>,
 ) -> anyhow::Result<StartupState> {
     let initial_pane_id: PaneId = 0;
-    let surface = spawn_surface(80, 24, ipc_addr, socket_token, config, 0, 0, None, None)?;
+    let surface = spawn_surface(
+        80,
+        24,
+        ipc_addr,
+        socket_token,
+        config,
+        0,
+        0,
+        None,
+        None,
+        shell_override,
+    )?;
 
     let managed = PaneEntry::Terminal(ManagedPane {
         tabs: vec![managed_pane::TabEntry::Terminal(Box::new(surface))],
@@ -538,6 +551,7 @@ pub(crate) fn restore_session(
     ipc_addr: &amux_ipc::IpcAddr,
     socket_token: &str,
     config: &Arc<AmuxTermConfig>,
+    shell_override: Option<&str>,
 ) -> StartupState {
     let mut workspaces = Vec::new();
     let mut panes: HashMap<PaneId, PaneEntry> = HashMap::new();
@@ -580,6 +594,7 @@ pub(crate) fn restore_session(
                     saved_sf.id,
                     cwd,
                     scrollback,
+                    shell_override,
                 ) {
                     Ok(mut surface) => {
                         // Restore git/PR metadata from session
@@ -666,7 +681,7 @@ pub(crate) fn restore_session(
     // If nothing restored, fall back to fresh
     if workspaces.is_empty() {
         tracing::warn!("Session restore produced no workspaces, starting fresh");
-        return match fresh_startup(ipc_addr, socket_token, config) {
+        return match fresh_startup(ipc_addr, socket_token, config, shell_override) {
             Ok(result) => result,
             Err(e) => {
                 tracing::error!("Fresh startup also failed: {}", e);
@@ -736,6 +751,7 @@ pub(crate) fn cleanup_addr(addr: &amux_ipc::IpcAddr) {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
 pub(crate) fn spawn_surface(
     cols: u16,
     rows: u16,
@@ -746,8 +762,9 @@ pub(crate) fn spawn_surface(
     surface_id: u64,
     cwd: Option<&str>,
     scrollback: Option<&str>,
+    shell_override: Option<&str>,
 ) -> anyhow::Result<PaneSurface> {
-    let shell = shell::default_shell();
+    let shell = shell::resolve_shell(shell_override);
     let mut cmd = CommandBuilder::new(&shell);
     cmd.env("AMUX_SOCKET_PATH", ipc_addr.to_string());
     cmd.env("AMUX_SOCKET_TOKEN", socket_token);

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -53,6 +53,7 @@ impl AmuxApp {
             sf_id,
             cwd.as_deref(),
             None,
+            self.app_config.shell.as_deref(),
         ) {
             Ok(surface) => {
                 let pane_id = self.next_pane_id;
@@ -92,6 +93,7 @@ impl AmuxApp {
             sf_id,
             cwd.as_deref(),
             None,
+            self.app_config.shell.as_deref(),
         ) {
             Ok(surface) => {
                 self.next_workspace_id += 1;
@@ -146,6 +148,7 @@ impl AmuxApp {
             sf_id,
             cwd.as_deref(),
             None,
+            self.app_config.shell.as_deref(),
         ) {
             Ok(surface) => {
                 if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&focused) {
@@ -390,6 +393,7 @@ impl AmuxApp {
             sf_id,
             cwd.as_deref(),
             None,
+            self.app_config.shell.as_deref(),
         ) {
             Ok(new_surface) => {
                 let idx = managed.active_tab_idx;

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -383,6 +383,12 @@ pub struct AppConfig {
     /// Theme source: "default" uses built-in Tokyo Night, "ghostty" loads
     /// colors/fonts from Ghostty's config file (`~/.config/ghostty/config`).
     pub theme_source: String,
+    /// Shell to spawn in new panes. Accepts either a plain binary name
+    /// (`"pwsh"`, `"bash"`) that amux resolves against `PATH`, or an
+    /// absolute path (`"/opt/homebrew/bin/fish"`, `"C:\\Program Files\\PowerShell\\7\\pwsh.exe"`).
+    /// When unset (the default), amux uses `$SHELL` on Unix and prefers
+    /// `pwsh.exe` on Windows if it's on `PATH`, otherwise `$COMSPEC`.
+    pub shell: Option<String>,
     pub notifications: NotificationConfig,
     pub browser: BrowserConfig,
     #[serde(default)]
@@ -397,6 +403,7 @@ impl Default for AppConfig {
             font_size: DEFAULT_FONT_SIZE,
             font_family: DEFAULT_FONT_FAMILY.to_owned(),
             theme_source: "default".to_owned(),
+            shell: None,
             notifications: NotificationConfig::default(),
             browser: BrowserConfig::default(),
             colors: ColorsConfig::default(),

--- a/crates/amux-core/src/shell.rs
+++ b/crates/amux-core/src/shell.rs
@@ -5,7 +5,16 @@
 
 use portable_pty::CommandBuilder;
 
-/// Return the user's default shell.
+/// Return the default shell amux should spawn in new panes.
+///
+/// Unix: `$SHELL`, falling back to `/bin/bash`.
+///
+/// Windows: prefers `pwsh.exe` (PowerShell 7+) if it's on `PATH` so the
+/// user automatically gets the amux shell integration that ships in
+/// `resources/shell-integration/amux-pwsh-integration.ps1`. Falls back
+/// to `$COMSPEC` (typically `cmd.exe`) when pwsh isn't installed. Users
+/// who want a specific shell can override this in `config.toml` via the
+/// top-level `shell` key — see [`resolve_shell`].
 pub fn default_shell() -> String {
     #[cfg(unix)]
     {
@@ -13,8 +22,73 @@ pub fn default_shell() -> String {
     }
     #[cfg(windows)]
     {
+        if let Some(pwsh) = find_on_path("pwsh.exe") {
+            return pwsh;
+        }
         std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
     }
+}
+
+/// Resolve the shell amux should spawn for a new pane. Config override
+/// wins, falling through to [`default_shell`]. An absolute-path override
+/// is returned verbatim; a bare name (`"pwsh"`, `"bash"`) is resolved
+/// against `PATH` — if resolution fails, the bare name is still returned
+/// so portable-pty can surface a clearer spawn error than "not found".
+pub fn resolve_shell(config_override: Option<&str>) -> String {
+    if let Some(override_value) = config_override {
+        let trimmed = override_value.trim();
+        if !trimmed.is_empty() {
+            let path = std::path::Path::new(trimmed);
+            if path.is_absolute() {
+                return trimmed.to_string();
+            }
+            if let Some(resolved) = find_on_path(trimmed) {
+                return resolved;
+            }
+            return trimmed.to_string();
+        }
+    }
+    default_shell()
+}
+
+/// Walk `PATH` looking for an executable with the given file name. On
+/// Windows, honours `PATHEXT` so `find_on_path("pwsh")` matches `pwsh.exe`.
+/// Returns the first match as an absolute path string, or `None`.
+fn find_on_path(name: &str) -> Option<String> {
+    let path_var = std::env::var_os("PATH")?;
+    #[cfg(windows)]
+    let extensions: Vec<String> = {
+        let raw = std::env::var("PATHEXT").unwrap_or_else(|_| ".EXE;.CMD;.BAT;.COM".to_string());
+        // An empty entry represents the original `name` without any extension
+        // appended — matches the behaviour of `where.exe` and `Get-Command`.
+        std::iter::once(String::new())
+            .chain(
+                raw.split(';')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string),
+            )
+            .collect()
+    };
+    #[cfg(unix)]
+    let extensions: Vec<String> = vec![String::new()];
+
+    for dir in std::env::split_paths(&path_var) {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        for ext in &extensions {
+            let candidate = if ext.is_empty() {
+                dir.join(name)
+            } else {
+                dir.join(format!("{name}{ext}"))
+            };
+            if candidate.is_file() {
+                return Some(candidate.to_string_lossy().into_owned());
+            }
+        }
+    }
+    None
 }
 
 /// Normalize a shell file name to its stem. On Windows the shell binary is
@@ -231,6 +305,56 @@ pub fn install_agent_wrappers_at(bin_dir: &std::path::Path) -> Option<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_shell_honours_absolute_override() {
+        // Absolute paths are returned verbatim, even if they don't exist —
+        // portable-pty surfaces the spawn error with context. We don't
+        // stat-check here because the override is an explicit user choice.
+        let path = if cfg!(windows) {
+            "C:\\Program Files\\Fish\\bin\\fish.exe"
+        } else {
+            "/opt/homebrew/bin/fish"
+        };
+        assert_eq!(resolve_shell(Some(path)), path);
+    }
+
+    #[test]
+    fn resolve_shell_ignores_empty_or_whitespace_override() {
+        // `shell = ""` or `shell = "   "` in config.toml falls back to
+        // default_shell() — we don't want to spawn an empty command.
+        let fallback = default_shell();
+        assert_eq!(resolve_shell(Some("")), fallback);
+        assert_eq!(resolve_shell(Some("   ")), fallback);
+    }
+
+    #[test]
+    fn resolve_shell_none_falls_back_to_default() {
+        assert_eq!(resolve_shell(None), default_shell());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_shell_bare_name_resolves_against_path() {
+        // `sh` is guaranteed to exist on every Unix runner, so this test
+        // doubles as a sanity check for `find_on_path` on Unix.
+        let resolved = resolve_shell(Some("sh"));
+        assert!(
+            resolved.ends_with("/sh") || resolved == "sh",
+            "expected resolved sh path or bare fallback, got {resolved}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_shell_bare_name_returns_input_when_missing() {
+        // A made-up name must not crash — we return it verbatim so the
+        // subsequent CommandBuilder::new gives a clean "not found" error.
+        assert_eq!(
+            resolve_shell(Some("definitely-not-a-real-shell-xyz")),
+            "definitely-not-a-real-shell-xyz"
+        );
+    }
 
     #[test]
     fn shell_stem_strips_extensions_and_directories() {

--- a/crates/amux-core/src/shell.rs
+++ b/crates/amux-core/src/shell.rs
@@ -53,6 +53,10 @@ pub fn resolve_shell(config_override: Option<&str>) -> String {
 
 /// Walk `PATH` looking for an executable with the given file name. On
 /// Windows, honours `PATHEXT` so `find_on_path("pwsh")` matches `pwsh.exe`.
+/// On Unix, verifies the execute bit is set so we never return a candidate
+/// that would fail to spawn. Relative `PATH` entries are skipped to avoid
+/// PATH-hijacking risk (e.g. a `.` entry pointing the shell resolver at
+/// whatever binary happens to be in the current working directory).
 /// Returns the first match as an absolute path string, or `None`.
 fn find_on_path(name: &str) -> Option<String> {
     let path_var = std::env::var_os("PATH")?;
@@ -74,7 +78,10 @@ fn find_on_path(name: &str) -> Option<String> {
     let extensions: Vec<String> = vec![String::new()];
 
     for dir in std::env::split_paths(&path_var) {
-        if dir.as_os_str().is_empty() {
+        // Skip empty and relative entries. Absolute-only guarantees the
+        // returned path is safe to embed in command spawns and matches
+        // the docstring contract above.
+        if dir.as_os_str().is_empty() || !dir.is_absolute() {
             continue;
         }
         for ext in &extensions {
@@ -83,12 +90,36 @@ fn find_on_path(name: &str) -> Option<String> {
             } else {
                 dir.join(format!("{name}{ext}"))
             };
-            if candidate.is_file() {
-                return Some(candidate.to_string_lossy().into_owned());
+            if !candidate.is_file() {
+                continue;
             }
+            if !is_executable(&candidate) {
+                continue;
+            }
+            return Some(candidate.to_string_lossy().into_owned());
         }
     }
     None
+}
+
+/// Returns true when the path at `candidate` is executable by the current
+/// process. On Unix, checks the file-mode execute bits. On Windows, the
+/// `.exe`/`.cmd`/`.bat` extension probe done by `find_on_path` already
+/// filters out non-executable files so we accept any regular file.
+fn is_executable(candidate: &std::path::Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let Ok(meta) = std::fs::metadata(candidate) else {
+            return false;
+        };
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(windows)]
+    {
+        let _ = candidate;
+        true
+    }
 }
 
 /// Normalize a shell file name to its stem. On Windows the shell binary is
@@ -353,6 +384,131 @@ mod tests {
         assert_eq!(
             resolve_shell(Some("definitely-not-a-real-shell-xyz")),
             "definitely-not-a-real-shell-xyz"
+        );
+    }
+
+    /// Serializes the Windows PATH/PATHEXT tests so parallel test threads
+    /// can't stomp each other's env manipulation.
+    #[cfg(windows)]
+    static WINDOWS_PATH_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// RAII guard that restores a named env var to its prior value on drop.
+    #[cfg(windows)]
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<std::ffi::OsString>,
+    }
+    #[cfg(windows)]
+    impl EnvGuard {
+        fn set(key: &'static str, value: &std::ffi::OsStr) -> Self {
+            let prev = std::env::var_os(key);
+            // SAFETY: tests are serialized via WINDOWS_PATH_TEST_LOCK.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+    }
+    #[cfg(windows)]
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: tests are serialized via WINDOWS_PATH_TEST_LOCK.
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    /// Regression for Copilot #3068233897: Windows `find_on_path` must
+    /// honour `PATHEXT` so a bare `"pwsh"` override resolves to
+    /// `pwsh.exe` inside a PATH directory, and the empty-extension
+    /// case matches before extension-appended candidates (matches the
+    /// `where.exe` / `Get-Command` lookup order).
+    #[cfg(windows)]
+    #[test]
+    fn windows_find_on_path_pathext_prefers_exe() {
+        let _guard = WINDOWS_PATH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let exe = tmp.path().join("pwsh.exe");
+        std::fs::write(&exe, b"dummy").expect("write exe");
+
+        let path_env = EnvGuard::set("PATH", tmp.path().as_os_str());
+        let pathext_env = EnvGuard::set("PATHEXT", std::ffi::OsStr::new(".EXE;.CMD;.BAT;.COM"));
+
+        let resolved = resolve_shell(Some("pwsh"));
+        drop(path_env);
+        drop(pathext_env);
+        assert_eq!(
+            std::path::PathBuf::from(&resolved).file_name().unwrap(),
+            "pwsh.exe"
+        );
+    }
+
+    /// Windows: when only a `.cmd` shim exists (no `.exe`), PATHEXT
+    /// iteration still resolves via the extension fallback.
+    #[cfg(windows)]
+    #[test]
+    fn windows_find_on_path_falls_back_to_cmd_extension() {
+        let _guard = WINDOWS_PATH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cmd_shim = tmp.path().join("mytool.cmd");
+        std::fs::write(&cmd_shim, b"@echo off\r\n").expect("write cmd");
+
+        let path_env = EnvGuard::set("PATH", tmp.path().as_os_str());
+        let pathext_env = EnvGuard::set("PATHEXT", std::ffi::OsStr::new(".EXE;.CMD;.BAT;.COM"));
+
+        let resolved = resolve_shell(Some("mytool"));
+        drop(path_env);
+        drop(pathext_env);
+        assert_eq!(
+            std::path::PathBuf::from(&resolved).file_name().unwrap(),
+            "mytool.cmd"
+        );
+    }
+
+    /// Windows: a relative PATH entry (e.g. `.`) must be skipped so we
+    /// don't fall prey to PATH hijacking. The resolver must return the
+    /// bare name verbatim when no absolute match exists.
+    #[cfg(windows)]
+    #[test]
+    fn windows_find_on_path_skips_relative_entries() {
+        let _guard = WINDOWS_PATH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Write an "evil" exe in the temp dir and set PATH=. while the
+        // CWD is the temp dir. The resolver should NOT return it.
+        let evil = tmp.path().join("pwsh.exe");
+        std::fs::write(&evil, b"dummy").expect("write evil");
+        let _cwd_guard = {
+            let prev_cwd = std::env::current_dir().expect("cwd");
+            std::env::set_current_dir(tmp.path()).expect("set cwd");
+            // Move `prev_cwd` into a closure that restores on drop via a
+            // `defer`-style helper. Simpler: a struct guard.
+            struct CwdGuard(std::path::PathBuf);
+            impl Drop for CwdGuard {
+                fn drop(&mut self) {
+                    let _ = std::env::set_current_dir(&self.0);
+                }
+            }
+            CwdGuard(prev_cwd)
+        };
+
+        let path_env = EnvGuard::set("PATH", std::ffi::OsStr::new("."));
+        let pathext_env = EnvGuard::set("PATHEXT", std::ffi::OsStr::new(".EXE"));
+
+        let resolved = resolve_shell(Some("pwsh"));
+        drop(path_env);
+        drop(pathext_env);
+
+        assert_eq!(
+            resolved, "pwsh",
+            "relative PATH entry must not resolve — got {resolved:?}"
         );
     }
 


### PR DESCRIPTION
## Phase 2 of the Windows gap-analysis plan

Unblocks PR #174's pwsh shell integration on Windows. Until now, amux always spawned \`\$COMSPEC\` (cmd.exe) with no way to override unless users changed COMSPEC system-wide — meaning #174's pwsh integration script shipped but was unreachable for anyone who wanted pwsh inside amux.

See \`~/.claude/plans/2026-04-11-windows-gap-analysis.md\` for the full plan.

## What ships

### New \`shell\` field in config.toml

\`\`\`toml
# Bare name — resolves against PATH
shell = "pwsh"

# Absolute path — returned verbatim
shell = "/opt/homebrew/bin/fish"
shell = "C:\\\\Program Files\\\\PowerShell\\\\7\\\\pwsh.exe"
\`\`\`

Unset is the default. Empty string or whitespace is treated as unset.

### \`default_shell()\` prefers pwsh on Windows

Before: \`std::env::var(\"COMSPEC\").unwrap_or(\"cmd.exe\")\`.
After: probes PATH for \`pwsh.exe\` first, falls back to COMSPEC. Fresh Windows install with PowerShell 7 gets #174's pwsh shell integration (CWD reporting, git branch pill, scrollback restore, OSC 133 marks) automatically.

### \`resolve_shell(override)\` — the new entry point

| Input | Behavior |
|---|---|
| \`Some(absolute_path)\` | returned verbatim (explicit user choice) |
| \`Some(bare_name)\` | resolved via \`find_on_path\`, falls through to bare name if lookup fails |
| \`Some(\"\")\` or whitespace | treated as None, falls to \`default_shell()\` |
| \`None\` | \`default_shell()\` |

### \`find_on_path\` with PATHEXT semantics

Windows honours \`PATHEXT\` so \`find_on_path(\"pwsh\")\` matches \`pwsh.exe\`. Empty extension prepended so exact matches win first (matches \`where.exe\` / \`Get-Command\`). Unix uses a single empty-extension entry.

### Plumbing through \`spawn_surface\`

\`fresh_startup\`, \`restore_session\`, and \`spawn_surface\` all gain a \`shell_override: Option<&str>\` parameter. Every call site in \`workspace_ops.rs\`, \`ipc_dispatch.rs\`, and \`pane_render.rs\` passes \`self.app_config.shell.as_deref()\` so the config override reaches pane splits, new tabs, IPC-driven pane creation, and workspace restore.

## Tests

5 new unit tests in \`amux-core::shell::tests\`:
- \`resolve_shell_honours_absolute_override\`
- \`resolve_shell_ignores_empty_or_whitespace_override\`
- \`resolve_shell_none_falls_back_to_default\`
- \`resolve_shell_bare_name_resolves_against_path\` (unix)
- \`resolve_shell_bare_name_returns_input_when_missing\` (unix)

Existing \`has_shell_integration\` tests still cover the stem-based shell detection that was added in PR #174.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\` — all green including the previously flaky \`amux-term::exit_status_reports_failure\`
- [x] 11 \`shell::tests\` pass (6 existing + 5 new)
- [ ] Windows CI — first test of #175's libghostty-vt-sys patch in the wild. Should also go green.

## Next phase

Phase 3: compiled Rust agent wrappers on Windows so Claude/Gemini/Codex hook injection works there too. Currently the Windows agent-wrapper situation is still F2/F3 from the gap analysis — only a \`claude.cmd\` passthrough shim.

Refs #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional shell setting to control which executable is used for new terminal panes (bare name resolved via PATH or absolute path; otherwise system defaults).
* **Bug Fixes**
  * Corrected Windows PATH handling and improved executable resolution to prefer PowerShell when available.
  * Ignore relative PATH entries to avoid accidental PATH hijacking.
* **Tests**
  * Expanded tests for shell resolution and Windows behavior.
* **Documentation**
  * Documented the new shell configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->