### PR TITLE
Windows phase 3: compiled Rust agent wrapper for Claude + Gemini

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,9 @@ dependencies = [
 [[package]]
 name = "amux-agent-wrapper"
 version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "amux-app"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "amux-agent-wrapper"
+version = "0.1.0"
+
+[[package]]
 name = "amux-app"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/amux-app",
+    "crates/amux-agent-wrapper",
     "crates/amux-cli",
     "crates/amux-core",
     "crates/amux-term",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Sidebar shows git branch, PR status, working directory, listening ports, and lat
 
 ---
 
-- **All three agentic CLIs, first-class** — Claude Code, Gemini CLI, and Codex CLI each get hook integration, live status indicators, and tool visibility in the sidebar. Zero-setup on Unix — hooks inject automatically when the agent launches inside an amux pane, without touching the user's native agent config. On Windows, automatic wrapper installation currently covers Claude Code only (Gemini: [#166](https://github.com/daveowenatl/amux/issues/166); Codex CLI wrapper is POSIX-only).
+- **All three agentic CLIs, first-class** — Claude Code, Gemini CLI, and Codex CLI each get hook integration, live status indicators, and tool visibility in the sidebar. Zero-setup everywhere — hooks inject automatically when the agent launches inside an amux pane, without touching the user's native agent config. Unix uses bash wrappers; Windows uses a compiled Rust wrapper (`amux-agent-wrapper.exe`) that ships alongside `amux.exe`. Codex on Windows is still a follow-up — it needs a symlinked `CODEX_HOME` which requires Developer Mode.
 - **Scriptable** — CLI and socket API to create workspaces, split panes, send keystrokes, and drive agents programmatically. tmux-compat shim included for agent scripts that call tmux directly.
 - **Native on every platform** — Built in Rust with wgpu for GPU-accelerated rendering. Runs natively on Windows (DX12/Vulkan), macOS (Metal), and Linux (Vulkan). Not Electron. Not Tauri.
 - **Cross-platform config** — Reads `~/.config/amux/config.toml`. No platform-specific config format.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Sidebar shows git branch, PR status, working directory, listening ports, and lat
 
 ---
 
-- **All three agentic CLIs, first-class** — Claude Code, Gemini CLI, and Codex CLI each get hook integration, live status indicators, and tool visibility in the sidebar. Zero-setup everywhere — hooks inject automatically when the agent launches inside an amux pane, without touching the user's native agent config. Unix uses bash wrappers; Windows uses a compiled Rust wrapper (`amux-agent-wrapper.exe`) that ships alongside `amux.exe`. Codex on Windows is still a follow-up — it needs a symlinked `CODEX_HOME` which requires Developer Mode.
+- **All three agentic CLIs, first-class** — Claude Code, Gemini CLI, and Codex CLI each get hook integration, live status indicators, and tool visibility in the sidebar. Hooks inject automatically when the agent launches inside an amux pane, without touching the user's native agent config. Unix uses bash wrappers; Windows uses a compiled Rust wrapper (`amux-agent-wrapper.exe`) that ships alongside `amux.exe`. Zero-setup on Unix for all three agents, and on Windows for Claude Code and Gemini CLI; **Codex on Windows is tracked as follow-up work** because its wrapper needs a symlinked `CODEX_HOME`, which in turn requires Windows Developer Mode.
 - **Scriptable** — CLI and socket API to create workspaces, split panes, send keystrokes, and drive agents programmatically. tmux-compat shim included for agent scripts that call tmux directly.
 - **Native on every platform** — Built in Rust with wgpu for GPU-accelerated rendering. Runs natively on Windows (DX12/Vulkan), macOS (Metal), and Linux (Vulkan). Not Electron. Not Tauri.
 - **Cross-platform config** — Reads `~/.config/amux/config.toml`. No platform-specific config format.
@@ -99,7 +99,9 @@ Hooks into Gemini CLI's BeforeAgent, AfterAgent, BeforeTool, Notification, Sessi
 
 ### Codex CLI
 
-Hooks into Codex CLI's SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, and Stop events via a wrapper script that creates a per-session `CODEX_HOME` tempdir symlinking your real `~/.codex/` and overlaying amux hook config. No modification of your real Codex config, credentials, or history. Launching `codex` inside an amux pane is enough — no manual install step. Amux observes Codex state for the sidebar but does not intercept approvals or drive the model; full `codex app-server` integration with approval interception is tracked as future work.
+Hooks into Codex CLI's SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, and Stop events via a wrapper script that creates a per-session `CODEX_HOME` tempdir symlinking your real `~/.codex/` and overlaying amux hook config. No modification of your real Codex config, credentials, or history. Launching `codex` inside an amux pane on macOS or Linux is enough — no manual install step. Amux observes Codex state for the sidebar but does not intercept approvals or drive the model; full `codex app-server` integration with approval interception is tracked as future work.
+
+> **Windows:** Codex integration via `amux-agent-wrapper.exe` is tracked as follow-up work. The Codex wrapper relies on a symlinked `CODEX_HOME` overlay, and creating symlinks on Windows requires either administrator privileges or [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) to be enabled. Until that's wired up, Codex on Windows runs passthrough — you'll still get a working Codex session, just without amux sidebar status / tool indicators. Claude Code and Gemini CLI are unaffected and work with zero setup on Windows.
 
 ### Any other agent
 

--- a/crates/amux-agent-wrapper/Cargo.toml
+++ b/crates/amux-agent-wrapper/Cargo.toml
@@ -10,3 +10,6 @@ name = "amux-agent-wrapper"
 path = "src/main.rs"
 
 [dependencies]
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/amux-agent-wrapper/Cargo.toml
+++ b/crates/amux-agent-wrapper/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "amux-agent-wrapper"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Cross-platform amux agent wrapper binary. Self-dispatches on argv[0] to intercept claude/gemini invocations inside an amux pane and inject hook settings."
+
+[[bin]]
+name = "amux-agent-wrapper"
+path = "src/main.rs"
+
+[dependencies]

--- a/crates/amux-agent-wrapper/src/agents/claude.rs
+++ b/crates/amux-agent-wrapper/src/agents/claude.rs
@@ -1,0 +1,130 @@
+//! Claude Code wrapper — mirrors the logic in `resources/bin/claude`.
+//!
+//! When launched inside an amux pane, builds a `--settings` JSON blob
+//! registering all 9 Claude hook events and execs the real `claude`
+//! binary with that blob prepended to argv. The settings JSON contains
+//! hook commands that call `amux claude-hook <event>`.
+//!
+//! When not in an amux pane (or the socket is down), passthrough exec.
+
+use std::ffi::OsString;
+
+use crate::amux;
+
+pub(crate) fn run(forward_args: &[OsString]) -> Result<u8, String> {
+    let wrapper_dir = amux::wrapper_install_dir();
+    let real_claude = crate::find_real_agent("claude", &wrapper_dir)
+        .ok_or_else(|| "claude not found in PATH".to_string())?;
+
+    // Passthrough when not in amux or amux isn't responding.
+    if !amux::in_amux_pane() {
+        return Ok(crate::spawn_and_wait(&real_claude, forward_args));
+    }
+
+    // Resolve the amux CLI binary once so every hook entry in the
+    // generated JSON embeds the same verified absolute path.
+    let Some(amux_bin) = amux::resolve_amux_bin() else {
+        // We're in amux but can't find amux itself — passthrough rather
+        // than refuse to start claude. Shell integration may still run.
+        return Ok(crate::spawn_and_wait(&real_claude, forward_args));
+    };
+
+    // Claude Code hook subcommands we wire up. Kept in sync with the
+    // `resources/bin/claude` bash script that #173 expanded to cover
+    // all 9 hook events.
+    let events: &[&str] = &[
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "Notification",
+        "Stop",
+        "SubagentStart",
+        "SubagentStop",
+        "SessionEnd",
+    ];
+    let hooks_json = build_hooks_json(&amux_bin, events);
+
+    // Prepend `--settings <blob>` to the user's argv. Claude Code
+    // merges --settings additively with the user's ~/.claude/settings.json
+    // so their own hooks still fire.
+    //
+    // CLAUDECODE is unset to avoid "nested session" detection — amux
+    // panes are independent sessions even when the parent shell was
+    // launched from Claude Code.
+    let mut cmd = std::process::Command::new(&real_claude);
+    cmd.env_remove("CLAUDECODE");
+    cmd.arg("--settings");
+    cmd.arg(&hooks_json);
+    cmd.args(forward_args);
+
+    match cmd.status() {
+        Ok(status) => Ok(status
+            .code()
+            .and_then(|c| u8::try_from(c & 0xff).ok())
+            .unwrap_or(1)),
+        Err(e) => Err(format!(
+            "amux-agent-wrapper: failed to spawn {}: {e}",
+            real_claude.display()
+        )),
+    }
+}
+
+/// Build the `--settings` JSON blob that registers an `amux claude-hook
+/// <event>` command for every event in `events`. Mirrors the HEREDOC
+/// structure of `resources/bin/claude`.
+fn build_hooks_json(amux_bin: &std::path::Path, events: &[&str]) -> String {
+    let cmd_path = amux::hook_cmd_path(amux_bin);
+    let mut out = String::from("{\"hooks\":{");
+    for (i, event) in events.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str(&format!(
+            "\"{event}\":[{{\"matcher\":\"\",\"hooks\":[{{\
+             \"type\":\"command\",\
+             \"command\":\"{cmd_path} claude-hook {event}\",\
+             \"timeout\":5\
+             }}]}}]"
+        ));
+    }
+    out.push_str("}}");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn build_hooks_json_registers_each_event() {
+        let json = build_hooks_json(Path::new("/usr/local/bin/amux"), &["SessionStart", "Stop"]);
+        // Two events, each with the claude-hook command.
+        assert!(json.contains("\"SessionStart\":"));
+        assert!(json.contains("\"Stop\":"));
+        assert!(json.contains("\"/usr/local/bin/amux\" claude-hook SessionStart"));
+        assert!(json.contains("\"/usr/local/bin/amux\" claude-hook Stop"));
+        // JSON structure sanity check — must parse as valid JSON.
+        // We don't have serde here, so check balance by counting braces.
+        let opens = json.matches('{').count();
+        let closes = json.matches('}').count();
+        assert_eq!(opens, closes, "json braces unbalanced: {json}");
+    }
+
+    #[test]
+    fn build_hooks_json_escapes_windows_paths() {
+        let json = build_hooks_json(Path::new("C:\\Program Files\\amux\\amux.exe"), &["Stop"]);
+        // The backslashes must appear doubled in the JSON string literal.
+        assert!(
+            json.contains("\"C:\\\\Program Files\\\\amux\\\\amux.exe\" claude-hook Stop"),
+            "expected JSON-escaped Windows path in output: {json}"
+        );
+    }
+
+    #[test]
+    fn build_hooks_json_empty_events_still_parses() {
+        let json = build_hooks_json(Path::new("/usr/local/bin/amux"), &[]);
+        assert_eq!(json, "{\"hooks\":{}}");
+    }
+}

--- a/crates/amux-agent-wrapper/src/agents/claude.rs
+++ b/crates/amux-agent-wrapper/src/agents/claude.rs
@@ -100,25 +100,32 @@ mod tests {
     #[test]
     fn build_hooks_json_registers_each_event() {
         let json = build_hooks_json(Path::new("/usr/local/bin/amux"), &["SessionStart", "Stop"]);
-        // Two events, each with the claude-hook command.
-        assert!(json.contains("\"SessionStart\":"));
-        assert!(json.contains("\"Stop\":"));
-        assert!(json.contains("\"/usr/local/bin/amux\" claude-hook SessionStart"));
-        assert!(json.contains("\"/usr/local/bin/amux\" claude-hook Stop"));
-        // JSON structure sanity check — must parse as valid JSON.
-        // We don't have serde here, so check balance by counting braces.
-        let opens = json.matches('{').count();
-        let closes = json.matches('}').count();
-        assert_eq!(opens, closes, "json braces unbalanced: {json}");
+        // Must parse as valid JSON with the expected structure.
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        let hooks = parsed["hooks"].as_object().expect("hooks object");
+        assert!(hooks.contains_key("SessionStart"));
+        assert!(hooks.contains_key("Stop"));
+        for event in ["SessionStart", "Stop"] {
+            let command = hooks[event][0]["hooks"][0]["command"]
+                .as_str()
+                .expect("command string");
+            let expected = format!("\"/usr/local/bin/amux\" claude-hook {event}");
+            assert_eq!(command, expected);
+        }
     }
 
     #[test]
     fn build_hooks_json_escapes_windows_paths() {
         let json = build_hooks_json(Path::new("C:\\Program Files\\amux\\amux.exe"), &["Stop"]);
-        // The backslashes must appear doubled in the JSON string literal.
-        assert!(
-            json.contains("\"C:\\\\Program Files\\\\amux\\\\amux.exe\" claude-hook Stop"),
-            "expected JSON-escaped Windows path in output: {json}"
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        let command = parsed["hooks"]["Stop"][0]["hooks"][0]["command"]
+            .as_str()
+            .expect("command string");
+        // After JSON decoding, the command field must contain the raw
+        // Windows path (single backslashes) wrapped in shell quotes.
+        assert_eq!(
+            command,
+            "\"C:\\Program Files\\amux\\amux.exe\" claude-hook Stop"
         );
     }
 
@@ -126,5 +133,7 @@ mod tests {
     fn build_hooks_json_empty_events_still_parses() {
         let json = build_hooks_json(Path::new("/usr/local/bin/amux"), &[]);
         assert_eq!(json, "{\"hooks\":{}}");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert!(parsed["hooks"].as_object().unwrap().is_empty());
     }
 }

--- a/crates/amux-agent-wrapper/src/agents/gemini.rs
+++ b/crates/amux-agent-wrapper/src/agents/gemini.rs
@@ -83,17 +83,22 @@ fn settings_file_path(surface_id: &str) -> PathBuf {
 
 /// Probe `gemini --version` with a bounded 2s timeout. Returns true if
 /// the version string matches `0.26.0` or newer. Passthrough-safe: if
-/// the probe fails or times out, we return false and skip injection.
+/// the probe fails, times out, or exits non-zero, we return false and
+/// skip injection. The timeout is enforced by
+/// `amux::run_capture_stdout_with_timeout`, which polls `try_wait` and
+/// kills the child on deadline — `Command::output()` (which blocks
+/// indefinitely) is deliberately not used here.
 fn gemini_supports_hooks(real: &Path) -> bool {
     let mut cmd = std::process::Command::new(real);
     cmd.arg("--version")
         .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped());
-    let Ok(output) = cmd.output() else {
+        .stderr(std::process::Stdio::null());
+    let Some(stdout_bytes) =
+        amux::run_capture_stdout_with_timeout(cmd, std::time::Duration::from_secs(2))
+    else {
         return false;
     };
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = String::from_utf8_lossy(&stdout_bytes);
     parse_version_supports_hooks(&stdout)
 }
 
@@ -174,14 +179,33 @@ mod tests {
             Path::new("/usr/local/bin/amux"),
             &["BeforeAgent", "AfterAgent"],
         );
-        assert!(json.contains("\"BeforeAgent\":"));
-        assert!(json.contains("\"AfterAgent\":"));
-        assert!(json.contains("\"timeout\":5000"));
-        assert!(json.contains("gemini-hook BeforeAgent"));
-        assert!(json.contains("gemini-hook AfterAgent"));
-        let opens = json.matches('{').count();
-        let closes = json.matches('}').count();
-        assert_eq!(opens, closes, "json braces unbalanced: {json}");
+        // Must parse as valid JSON with the expected structure for every event.
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        let hooks = parsed["hooks"].as_object().expect("hooks object");
+        for event in ["BeforeAgent", "AfterAgent"] {
+            let entry = &hooks[event][0]["hooks"][0];
+            assert_eq!(entry["type"], "command");
+            assert_eq!(entry["timeout"], 5000);
+            let command = entry["command"].as_str().expect("command string");
+            let expected = format!("\"/usr/local/bin/amux\" gemini-hook {event}");
+            assert_eq!(command, expected);
+        }
+    }
+
+    #[test]
+    fn build_settings_json_escapes_windows_paths() {
+        let json = build_settings_json(
+            Path::new("C:\\Program Files\\amux\\amux.exe"),
+            &["BeforeAgent"],
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        let command = parsed["hooks"]["BeforeAgent"][0]["hooks"][0]["command"]
+            .as_str()
+            .expect("command string");
+        assert_eq!(
+            command,
+            "\"C:\\Program Files\\amux\\amux.exe\" gemini-hook BeforeAgent"
+        );
     }
 
     #[test]

--- a/crates/amux-agent-wrapper/src/agents/gemini.rs
+++ b/crates/amux-agent-wrapper/src/agents/gemini.rs
@@ -1,0 +1,208 @@
+//! Gemini CLI wrapper — mirrors the logic in `resources/bin/gemini`.
+//!
+//! When launched inside an amux pane, writes a temp settings JSON file
+//! containing amux hook commands and exports
+//! `GEMINI_CLI_SYSTEM_SETTINGS_PATH` pointing at it before spawning
+//! the real `gemini` binary. Because Gemini's hook arrays use CONCAT
+//! merging, the user's own hooks in `~/.gemini/settings.json` coexist
+//! with ours — zero pollution of the user's config.
+//!
+//! Version gate: we skip injection entirely when `gemini --version`
+//! reports anything older than 0.26.0 (the first hook-capable release),
+//! so old installs run unhooked rather than fail weirdly.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use crate::amux;
+
+pub(crate) fn run(forward_args: &[OsString]) -> Result<u8, String> {
+    let wrapper_dir = amux::wrapper_install_dir();
+    let real_gemini = crate::find_real_agent("gemini", &wrapper_dir)
+        .ok_or_else(|| "gemini not found in PATH".to_string())?;
+
+    // Passthrough when not in amux, gemini is too old, or amux isn't up.
+    if !amux::in_amux_pane() || !gemini_supports_hooks(&real_gemini) {
+        return Ok(crate::spawn_and_wait(&real_gemini, forward_args));
+    }
+
+    let Some(amux_bin) = amux::resolve_amux_bin() else {
+        return Ok(crate::spawn_and_wait(&real_gemini, forward_args));
+    };
+
+    // Per-surface temp settings file. Stable path so sibling panes don't
+    // race each other and so amux-app's stale-file sweeper can clean up
+    // after us. Falls back to a generic per-pid name if the surface id
+    // env var is missing (shouldn't happen inside amux, but keeps the
+    // wrapper robust).
+    let surface_id =
+        std::env::var("AMUX_SURFACE_ID").unwrap_or_else(|_| std::process::id().to_string());
+    let settings_path = settings_file_path(&surface_id);
+
+    let events: &[&str] = &[
+        "BeforeAgent",
+        "BeforeTool",
+        "Notification",
+        "AfterAgent",
+        "SessionStart",
+        "SessionEnd",
+    ];
+    let settings_json = build_settings_json(&amux_bin, events);
+
+    if let Err(e) = std::fs::write(&settings_path, &settings_json) {
+        eprintln!(
+            "amux-agent-wrapper: failed to write gemini settings at {}: {e}",
+            settings_path.display()
+        );
+        return Ok(crate::spawn_and_wait(&real_gemini, forward_args));
+    }
+
+    let mut cmd = std::process::Command::new(&real_gemini);
+    cmd.env("GEMINI_CLI_SYSTEM_SETTINGS_PATH", &settings_path);
+    cmd.args(forward_args);
+
+    match cmd.status() {
+        Ok(status) => Ok(status
+            .code()
+            .and_then(|c| u8::try_from(c & 0xff).ok())
+            .unwrap_or(1)),
+        Err(e) => Err(format!(
+            "amux-agent-wrapper: failed to spawn {}: {e}",
+            real_gemini.display()
+        )),
+    }
+}
+
+/// Computes the per-surface settings file path under the system temp
+/// dir. Matches the `amux-gemini-settings-<surface>.json` pattern that
+/// amux-app's stale-file sweeper (in `startup.rs`) scans for on launch.
+fn settings_file_path(surface_id: &str) -> PathBuf {
+    let tmp = std::env::temp_dir();
+    tmp.join(format!("amux-gemini-settings-{surface_id}.json"))
+}
+
+/// Probe `gemini --version` with a bounded 2s timeout. Returns true if
+/// the version string matches `0.26.0` or newer. Passthrough-safe: if
+/// the probe fails or times out, we return false and skip injection.
+fn gemini_supports_hooks(real: &Path) -> bool {
+    let mut cmd = std::process::Command::new(real);
+    cmd.arg("--version")
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped());
+    let Ok(output) = cmd.output() else {
+        return false;
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_version_supports_hooks(&stdout)
+}
+
+/// Parse a `major.minor.patch` version string from stdout. Returns true
+/// if it's >= 0.26.0. Split out for testing.
+fn parse_version_supports_hooks(stdout: &str) -> bool {
+    // Grab the first token matching `<digits>.<digits>.<digits>`.
+    let first_line = stdout.lines().next().unwrap_or("");
+    let mut ver_chars = String::new();
+    let mut seen_dot = 0;
+    let mut in_version = false;
+    for ch in first_line.chars() {
+        if ch.is_ascii_digit() {
+            ver_chars.push(ch);
+            in_version = true;
+        } else if ch == '.' && in_version {
+            ver_chars.push(ch);
+            seen_dot += 1;
+            if seen_dot == 3 {
+                ver_chars.pop();
+                break;
+            }
+        } else if in_version {
+            break;
+        }
+    }
+    if seen_dot < 2 {
+        return false;
+    }
+    let parts: Vec<u32> = ver_chars
+        .split('.')
+        .take(3)
+        .filter_map(|s| s.parse::<u32>().ok())
+        .collect();
+    if parts.len() < 2 {
+        return false;
+    }
+    let major = parts[0];
+    let minor = parts[1];
+    major > 0 || (major == 0 && minor >= 26)
+}
+
+/// Build the Gemini settings JSON for the given hook events. Mirrors
+/// the `resources/bin/gemini` HEREDOC.
+fn build_settings_json(amux_bin: &Path, events: &[&str]) -> String {
+    let cmd_path = amux::hook_cmd_path(amux_bin);
+    let mut out = String::from("{\"hooks\":{");
+    for (i, event) in events.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str(&format!(
+            "\"{event}\":[{{\"matcher\":\"\",\"hooks\":[{{\
+             \"type\":\"command\",\
+             \"command\":\"{cmd_path} gemini-hook {event}\",\
+             \"timeout\":5000,\
+             \"name\":\"amux-status\"\
+             }}]}}]"
+        ));
+    }
+    out.push_str("}}");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_path_uses_surface_id() {
+        let path = settings_file_path("42");
+        assert!(path.file_name().unwrap() == "amux-gemini-settings-42.json");
+    }
+
+    #[test]
+    fn build_settings_json_has_all_events_and_timeout() {
+        let json = build_settings_json(
+            Path::new("/usr/local/bin/amux"),
+            &["BeforeAgent", "AfterAgent"],
+        );
+        assert!(json.contains("\"BeforeAgent\":"));
+        assert!(json.contains("\"AfterAgent\":"));
+        assert!(json.contains("\"timeout\":5000"));
+        assert!(json.contains("gemini-hook BeforeAgent"));
+        assert!(json.contains("gemini-hook AfterAgent"));
+        let opens = json.matches('{').count();
+        let closes = json.matches('}').count();
+        assert_eq!(opens, closes, "json braces unbalanced: {json}");
+    }
+
+    #[test]
+    fn version_probe_accepts_0_26_and_newer() {
+        // Happy path: exactly the minimum.
+        assert!(parse_version_supports_hooks("0.26.0"));
+        // Newer minor versions pass.
+        assert!(parse_version_supports_hooks("0.27.3"));
+        // Major bump passes trivially.
+        assert!(parse_version_supports_hooks("1.0.0"));
+        // Common prefix styles (`gemini-cli v0.26.0`, leading spaces).
+        assert!(parse_version_supports_hooks("gemini-cli 0.26.0"));
+        assert!(parse_version_supports_hooks("   0.26.0   "));
+    }
+
+    #[test]
+    fn version_probe_rejects_older_or_garbage() {
+        assert!(!parse_version_supports_hooks("0.25.9"));
+        assert!(!parse_version_supports_hooks("0.1.1"));
+        assert!(!parse_version_supports_hooks(""));
+        assert!(!parse_version_supports_hooks("no version here"));
+        assert!(!parse_version_supports_hooks("v0"));
+    }
+}

--- a/crates/amux-agent-wrapper/src/agents/mod.rs
+++ b/crates/amux-agent-wrapper/src/agents/mod.rs
@@ -1,0 +1,7 @@
+//! Per-agent wrapper logic. Each sub-module handles the injection
+//! mechanism specific to its agent (`--settings` for Claude,
+//! `GEMINI_CLI_SYSTEM_SETTINGS_PATH` for Gemini) and the passthrough
+//! path when the wrapper isn't running inside an amux pane.
+
+pub(crate) mod claude;
+pub(crate) mod gemini;

--- a/crates/amux-agent-wrapper/src/amux.rs
+++ b/crates/amux-agent-wrapper/src/amux.rs
@@ -1,0 +1,162 @@
+//! Shared helpers: detecting whether we're inside an amux pane,
+//! resolving the amux CLI binary, and emitting hook-command strings
+//! that embed it verbatim.
+
+use std::path::{Path, PathBuf};
+
+/// Determine the directory we were launched from. The wrapper is
+/// typically installed at `~/.config/amux/bin/claude.exe`, so this
+/// returns `~/.config/amux/bin`. Used to skip ourselves in
+/// `find_real_agent` and to emit correct hook command paths.
+pub(crate) fn wrapper_install_dir() -> PathBuf {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Return true when all of the following hold:
+///
+/// 1. `AMUX_SURFACE_ID` is set (we're inside an amux pane)
+/// 2. `AMUX_SOCKET_PATH` points at a live socket (amux is running)
+/// 3. `amux ping` over that socket succeeds inside a bounded timeout
+///
+/// A miss on any of these means we passthrough — the user can still
+/// run the agent outside amux without paying for wrapper logic.
+pub(crate) fn in_amux_pane() -> bool {
+    if std::env::var_os("AMUX_SURFACE_ID").is_none() {
+        return false;
+    }
+    let Some(socket) = std::env::var_os("AMUX_SOCKET_PATH") else {
+        return false;
+    };
+    if socket.is_empty() {
+        return false;
+    }
+    let Some(amux_bin) = resolve_amux_bin() else {
+        return false;
+    };
+
+    // Bounded ping: we'd rather passthrough than hang the agent launch
+    // behind a stuck amux socket. Use a 2-second hard timeout via a
+    // spawned child + wait-with-timeout fallback.
+    let mut cmd = std::process::Command::new(&amux_bin);
+    cmd.arg("--socket")
+        .arg(&socket)
+        .arg("ping")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    matches!(cmd.status().map(|s| s.success()), Ok(true))
+}
+
+/// Resolve the amux CLI binary. Preference order:
+///
+/// 1. `AMUX_BIN` env var if it points at an executable file
+/// 2. `amux[.exe]` in the same directory as this wrapper (both are
+///    typically in `~/.config/amux/bin/`)
+/// 3. `amux[.exe]` anywhere on `PATH`
+///
+/// Returns an absolute path, or `None` if amux can't be located.
+pub(crate) fn resolve_amux_bin() -> Option<PathBuf> {
+    if let Some(env_bin) = std::env::var_os("AMUX_BIN") {
+        let p = PathBuf::from(env_bin);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+
+    let wrapper_dir = wrapper_install_dir();
+    let names: &[&str] = if cfg!(windows) {
+        &["amux.exe", "amux"]
+    } else {
+        &["amux"]
+    };
+
+    for name in names {
+        let candidate = wrapper_dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    // Final fallback: walk PATH. Skip our own install dir so we don't
+    // resolve back to a shim if the user has somehow aliased `amux` to
+    // this wrapper.
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        if dir.as_os_str().is_empty() || !dir.is_absolute() {
+            continue;
+        }
+        if dir == wrapper_dir {
+            continue;
+        }
+        for name in names {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// JSON-escape a string for embedding inside a JSON string literal.
+/// Rust-std doesn't expose serde-level escaping and we don't want to
+/// pull serde_json into the wrapper just for this — the wrapper is
+/// supposed to be tiny. Covers the escapes that can appear in file
+/// paths: backslash, quote, and control characters.
+pub(crate) fn json_escape(input: &str) -> String {
+    let mut out = String::with_capacity(input.len() + 2);
+    for ch in input.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\x08' => out.push_str("\\b"),
+            '\x0c' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Render the `amux` CLI binary path for embedding inside a hook
+/// command string. Wraps in quotes so spaces in the path (`C:\Program
+/// Files\...`) don't split the command at shell parse time.
+pub(crate) fn hook_cmd_path(amux_bin: &Path) -> String {
+    format!("\"{}\"", json_escape(&amux_bin.to_string_lossy()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_escape_handles_quotes_backslashes_and_controls() {
+        assert_eq!(json_escape("hello"), "hello");
+        assert_eq!(json_escape("a\"b"), "a\\\"b");
+        assert_eq!(
+            json_escape("C:\\Program Files\\x"),
+            "C:\\\\Program Files\\\\x"
+        );
+        assert_eq!(json_escape("\nlineA\tend"), "\\nlineA\\tend");
+        assert_eq!(json_escape("\x01"), "\\u0001");
+    }
+
+    #[test]
+    fn hook_cmd_path_quotes_and_escapes() {
+        let rendered = hook_cmd_path(Path::new("/usr/local/bin/amux"));
+        assert_eq!(rendered, "\"/usr/local/bin/amux\"");
+
+        let windows = hook_cmd_path(Path::new("C:\\Program Files\\amux\\amux.exe"));
+        // The inner backslashes must be JSON-escaped since this string
+        // lands inside a JSON string literal in the hook config.
+        assert_eq!(windows, "\"C:\\\\Program Files\\\\amux\\\\amux.exe\"");
+    }
+}

--- a/crates/amux-agent-wrapper/src/amux.rs
+++ b/crates/amux-agent-wrapper/src/amux.rs
@@ -3,6 +3,73 @@
 //! that embed it verbatim.
 
 use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+/// Poll `child` with a 50ms interval until it exits or `timeout`
+/// elapses. On timeout the child is killed and reaped, and `None` is
+/// returned. Implemented with `try_wait` + sleep instead of pulling in
+/// the `wait-timeout` crate — keeps the wrapper dep-free, and 50ms is
+/// short enough that realistic local IPC / version probes finish on
+/// the first or second wakeup.
+fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+}
+
+/// Spawn `cmd`, wait up to `timeout`, and return whether the command
+/// exited successfully. Used for fire-and-forget probes like
+/// `amux … ping` where stdout is irrelevant.
+pub(crate) fn run_status_with_timeout(mut cmd: Command, timeout: Duration) -> bool {
+    let Ok(mut child) = cmd.spawn() else {
+        return false;
+    };
+    wait_with_timeout(&mut child, timeout)
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Spawn `cmd` with stdout captured, wait up to `timeout`, and return
+/// the captured stdout on successful exit. Returns `None` on spawn
+/// failure, non-zero exit, or timeout. Used for the `gemini --version`
+/// probe.
+pub(crate) fn run_capture_stdout_with_timeout(
+    mut cmd: Command,
+    timeout: Duration,
+) -> Option<Vec<u8>> {
+    cmd.stdout(std::process::Stdio::piped());
+    let mut child = cmd.spawn().ok()?;
+    let status = wait_with_timeout(&mut child, timeout)?;
+    if !status.success() {
+        return None;
+    }
+    // Child has already exited; read any buffered stdout directly. We
+    // avoid `wait_with_output` because it takes ownership of the child
+    // and we've already waited above.
+    use std::io::Read as _;
+    let mut buf = Vec::new();
+    if let Some(mut out) = child.stdout.take() {
+        out.read_to_end(&mut buf).ok()?;
+    }
+    Some(buf)
+}
 
 /// Determine the directory we were launched from. The wrapper is
 /// typically installed at `~/.config/amux/bin/claude.exe`, so this
@@ -38,16 +105,16 @@ pub(crate) fn in_amux_pane() -> bool {
     };
 
     // Bounded ping: we'd rather passthrough than hang the agent launch
-    // behind a stuck amux socket. Use a 2-second hard timeout via a
-    // spawned child + wait-with-timeout fallback.
-    let mut cmd = std::process::Command::new(&amux_bin);
+    // behind a stuck amux socket. 2-second hard deadline enforced via
+    // spawn + try_wait poll loop (see `run_status_with_timeout`).
+    let mut cmd = Command::new(&amux_bin);
     cmd.arg("--socket")
         .arg(&socket)
         .arg("ping")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
-    matches!(cmd.status().map(|s| s.success()), Ok(true))
+    run_status_with_timeout(cmd, Duration::from_secs(2))
 }
 
 /// Resolve the amux CLI binary. Preference order:
@@ -126,11 +193,27 @@ pub(crate) fn json_escape(input: &str) -> String {
     out
 }
 
-/// Render the `amux` CLI binary path for embedding inside a hook
-/// command string. Wraps in quotes so spaces in the path (`C:\Program
-/// Files\...`) don't split the command at shell parse time.
+/// Render the `amux` CLI binary path for embedding inside a JSON
+/// string literal that represents a shell command. The returned string
+/// is *not* a standalone JSON value — it's the inner contents of a
+/// `"command":"…"` string literal.
+///
+/// Two levels of escaping are happening simultaneously:
+/// 1. **Shell level**: we want the shell (which eventually runs the
+///    hook command) to see `"C:\Program Files\amux\amux.exe"` with
+///    literal quote characters so the path is parsed as one token.
+/// 2. **JSON level**: those literal quote characters and any
+///    backslashes must be escaped so the surrounding JSON string
+///    parses correctly. A backslash becomes `\\` and a quote becomes
+///    `\"` inside a JSON string literal.
+///
+/// So the return value for `C:\Program Files\amux\amux.exe` is
+/// `\"C:\\Program Files\\amux\\amux.exe\"` (bytes: `\ " C : \ \ P … \ \ . e x e \ "`),
+/// which when dropped into `"command":"<here> gemini-hook Evt"` yields
+/// valid JSON that decodes to `"C:\Program Files\amux\amux.exe" gemini-hook Evt`.
 pub(crate) fn hook_cmd_path(amux_bin: &Path) -> String {
-    format!("\"{}\"", json_escape(&amux_bin.to_string_lossy()))
+    let escaped = json_escape(&amux_bin.to_string_lossy());
+    format!("\\\"{escaped}\\\"")
 }
 
 #[cfg(test)]
@@ -151,12 +234,99 @@ mod tests {
 
     #[test]
     fn hook_cmd_path_quotes_and_escapes() {
+        // Unix path: the outer quotes are JSON-escaped (`\"`) so they
+        // survive embedding inside a JSON string literal and then get
+        // seen by the shell as actual quote characters.
         let rendered = hook_cmd_path(Path::new("/usr/local/bin/amux"));
-        assert_eq!(rendered, "\"/usr/local/bin/amux\"");
+        assert_eq!(rendered, "\\\"/usr/local/bin/amux\\\"");
 
+        // Windows path: both the outer quotes and every inner backslash
+        // must be JSON-escaped.
         let windows = hook_cmd_path(Path::new("C:\\Program Files\\amux\\amux.exe"));
-        // The inner backslashes must be JSON-escaped since this string
-        // lands inside a JSON string literal in the hook config.
-        assert_eq!(windows, "\"C:\\\\Program Files\\\\amux\\\\amux.exe\"");
+        assert_eq!(windows, "\\\"C:\\\\Program Files\\\\amux\\\\amux.exe\\\"");
+    }
+
+    /// Round-trip a `"command":"<hook_cmd_path … args>"` fragment
+    /// through `serde_json` to confirm the escaping is correct. Guards
+    /// against regressions where the outer quotes are accidentally
+    /// emitted unescaped, which would silently produce malformed JSON
+    /// that only breaks at agent launch time on a real system.
+    #[test]
+    fn hook_cmd_path_round_trips_inside_json_string() {
+        for raw in [
+            "/usr/local/bin/amux",
+            "C:\\Program Files\\amux\\amux.exe",
+            "/home/dave/bin with spaces/amux",
+            "C:\\Users\\d\"o\"e\\amux.exe",
+        ] {
+            let fragment = hook_cmd_path(Path::new(raw));
+            let json = format!("{{\"command\":\"{fragment} hook Evt\"}}");
+            let parsed: serde_json::Value = serde_json::from_str(&json).unwrap_or_else(|e| {
+                panic!("bad json for {raw}: {e}\nfragment={fragment}\njson={json}")
+            });
+            let command = parsed["command"].as_str().expect("string");
+            // The decoded shell command must contain the raw path in
+            // quotes followed by the rest of the args.
+            let expected = format!("\"{raw}\" hook Evt");
+            assert_eq!(command, expected, "round-trip mismatch for {raw}");
+        }
+    }
+
+    /// Smoke test: `run_status_with_timeout` must actually enforce the
+    /// deadline rather than block on a long-running child. Uses a
+    /// subprocess that sleeps well past the 300ms deadline.
+    #[cfg(unix)]
+    #[test]
+    fn run_status_with_timeout_kills_hung_child() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 10"]);
+        let start = Instant::now();
+        let ok = run_status_with_timeout(cmd, Duration::from_millis(300));
+        let elapsed = start.elapsed();
+        assert!(!ok, "hung child should not report success");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "timeout not enforced: took {elapsed:?}"
+        );
+    }
+
+    /// `run_status_with_timeout` returns true for a command that
+    /// completes cleanly inside the deadline.
+    #[cfg(unix)]
+    #[test]
+    fn run_status_with_timeout_reports_fast_success() {
+        let mut cmd = Command::new("true");
+        cmd.stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        assert!(run_status_with_timeout(cmd, Duration::from_secs(2)));
+    }
+
+    /// `run_capture_stdout_with_timeout` reads stdout on fast success.
+    #[cfg(unix)]
+    #[test]
+    fn run_capture_stdout_with_timeout_returns_stdout() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "printf gemini-cli\\ 0.26.0"]);
+        let stdout = run_capture_stdout_with_timeout(cmd, Duration::from_secs(2))
+            .expect("should capture stdout");
+        assert_eq!(String::from_utf8_lossy(&stdout), "gemini-cli 0.26.0");
+    }
+
+    /// `run_capture_stdout_with_timeout` kills a child that exceeds the
+    /// deadline and returns `None`.
+    #[cfg(unix)]
+    #[test]
+    fn run_capture_stdout_with_timeout_kills_hung_child() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 10"]);
+        let start = Instant::now();
+        let out = run_capture_stdout_with_timeout(cmd, Duration::from_millis(300));
+        let elapsed = start.elapsed();
+        assert!(out.is_none(), "hung child should not produce stdout");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "timeout not enforced: took {elapsed:?}"
+        );
     }
 }

--- a/crates/amux-agent-wrapper/src/main.rs
+++ b/crates/amux-agent-wrapper/src/main.rs
@@ -1,0 +1,216 @@
+//! amux agent wrapper — cross-platform Rust reimplementation of the bash
+//! wrappers in `resources/bin/{claude,gemini,codex}`. Built as a single
+//! binary that self-dispatches on argv[0] so a single copy installed as
+//! `claude.exe`, `gemini.exe`, etc. wraps the matching agent.
+//!
+//! The wrapper is the **Windows-native replacement** for the POSIX shell
+//! wrappers — it avoids the `.cmd`/`.ps1` chaining, PATHEXT, and
+//! PowerShell execution-policy pitfalls that would come with any shell
+//! approach on Windows. Unix continues to use the bash wrappers today;
+//! a future cleanup can swap those out too.
+//!
+//! Installation: `amux-core::shell::install_agent_wrappers_at` on Windows
+//! locates this binary next to `amux.exe` (via `std::env::current_exe`)
+//! and copies it into `~/.config/amux/bin/claude.exe` (and friends) each
+//! time amux starts a new pane.
+//!
+//! ## How a wrapped invocation runs
+//!
+//! 1. User (or amux pane shell) runs `claude.exe`.
+//! 2. Windows resolves `claude.exe` via PATH and launches our binary.
+//! 3. `main()` inspects `argv[0]` to decide which agent to wrap.
+//! 4. The per-agent handler locates the **real** agent binary in PATH,
+//!    skipping our own directory so we don't recurse.
+//! 5. If we're not inside an amux pane (`AMUX_SURFACE_ID` unset, socket
+//!    down, etc.), we passthrough: spawn the real agent with the
+//!    unmodified argv and propagate its exit code.
+//! 6. Otherwise, we construct the agent-specific hook injection (Claude:
+//!    `--settings` JSON; Gemini: temp settings file pointed at by
+//!    `GEMINI_CLI_SYSTEM_SETTINGS_PATH`), spawn the real agent, and
+//!    propagate its exit code.
+//!
+//! Note on exec semantics: on Unix, the bash wrappers use `exec` to
+//! replace the process image. This Rust wrapper uses `Command::status`
+//! which spawns a child and waits — less efficient but portable. On
+//! Windows there's no process-replacement primitive, so waiting is the
+//! only option anyway.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+mod agents;
+mod amux;
+
+/// Exit code returned when we can't locate the real agent binary.
+/// Matches the sh idiom of `127` for "command not found".
+const EXIT_NOT_FOUND: u8 = 127;
+
+fn main() -> ExitCode {
+    let args: Vec<OsString> = std::env::args_os().collect();
+    let argv0 = args.first().cloned().unwrap_or_default();
+    let agent_name = match detect_agent(&argv0) {
+        Some(name) => name,
+        None => {
+            eprintln!(
+                "amux-agent-wrapper: could not determine agent from argv[0] {:?}. \
+                 Invoke this binary via a copy named claude.exe, gemini.exe, etc.",
+                argv0
+            );
+            return ExitCode::from(1);
+        }
+    };
+
+    // Pass argv[1..] to the real agent; argv[0] is ours.
+    let forward_args: Vec<OsString> = args.iter().skip(1).cloned().collect();
+
+    let result = match agent_name {
+        Agent::Claude => agents::claude::run(&forward_args),
+        Agent::Gemini => agents::gemini::run(&forward_args),
+    };
+
+    match result {
+        Ok(code) => ExitCode::from(code),
+        Err(err) => {
+            eprintln!("{err}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+/// Agent kinds this wrapper knows how to wrap. Codex is intentionally not
+/// implemented on Windows yet — its integration requires a symlinked
+/// `CODEX_HOME` which needs elevated privileges on Windows without
+/// Developer Mode. Tracked as a follow-up to the Windows gap plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Agent {
+    Claude,
+    Gemini,
+}
+
+/// Detect which agent we should wrap based on `argv[0]`. Strips any
+/// directory components and extension, then matches a known agent stem.
+/// Returns `None` if the stem doesn't match — the binary refuses to run
+/// rather than guess, so a misnamed install surfaces loudly.
+pub(crate) fn detect_agent(argv0: &std::ffi::OsStr) -> Option<Agent> {
+    let stem = Path::new(argv0).file_stem()?.to_str()?.to_ascii_lowercase();
+    match stem.as_str() {
+        "claude" => Some(Agent::Claude),
+        "gemini" => Some(Agent::Gemini),
+        _ => None,
+    }
+}
+
+/// Walk `PATH` for `name`, skipping `skip_dir` (used to avoid finding
+/// our own wrapper when looking for the real agent binary). Honours
+/// `PATHEXT` on Windows so `find_real_agent("claude", ...)` matches
+/// `claude.exe` / `claude.cmd`. Returns the absolute path of the first
+/// executable match, or `None`.
+pub(crate) fn find_real_agent(name: &str, skip_dir: &Path) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+
+    #[cfg(windows)]
+    let extensions: Vec<String> = {
+        let raw = std::env::var("PATHEXT").unwrap_or_else(|_| ".EXE;.CMD;.BAT;.COM".to_string());
+        std::iter::once(String::new())
+            .chain(
+                raw.split(';')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string),
+            )
+            .collect()
+    };
+    #[cfg(unix)]
+    let extensions: Vec<String> = vec![String::new()];
+
+    let canonical_skip = std::fs::canonicalize(skip_dir).ok();
+
+    for dir in std::env::split_paths(&path_var) {
+        if dir.as_os_str().is_empty() || !dir.is_absolute() {
+            continue;
+        }
+        // Skip our own install dir so we don't pick up the wrapper again.
+        if let Some(ref canonical) = canonical_skip {
+            if std::fs::canonicalize(&dir).is_ok_and(|d| d == *canonical) {
+                continue;
+            }
+        }
+        for ext in &extensions {
+            let candidate = if ext.is_empty() {
+                dir.join(name)
+            } else {
+                dir.join(format!("{name}{ext}"))
+            };
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Run the real agent with the given argv and propagate its exit code.
+/// Returns the u8 exit code (127 if we can't even spawn). Stdio is
+/// inherited so the agent's TUI works normally.
+pub(crate) fn spawn_and_wait(real: &Path, args: &[OsString]) -> u8 {
+    let mut cmd = Command::new(real);
+    cmd.args(args);
+    // Inherit stdin/stdout/stderr — the agent is interactive.
+    match cmd.status() {
+        Ok(status) => status
+            .code()
+            .and_then(|c| u8::try_from(c & 0xff).ok())
+            .unwrap_or(1),
+        Err(e) => {
+            eprintln!(
+                "amux-agent-wrapper: failed to spawn {}: {e}",
+                real.display()
+            );
+            EXIT_NOT_FOUND
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_agent_from_basename() {
+        assert_eq!(detect_agent("claude".as_ref()), Some(Agent::Claude));
+        assert_eq!(detect_agent("gemini".as_ref()), Some(Agent::Gemini));
+        assert_eq!(detect_agent("claude.exe".as_ref()), Some(Agent::Claude));
+        assert_eq!(detect_agent("gemini.exe".as_ref()), Some(Agent::Gemini));
+    }
+
+    #[test]
+    fn detect_agent_from_absolute_path() {
+        // Unix-style absolute path.
+        assert_eq!(
+            detect_agent("/Users/me/.config/amux/bin/claude".as_ref()),
+            Some(Agent::Claude)
+        );
+        // Windows-style path — on unix std::path treats `\` as a literal, so
+        // use forward slashes here to stay portable.
+        assert_eq!(
+            detect_agent("C:/Users/me/AppData/Roaming/amux/bin/gemini.exe".as_ref()),
+            Some(Agent::Gemini)
+        );
+    }
+
+    #[test]
+    fn detect_agent_is_case_insensitive() {
+        assert_eq!(detect_agent("Claude".as_ref()), Some(Agent::Claude));
+        assert_eq!(detect_agent("CLAUDE.EXE".as_ref()), Some(Agent::Claude));
+        assert_eq!(detect_agent("GeMiNi".as_ref()), Some(Agent::Gemini));
+    }
+
+    #[test]
+    fn detect_agent_rejects_unknown_names() {
+        assert_eq!(detect_agent("codex".as_ref()), None);
+        assert_eq!(detect_agent("amux-agent-wrapper".as_ref()), None);
+        assert_eq!(detect_agent("bash".as_ref()), None);
+        assert_eq!(detect_agent("".as_ref()), None);
+    }
+}

--- a/crates/amux-core/src/shell.rs
+++ b/crates/amux-core/src/shell.rs
@@ -503,9 +503,18 @@ mod tests {
         let resolved = resolve_shell(Some("pwsh"));
         drop(path_env);
         drop(pathext_env);
-        assert_eq!(
-            std::path::PathBuf::from(&resolved).file_name().unwrap(),
-            "pwsh.exe"
+        // PATHEXT case is preserved in the constructed candidate, so the
+        // resolved file_name may be "pwsh.EXE" (uppercase) even though the
+        // on-disk file is "pwsh.exe". Windows filesystems are
+        // case-insensitive, so compare ignoring ASCII case.
+        let file_name = std::path::PathBuf::from(&resolved)
+            .file_name()
+            .expect("file_name")
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            file_name.eq_ignore_ascii_case("pwsh.exe"),
+            "expected pwsh.exe (any case), got {file_name}"
         );
     }
 
@@ -527,9 +536,15 @@ mod tests {
         let resolved = resolve_shell(Some("mytool"));
         drop(path_env);
         drop(pathext_env);
-        assert_eq!(
-            std::path::PathBuf::from(&resolved).file_name().unwrap(),
-            "mytool.cmd"
+        // Same PATHEXT-case caveat as windows_find_on_path_pathext_prefers_exe.
+        let file_name = std::path::PathBuf::from(&resolved)
+            .file_name()
+            .expect("file_name")
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            file_name.eq_ignore_ascii_case("mytool.cmd"),
+            "expected mytool.cmd (any case), got {file_name}"
         );
     }
 

--- a/crates/amux-core/src/shell.rs
+++ b/crates/amux-core/src/shell.rs
@@ -316,21 +316,83 @@ pub fn install_agent_wrappers_at(bin_dir: &std::path::Path) -> Option<()> {
     }
     #[cfg(windows)]
     {
-        // PowerShell/pwsh support for Gemini is issue #166; for now only the
-        // claude.cmd shim is installed on Windows.
-        let wrapper_path = bin_dir.join("claude.cmd");
-        let wrapper_content = "@echo off\r\nclaude.exe %*\r\n";
+        // On Windows we install copies of `amux-agent-wrapper.exe` (built as
+        // a workspace member — see `crates/amux-agent-wrapper`) renamed to
+        // `claude.exe` and `gemini.exe`. The wrapper self-dispatches on its
+        // argv[0] filename so one source binary handles all agents. This
+        // replaces the legacy `claude.cmd` passthrough shim that gave zero
+        // hook integration on Windows.
+        //
+        // Codex on Windows is still deferred — its integration needs a
+        // symlink farm that requires Developer Mode on Windows. Tracked as
+        // a follow-up to the Windows gap plan.
+        let Some(wrapper_src) = locate_agent_wrapper_binary() else {
+            tracing::warn!(
+                "Windows agent wrappers skipped: amux-agent-wrapper.exe not found \
+                 next to the running amux binary. Claude/Gemini hook injection \
+                 will not work in new panes until the wrapper is available."
+            );
+            return Some(());
+        };
 
-        let needs_write = std::fs::read_to_string(&wrapper_path)
-            .map(|existing| existing != wrapper_content)
-            .unwrap_or(true);
-
-        if needs_write && std::fs::write(&wrapper_path, wrapper_content).is_err() {
-            return None;
+        let targets: &[&str] = &["claude.exe", "gemini.exe"];
+        for name in targets {
+            let dest = bin_dir.join(name);
+            if needs_wrapper_copy(&wrapper_src, &dest) {
+                // Remove first — `std::fs::copy` on Windows fails if the
+                // destination is currently executing (a running claude.exe
+                // from a prior pane). Falling through on removal failure
+                // lets the copy surface the real error.
+                let _ = std::fs::remove_file(&dest);
+                if std::fs::copy(&wrapper_src, &dest).is_err() {
+                    return None;
+                }
+            }
         }
     }
 
     Some(())
+}
+
+/// Locate `amux-agent-wrapper.exe` on Windows. Expected to live next to
+/// the running `amux.exe` / `amux-app.exe` — the release distribution
+/// ships all three binaries in the same directory, and `cargo build
+/// --workspace` during development puts them in the same `target/<profile>`.
+#[cfg(windows)]
+fn locate_agent_wrapper_binary() -> Option<std::path::PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    let candidate = dir.join("amux-agent-wrapper.exe");
+    if candidate.is_file() {
+        Some(candidate)
+    } else {
+        None
+    }
+}
+
+/// Returns true when `dest` is missing or has different content than
+/// `src`. Avoids redundant copies on every pane launch. Compared via
+/// file length first (cheap) then byte content as a fallback. The
+/// wrapper binary is small (a few hundred KB) so a full-file read is
+/// acceptable on mismatch.
+#[cfg(windows)]
+fn needs_wrapper_copy(src: &std::path::Path, dest: &std::path::Path) -> bool {
+    let Ok(src_meta) = std::fs::metadata(src) else {
+        return false; // source missing — refuse to copy anyway
+    };
+    let Ok(dest_meta) = std::fs::metadata(dest) else {
+        return true;
+    };
+    if src_meta.len() != dest_meta.len() {
+        return true;
+    }
+    let Ok(src_bytes) = std::fs::read(src) else {
+        return false;
+    };
+    let Ok(dest_bytes) = std::fs::read(dest) else {
+        return true;
+    };
+    src_bytes != dest_bytes
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Phase 3 of the Windows gap-analysis plan

Replaces the legacy \`claude.cmd\` passthrough shim on Windows (which did zero hook injection) with a **real compiled Rust wrapper** that implements the same hook-injection logic as the bash wrappers in \`resources/bin/{claude,gemini}\`, without any of the PATHEXT / \`.cmd\`-chaining / PowerShell execution-policy pitfalls that would come with a shell approach.

See \`~/.claude/plans/2026-04-11-windows-gap-analysis.md\` for the full plan.

## What ships

### New crate: \`crates/amux-agent-wrapper\`

Single bin crate whose binary self-dispatches on argv[0]. Install it as \`claude.exe\` and Windows resolves that name to our wrapper at spawn time; the wrapper inspects \`argv[0]\`'s file stem, picks the matching handler, and proceeds.

**Structure:**
- \`main.rs\` — \`detect_agent(argv0)\`, \`find_real_agent(name, skip_dir)\` with PATHEXT + relative-entry-skip + our-own-dir-skip, \`spawn_and_wait(real, args)\`
- \`amux.rs\` — \`wrapper_install_dir\`, \`in_amux_pane\` (with bounded socket ping), \`resolve_amux_bin\`, \`json_escape\`, \`hook_cmd_path\`
- \`agents/claude.rs\` — builds \`--settings\` JSON for all 9 Claude hook events, unsets CLAUDECODE, spawns real claude
- \`agents/gemini.rs\` — version-gates on \`gemini --version\` >= 0.26.0, writes per-surface temp settings JSON, exports \`GEMINI_CLI_SYSTEM_SETTINGS_PATH\`, spawns real gemini
- **No external deps** — crate Cargo.toml \`[dependencies]\` is empty. The wrapper is small, pure-std Rust, so it adds minimal bloat to the release.

### \`amux-core::shell\` installer

\`install_agent_wrappers_at\` on Windows now:
1. Locates \`amux-agent-wrapper.exe\` next to the running \`amux.exe\` via \`std::env::current_exe().parent()\`
2. Copies it to \`~/.config/amux/bin/claude.exe\` and \`~/.config/amux/bin/gemini.exe\`
3. \`needs_wrapper_copy\` compares length + bytes before copying so repeat launches are cheap
4. \`fs::remove_file\` before \`fs::copy\` handles the Windows \"dest is currently executing\" case
5. If the wrapper binary is missing (e.g., user built only amux-app), logs \`tracing::warn!\` and skips — doesn't break the whole launch

### Codex on Windows: still deferred

Codex integration needs a symlinked \`CODEX_HOME\` which requires Developer Mode on Windows without admin rights. Tracked as a follow-up; the existing Unix bash wrapper continues to handle it on macOS/Linux.

## 13 unit tests

- \`detect_agent_*\` × 4 — basename, absolute path, case-insensitive, rejects unknown/codex/bash/empty
- \`build_hooks_json_*\` × 3 — all events present, Windows path escaping, empty-events edge case
- \`build_settings_json_has_all_events_and_timeout\`
- \`settings_path_uses_surface_id\`
- \`version_probe_accepts_0_26_and_newer\` / \`version_probe_rejects_older_or_garbage\`
- \`json_escape_handles_quotes_backslashes_and_controls\`
- \`hook_cmd_path_quotes_and_escapes\`

## Verification

- [x] \`cargo build --workspace\` — all 12 crates compile (11 existing + new amux-agent-wrapper)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --workspace\` — 13 new tests pass, full suite green
- [ ] Windows CI — real test of the \`find_real_agent\` PATHEXT logic and the installer copy behavior on a windows-latest runner

## README

The \"first-class CLIs\" bullet is updated to mention both Unix bash and Windows Rust wrapper paths, and drops the old \"Windows covers Claude Code only\" disclaimer.

## Not in scope

- **Codex on Windows** — needs Developer Mode for symlinks; tracked as a follow-up.
- **Replacing Unix bash wrappers with the Rust wrapper** — valid cleanup, scope creep for this PR. Bash scripts stay.
- **Release workflow (phase 5)** — needed to ship \`amux-agent-wrapper.exe\` alongside \`amux.exe\` in the release zip. That's phase 5 of the plan.

Refs #166, #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic agent hook injection for Claude and Gemini CLIs on Windows via a pre-compiled wrapper.
  * Windows users now have zero-setup configuration for agentic CLI integration.

* **Documentation**
  * Updated README to reflect zero-setup support across all platforms (Unix and Windows).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->