### PR TITLE
Stage ghostty-vt.dll next to Windows exes in release archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,30 @@ jobs:
             fi
           done
 
+          # Windows only: stage ghostty-vt.dll next to the exes. The
+          # libghostty-rs fork we patch to (see workspace Cargo.toml)
+          # builds ghostty-vt as a shared library on Windows — so
+          # `ghostty-vt.lib` is an import library, not a true static
+          # lib, and `amux-app.exe` has `ghostty-vt.dll` in its import
+          # table. Without shipping the DLL alongside the exe, launching
+          # amux-app.exe fails with STATUS_DLL_NOT_FOUND (0xC0000135)
+          # before `main` runs, producing a silent startup crash with
+          # no stderr output. Hard-fail the job if the DLL is missing
+          # from the build output — that would mean the linker walked
+          # a different path than we expect, which is a bug we want
+          # surfaced loudly rather than shipped as a broken archive.
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            dll_src=$(find "target/${{ matrix.target }}/release/build" \
+              -type f -name "ghostty-vt.dll" 2>/dev/null | head -n1)
+            if [[ -n "$dll_src" && -f "$dll_src" ]]; then
+              cp "$dll_src" "$staging/ghostty-vt.dll"
+              echo "Staged ghostty-vt.dll from $dll_src"
+            else
+              echo "::error::ghostty-vt.dll not found under target/${{ matrix.target }}/release/build"
+              exit 1
+            fi
+          fi
+
           # Include README and LICENSE so end users have something to
           # read after extracting. Skip if either file is missing so
           # the archive still builds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,20 +131,53 @@ jobs:
           # table. Without shipping the DLL alongside the exe, launching
           # amux-app.exe fails with STATUS_DLL_NOT_FOUND (0xC0000135)
           # before `main` runs, producing a silent startup crash with
-          # no stderr output. Hard-fail the job if the DLL is missing
-          # from the build output — that would mean the linker walked
-          # a different path than we expect, which is a bug we want
-          # surfaced loudly rather than shipped as a broken archive.
+          # no stderr output.
+          #
+          # Selection strategy:
+          # - Match the exact expected cargo/libghostty-vt-sys output
+          #   path (`libghostty-vt-sys-*/out/ghostty-install/bin/`)
+          #   rather than a bare filename. With warm `rust-cache`
+          #   restoration, stale `libghostty-vt-sys-<oldhash>` dirs
+          #   can linger alongside the current one, and `find -name`
+          #   + `head -n1` would arbitrarily pick one.
+          # - Use `mapfile` rather than `find | head -n1`. Under
+          #   `set -o pipefail` (set at the top of this step), `head`
+          #   closing its stdin after reading one line would make
+          #   `find` exit with SIGPIPE, aborting the whole step
+          #   before reaching the friendly error branch below.
+          # - Hard-fail on both zero matches (build graph walked a
+          #   different path than we expect) and multiple matches
+          #   (nondeterministic packaging from cache pollution) —
+          #   both are bugs we want surfaced loudly rather than
+          #   shipped as a broken or stale archive.
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            dll_src=$(find "target/${{ matrix.target }}/release/build" \
-              -type f -name "ghostty-vt.dll" 2>/dev/null | head -n1)
-            if [[ -n "$dll_src" && -f "$dll_src" ]]; then
-              cp "$dll_src" "$staging/ghostty-vt.dll"
-              echo "Staged ghostty-vt.dll from $dll_src"
-            else
-              echo "::error::ghostty-vt.dll not found under target/${{ matrix.target }}/release/build"
-              exit 1
+            dll_build_dir="target/${{ matrix.target }}/release/build"
+            dll_matches=()
+            if [[ -d "$dll_build_dir" ]]; then
+              mapfile -t dll_matches < <(
+                find "$dll_build_dir" \
+                  -type f \
+                  -path '*/libghostty-vt-sys-*/out/ghostty-install/bin/ghostty-vt.dll' \
+                  2>/dev/null | sort
+              )
             fi
+
+            case "${#dll_matches[@]}" in
+              1)
+                dll_src="${dll_matches[0]}"
+                cp "$dll_src" "$staging/ghostty-vt.dll"
+                echo "Staged ghostty-vt.dll from $dll_src"
+                ;;
+              0)
+                echo "::error::ghostty-vt.dll not found under $dll_build_dir/libghostty-vt-sys-*/out/ghostty-install/bin/"
+                exit 1
+                ;;
+              *)
+                echo "::error::multiple ghostty-vt.dll candidates found (stale cache entries?); refusing to pick arbitrarily:"
+                printf '  %s\n' "${dll_matches[@]}"
+                exit 1
+                ;;
+            esac
           fi
 
           # Include README and LICENSE so end users have something to


### PR DESCRIPTION
## Summary

- Patches `release.yml` to stage `ghostty-vt.dll` next to the three Windows exes before zipping
- Unblocks launching `amux-app.exe` from the release archive on Windows — currently fails with `STATUS_DLL_NOT_FOUND` (`0xC0000135`) before `main` runs

Fixes #182

## Why

The libghostty-rs fork we pin builds ghostty-vt as a shared library on Windows. `ghostty-vt.lib` is an import library for a DLL, not a static lib, so `amux-app.exe` has `ghostty-vt.dll` in its import table. Without shipping that DLL alongside the exe in the release archive, the Windows loader refuses to start the process.

Confirmed diagnosis by downloading the archive from run [24289588595](https://github.com/daveowenatl/amux/actions/runs/24289588595) onto an ARM64 Windows 11 VM, running `amux-app.exe`, getting `0xC0000135`, and then PowerShell-grepping the binary for DLL strings — `ghostty-vt.dll` appears alongside `kernel32.dll`/`vcruntime140.dll`/etc.

## Test plan

- [ ] CI builds all 3 platforms green (Linux tar.gz, macOS ARM tar.gz, Windows zip)
- [ ] After merge, re-trigger release.yml via workflow_dispatch, download the Windows archive
- [ ] Unzip on ARM64 Windows 11 VM, run `amux-app.exe`, confirm window actually opens (previously: silent exit 0xC0000135)
- [ ] Smoke: `amux.exe --version` prints a version

## Follow-up (not this PR)

Medium-term fix: update the libghostty-rs fork to link against `ghostty-vt-static.lib` (the true static library it already builds as a separate target) so amux-app has no ghostty runtime dependency at all. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Windows release process now validates and includes the required runtime DLL in staged artifacts.
  * Release staging will halt with an error if the required DLL is missing or ambiguous, preventing incomplete or incorrect Windows builds from being archived.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->