### PR TITLE
Windows phase 5: release workflow + binary archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,17 +2,15 @@ name: Release
 
 # Triggered on `v*` tag push (normal release flow) and manual dispatch
 # so we can test the workflow without cutting a real tag. Manual runs
-# don't upload to a GitHub release — they just build and archive.
+# are always build-only — they never attach anything to a GitHub
+# release. Publishing is gated on `github.event_name == 'push'` in the
+# `release` job below, so even a manual dispatch against a tag ref
+# cannot accidentally publish.
 on:
   push:
     tags:
       - 'v*'
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry run (build only, do not attach to a release)'
-        type: boolean
-        default: true
 
 concurrency:
   group: release-${{ github.ref }}
@@ -80,29 +78,48 @@ jobs:
           staging="amux-${{ matrix.target }}"
           mkdir -p "$staging"
 
-          # Binaries shipped in every release. Each entry is
-          # "src_name:dest_name"; src_name is the cargo-produced filename
-          # under target/<target>/release and dest_name is the copy we
-          # put in the archive. On Windows, cargo produces <name>.exe so
-          # the dest names include the .exe suffix.
+          # On Windows, cargo emits <name>.exe.
           ext=""
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             ext=".exe"
           fi
 
-          bins=(
+          # Required binaries: the archive is broken without them, so
+          # a missing source file hard-fails the job. These are the CLI
+          # (`amux`) and the GUI app (`amux-app`), which ship on every
+          # platform.
+          required_bins=(
             "amux${ext}"
             "amux-app${ext}"
+          )
+
+          # Optional binaries: staged when available, warn-and-continue
+          # when missing. `amux-agent-wrapper` only matters on Windows
+          # (the compiled agent wrapper that replaces the Unix bash
+          # scripts) — on macOS/Linux it builds but isn't consumed, so
+          # its absence isn't fatal.
+          optional_bins=(
             "amux-agent-wrapper${ext}"
           )
 
-          for bin in "${bins[@]}"; do
+          for bin in "${required_bins[@]}"; do
             src="target/${{ matrix.target }}/release/${bin}"
             if [[ -f "$src" ]]; then
               cp "$src" "$staging/$bin"
-              echo "Staged $bin"
+              echo "Staged required $bin"
             else
-              echo "::warning::missing $src — skipping"
+              echo "::error::missing required binary $src"
+              exit 1
+            fi
+          done
+
+          for bin in "${optional_bins[@]}"; do
+            src="target/${{ matrix.target }}/release/${bin}"
+            if [[ -f "$src" ]]; then
+              cp "$src" "$staging/$bin"
+              echo "Staged optional $bin"
+            else
+              echo "::warning::missing optional binary $src — skipping"
             fi
           done
 
@@ -148,10 +165,12 @@ jobs:
     name: Attach to GitHub Release
     needs: build
     runs-on: ubuntu-latest
-    # Only attach to a release on a real tag push. Manual dispatches
-    # stay as build artifacts on the workflow run so we can test the
-    # pipeline without publishing anything.
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Only attach to a release on a real tag push. The `event_name`
+    # check is load-bearing: without it, a `workflow_dispatch` run
+    # against a tag ref would match `startsWith(github.ref, 'refs/tags/v')`
+    # and publish, which contradicts the "manual runs are build-only"
+    # contract documented at the top of this file.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,197 @@
+name: Release
+
+# Triggered on `v*` tag push (normal release flow) and manual dispatch
+# so we can test the workflow without cutting a real tag. Manual runs
+# don't upload to a GitHub release — they just build and archive.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build only, do not attach to a release)'
+        type: boolean
+        default: true
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  # Release builds: no -D warnings. We don't want a fresh toolchain
+  # upgrade with new warnings to break a release. Lint is enforced
+  # by ci.yml on every PR/main push instead.
+  RUSTFLAGS: ''
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            archive_ext: tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            archive_ext: tar.gz
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive_ext: tar.gz
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            archive_ext: zip
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libasound2-dev \
+            libudev-dev \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libsoup-3.0-dev
+
+      - uses: mlugg/setup-zig@v2
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      - name: Build release binaries
+        shell: bash
+        run: cargo build --release --workspace --target ${{ matrix.target }}
+
+      - name: Stage binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          staging="amux-${{ matrix.target }}"
+          mkdir -p "$staging"
+
+          # Binaries shipped in every release. Each entry is
+          # "src_name:dest_name"; src_name is the cargo-produced filename
+          # under target/<target>/release and dest_name is the copy we
+          # put in the archive. On Windows, cargo produces <name>.exe so
+          # the dest names include the .exe suffix.
+          ext=""
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            ext=".exe"
+          fi
+
+          bins=(
+            "amux${ext}"
+            "amux-app${ext}"
+            "amux-agent-wrapper${ext}"
+          )
+
+          for bin in "${bins[@]}"; do
+            src="target/${{ matrix.target }}/release/${bin}"
+            if [[ -f "$src" ]]; then
+              cp "$src" "$staging/$bin"
+              echo "Staged $bin"
+            else
+              echo "::warning::missing $src — skipping"
+            fi
+          done
+
+          # Include README and LICENSE so end users have something to
+          # read after extracting. Skip if either file is missing so
+          # the archive still builds.
+          for meta in README.md LICENSE LICENSE.md; do
+            if [[ -f "$meta" ]]; then
+              cp "$meta" "$staging/"
+            fi
+          done
+
+          ls -la "$staging"
+
+      - name: Archive (tar.gz) — macOS / Linux
+        if: matrix.archive_ext == 'tar.gz'
+        shell: bash
+        run: |
+          set -euo pipefail
+          staging="amux-${{ matrix.target }}"
+          tar -czf "${staging}.tar.gz" "$staging"
+          # Surface the artifact path for the upload step.
+          echo "ARCHIVE_PATH=${staging}.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Archive (zip) — Windows
+        if: matrix.archive_ext == 'zip'
+        shell: pwsh
+        run: |
+          $staging = "amux-${{ matrix.target }}"
+          Compress-Archive -Path $staging -DestinationPath "$staging.zip" -Force
+          # Surface the artifact path for the upload step.
+          Add-Content -Path $env:GITHUB_ENV -Value "ARCHIVE_PATH=$staging.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: amux-${{ matrix.target }}
+          path: ${{ env.ARCHIVE_PATH }}
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Attach to GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    # Only attach to a release on a real tag push. Manual dispatches
+    # stay as build artifacts on the workflow run so we can test the
+    # pipeline without publishing anything.
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Flatten artifact directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' \) \
+            -exec cp {} release-assets/ \;
+          ls -la release-assets
+
+      - name: Create / update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/}"
+          echo "Publishing release for tag $tag"
+
+          # Create the release as a draft on first run so a human can
+          # review the body + assets before marking it public. Re-runs
+          # (retries on a single tag) upload into the existing draft.
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            gh release create "$tag" \
+              --draft \
+              --title "$tag" \
+              --notes "Release $tag. See the commit log for changes."
+          fi
+
+          # Upload every staged asset. `--clobber` lets retries
+          # replace partial uploads from a failed prior run.
+          for asset in release-assets/*; do
+            gh release upload "$tag" "$asset" --clobber
+          done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-repository = "https://github.com/yourusername/amux"
+repository = "https://github.com/daveowenatl/amux"
 
 [workspace.dependencies]
 # Encoding

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <p align="center">A cross-platform terminal multiplexer for AI coding agents — Claude Code, Gemini CLI, and Codex CLI, all first-class</p>
 
 <p align="center">
-  <a href="https://github.com/yourusername/amux/releases"><img src="https://img.shields.io/github/v/release/yourusername/amux?color=555&label=latest" alt="Latest release" /></a>
+  <a href="https://github.com/daveowenatl/amux/releases"><img src="https://img.shields.io/github/v/release/daveowenatl/amux?color=555&label=latest" alt="Latest release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-555" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20macOS%20%7C%20Linux-555" alt="Platforms" />
   <img src="https://img.shields.io/badge/built%20with-Rust-555?logo=rust" alt="Built with Rust" />
@@ -33,7 +33,7 @@ Sidebar shows git branch, PR status, working directory, listening ports, and lat
 
 ### GitHub Releases (recommended)
 
-Download the latest binary for your platform from the [Releases page](https://github.com/yourusername/amux/releases/latest):
+Download the latest archive for your platform from the [Releases page](https://github.com/daveowenatl/amux/releases/latest):
 
 | Platform | File |
 |---|---|
@@ -42,12 +42,16 @@ Download the latest binary for your platform from the [Releases page](https://gi
 | Linux (x86_64) | `amux-x86_64-unknown-linux-gnu.tar.gz` |
 | Windows (x86_64) | `amux-x86_64-pc-windows-msvc.zip` |
 
-amux auto-updates on launch. You only need to download once.
+Extract and place the contents on your `PATH`. Each archive contains:
+
+- `amux` — the CLI (shell integration, notifications, session control)
+- `amux-app` — the GUI terminal multiplexer
+- `amux-agent-wrapper` *(Windows only)* — agent hook injector; runtime dependency used by `amux-app` to wire Claude/Gemini hook integration into new panes
 
 ### Homebrew (macOS)
 
 ```bash
-brew tap yourusername/amux
+brew tap daveowenatl/amux
 brew install --cask amux
 ```
 
@@ -277,7 +281,7 @@ toggle_sidebar = "ctrl+b"
 Requirements: Rust 1.80+, a C compiler, and platform graphics drivers.
 
 ```bash
-git clone https://github.com/yourusername/amux
+git clone https://github.com/daveowenatl/amux
 cd amux
 cargo build --release
 ./target/release/amux
@@ -287,8 +291,8 @@ On Windows, the MSVC toolchain is required (`rustup default stable-x86_64-pc-win
 
 ## Contributing
 
-- Open [GitHub Issues](https://github.com/yourusername/amux/issues) for bugs and feature requests
-- Start a [Discussion](https://github.com/yourusername/amux/discussions) for questions and ideas
+- Open [GitHub Issues](https://github.com/daveowenatl/amux/issues) for bugs and feature requests
+- Start a [Discussion](https://github.com/daveowenatl/amux/discussions) for questions and ideas
 - PRs welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## License


### PR DESCRIPTION
## Phase 5 — the final phase of the Windows gap-analysis plan

Ships the GitHub Actions workflow that actually produces the downloadable archives the README has been promising since the project started. Also closes a few loose ends left over from the workflow-free era (broken \`yourusername\` placeholders, incorrect \"auto-update\" claim).

See \`~/.claude/plans/2026-04-11-windows-gap-analysis.md\` for the full plan.

## What ships

### \`.github/workflows/release.yml\`

Triggered on \`v*\` tag push (real releases) and \`workflow_dispatch\` with a \`dry_run\` toggle (test the pipeline without publishing).

**Matrix — 4 targets matching the README install table:**

| Target | Runner | Format |
|---|---|---|
| \`aarch64-apple-darwin\` | \`macos-latest\` | .tar.gz |
| \`x86_64-apple-darwin\` | \`macos-13\` | .tar.gz |
| \`x86_64-unknown-linux-gnu\` | \`ubuntu-latest\` | .tar.gz |
| \`x86_64-pc-windows-msvc\` | \`windows-latest\` | .zip |

Linux gets the same apt-get deps as ci.yml's check-linux job. Build step is \`cargo build --release --workspace --target <target>\` so every bin in the workspace is produced at once.

**Staging:** copies \`amux\`, \`amux-app\`, and \`amux-agent-wrapper\` (with \`.exe\` suffix on Windows) into \`amux-<target>/\`. Each binary is copied with a \`::warning::missing\` fallback — the archive still builds if a binary is temporarily removed. README and LICENSE are included when present.

**Archiving:** \`tar -czf\` on Unix, \`Compress-Archive\` on Windows. Each matrix job uploads its archive as a workflow artifact.

**Publishing:** separate \`release\` job runs after all builds finish and **only** when the ref is \`refs/tags/v*\`. Manual dispatches stop at workflow artifacts so the pipeline can be tested end-to-end without publishing. On a real tag push: download all per-target artifacts, flatten to \`release-assets/\`, create a **draft** GitHub Release via \`gh\` CLI (human-reviewed before public), upload all archives with \`--clobber\` so retries replace partial uploads.

**\`RUSTFLAGS\` intentionally blank** — ci.yml already enforces \`-D warnings\` on every PR and main push. Release builds should be lenient so a fresh toolchain upgrade with new warnings doesn't break an in-flight release.

### Incidental fixes

- **\`Cargo.toml\` workspace \`repository\`** was \`github.com/yourusername/amux\` — fixed to \`github.com/daveowenatl/amux\` so \`cargo publish\` metadata is correct.
- **README install section** replaced the fake \"amux auto-updates on launch\" promise (no such feature exists) with an accurate description of what each archive contains: \`amux\` CLI, \`amux-app\` GUI, plus \`amux-agent-wrapper\` on Windows. The wrapper note links back to its role as the hook-injector for Claude / Gemini panes so users understand why the archive ships three binaries.
- **Several \`yourusername/amux\` placeholders** in the README fixed to \`daveowenatl/amux\` (badge link, releases link, issues link, discussions link, clone URL, Homebrew tap).

## File-scope independence

This PR is **file-scope independent** of the in-flight Windows phase 3 (#178) and phase 4a (#180) PRs. It only touches:

- \`.github/workflows/release.yml\` (new)
- \`Cargo.toml\` (just the \`repository\` field)
- \`README.md\` (install section + placeholder cleanup)

When #178 eventually merges, Windows archives will automatically start including \`amux-agent-wrapper.exe\` — the staging loop iterates a binary list with a missing-file warning, so no workflow change is required.

## Scope notes (what's NOT in this PR)

**Code signing + notarization** (tracked in **#29**): macOS Gatekeeper will complain on first launch (Ctrl-click → Open workaround), Windows SmartScreen will warn (More info → Run anyway). Both are fixable by a later layer on top of this workflow — Apple notarization needs a developer cert + App Store Connect API key, Windows Authenticode needs a signing certificate. Neither is urgent for a v0 release but both block a \"click-to-run\" user experience.

**MSIX packaging** (tracked in **#141**): replaces the .zip on Windows with a Windows Store–compatible package. Also a later layer.

**Auto-update** (the feature the README used to claim): not implemented. Omega-Y's \`self_update\` crate is a candidate. Separate work.

**Homebrew tap** (the README also mentions): no tap repo exists yet. Filing a follow-up would be good — probably out of scope for this phase.

## Test plan

Automated:
- [x] \`cargo fmt --check\` clean
- [x] \`cargo build --workspace\` clean (unchanged by this PR)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] YAML syntactically valid
- [ ] **Workflow dispatch run** — will trigger manually after this PR is open to verify the pipeline builds + archives cleanly on all 4 runners. Dry-run mode (the default for manual dispatch) won't publish anything.

Manual (post-merge):
- [ ] Push a test tag like \`v0.1.0-rc0\` to verify the end-to-end publish path + draft release creation
- [ ] Download the Windows archive from the draft release on a clean Windows VM and verify \`amux-app.exe\` launches

Refs #166, #29, #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to clarify extraction of release archives and placement on system PATH across all platforms.
* **Chores**
  * Updated repository metadata and GitHub references across project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->