### PR TITLE
Windows phase 4a: browser profile dir + install-shell-integration pwsh

### DIFF
--- a/crates/amux-browser/src/pane.rs
+++ b/crates/amux-browser/src/pane.rs
@@ -96,7 +96,12 @@ fn profiles_base_dir() -> PathBuf {
     }
     #[cfg(target_os = "windows")]
     {
-        dirs::data_dir()
+        // Browser profiles contain cache, session cookies, and user data
+        // that should NOT roam across machines via %APPDATA%. Use
+        // %LOCALAPPDATA% (dirs::data_local_dir) so the profile stays
+        // machine-local — matches the convention Chrome / Edge / Firefox
+        // follow on Windows.
+        dirs::data_local_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join("amux/browser-profiles")
     }

--- a/crates/amux-cli/src/install.rs
+++ b/crates/amux-cli/src/install.rs
@@ -56,8 +56,14 @@ pub fn install_shell_integration() -> anyhow::Result<()> {
     );
     println!();
     println!("  # For PowerShell 7+ ($PROFILE):");
+    // Escape apostrophes in the displayed path because we print a
+    // single-quoted PowerShell string literal — PowerShell escapes `'`
+    // inside `'...'` as `''`. Without this, a user whose home directory
+    // is something like `C:\Users\O'Connor\...` gets a syntax error
+    // when they paste the snippet into their $PROFILE.
+    let pwsh_path_escaped = pwsh_path.display().to_string().replace('\'', "''");
     println!("  if ($env:AMUX_SOCKET_PATH) {{");
-    println!("      . '{}'", pwsh_path.display());
+    println!("      . '{pwsh_path_escaped}'");
     println!("  }}");
 
     Ok(())

--- a/crates/amux-cli/src/install.rs
+++ b/crates/amux-cli/src/install.rs
@@ -25,16 +25,21 @@ pub fn install_shell_integration() -> anyhow::Result<()> {
     let zsh_script = include_str!("../../../resources/shell-integration/amux-zsh-integration.zsh");
     let bash_script =
         include_str!("../../../resources/shell-integration/amux-bash-integration.bash");
+    let pwsh_script =
+        include_str!("../../../resources/shell-integration/amux-pwsh-integration.ps1");
 
     let zsh_path = config_dir.join("amux-zsh-integration.zsh");
     let bash_path = config_dir.join("amux-bash-integration.bash");
+    let pwsh_path = config_dir.join("amux-pwsh-integration.ps1");
 
     std::fs::write(&zsh_path, zsh_script)?;
     std::fs::write(&bash_path, bash_script)?;
+    std::fs::write(&pwsh_path, pwsh_script)?;
 
     println!("Shell integration scripts installed to:");
     println!("  {}", zsh_path.display());
     println!("  {}", bash_path.display());
+    println!("  {}", pwsh_path.display());
     println!();
     println!("Add one of the following to your shell config:");
     println!();
@@ -49,6 +54,11 @@ pub fn install_shell_integration() -> anyhow::Result<()> {
         "  [[ -n \"$AMUX_SOCKET_PATH\" ]] && source \"{}\"",
         bash_path.display()
     );
+    println!();
+    println!("  # For PowerShell 7+ ($PROFILE):");
+    println!("  if ($env:AMUX_SOCKET_PATH) {{");
+    println!("      . '{}'", pwsh_path.display());
+    println!("  }}");
 
     Ok(())
 }


### PR DESCRIPTION
## Phase 4a of the Windows gap-analysis plan

Two targeted polish items that ship cleanly without hands-on Windows testing:

- **F11:** browser profile dir — Roaming → Local on Windows
- **F14:** \`install-shell-integration\` CLI writes and documents the pwsh script

The two bigger items from phase 4 (**F6** taskbar overlay icon, **F7** NT PEB cwd lookup) need a Windows dev environment to validate iteratively and are tracked separately in **#179**.

## F11: browser profile dir

\`dirs::data_dir()\` on Windows maps to \`%APPDATA%\` (Roaming). Browser profiles contain cache, session cookies, and user data that shouldn't sync across machines — every major browser stores profile data under \`%LOCALAPPDATA%\` for exactly this reason.

**Fix:** switch to \`dirs::data_local_dir()\` on Windows only. macOS and Linux paths unchanged.

## F14: \`install-shell-integration\` CLI pwsh output

Before this PR, \`amux install-shell-integration\` wrote \`amux-zsh-integration.zsh\` and \`amux-bash-integration.bash\` and printed source instructions for both — but silently ignored pwsh. Windows users invoking it got no pwsh integration even though the script exists in the repo.

**Fix:** also \`include_str!\` the pwsh script and write it alongside the bash/zsh ones, plus print a PowerShell source snippet for the user's \`\$PROFILE\`:

\`\`\`powershell
# For PowerShell 7+ (\$PROFILE):
if (\$env:AMUX_SOCKET_PATH) {
    . '<path>'
}
\`\`\`

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --workspace\` — full suite green
- [ ] Windows CI — the #175 libghostty-vt-sys patch should have this green already

## Tracking

This is **phase 4a** of the Windows gap-analysis. The deferred items:

- **#179 — Windows polish follow-ups: taskbar overlay icon + NT PEB cwd lookup** — captures F6 and F7 with full context on why they need hands-on Windows work (COM init + HICON rendering for overlay; NT PEB walk with WOW64 caveats for cwd).

Phase 5 (release workflow + Windows binary zip) is still the last remaining piece of the plan.

Refs #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)