### PR TITLE
Rewrite README: own MVP status, credit cmux, fix keybindings (closes #184)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-amux is a cross-platform terminal multiplexer for AI coding agents (Claude Code, Gemini CLI, Codex CLI). Built in Rust with GPU-accelerated rendering via wgpu (Metal on macOS, DX12/Vulkan on Windows, Vulkan on Linux) and wezterm-term for VT state machine.
+amux is a cross-platform terminal multiplexer for AI coding agents (Claude Code, Gemini CLI, Codex CLI). Built in Rust with GPU-accelerated rendering via wgpu (Metal on macOS, DX12/Vulkan on Windows, Vulkan on Linux) and `libghostty-vt` for the VT state machine.
 
 ## Build Commands
 
@@ -29,7 +29,7 @@ Cargo workspace with 9 crates under `crates/`:
 
 | Crate | Type | Purpose |
 |---|---|---|
-| `amux-term` | lib | Terminal pane abstraction (wezterm-term + portable-pty). Key/mouse encoders, OSC handling, color resolution. |
+| `amux-term` | lib | Terminal pane abstraction (`libghostty-vt` + portable-pty). Key/mouse encoders, OSC handling, color resolution. |
 | `amux-app` | bin | Main binary: GUI + event loop (eframe/winit) |
 | `amux-cli` | bin | CLI binary (socket client) |
 | `amux-render-soft` | lib | Softbuffer renderer (Phase 1–7) |
@@ -39,12 +39,12 @@ Cargo workspace with 9 crates under `crates/`:
 | `amux-notify` | lib | OSC notification parsing + in-app store |
 | `amux-session` | lib | Session persistence (save/restore JSON) |
 
-Key dependency: `wezterm-term` is a git dependency pinned to rev `05343b3` from the wezterm monorepo.
+Key dependency: `libghostty-vt` is patched to a fork at `github.com/daveowenatl/libghostty-rs` rev `cabcfb81cc3f4f20ef9b62312df6bb04c929abb5`. The fork cherry-picks unpublished fixes for Windows — upstream's `build.rs` hardcodes `libghostty-vt.so.0.1.0` as the expected shared-library filename, which panics on Windows where Zig emits `ghostty-vt.dll` + `ghostty-vt.lib`.
 
 ## Architecture
 
 ### Rendering
-wgpu for GPU rendering with platform-specific backends. wezterm-term handles VT/terminal state machine. PTY streams are monitored for OSC 9/99/777 sequences.
+wgpu for GPU rendering with platform-specific backends. `libghostty-vt` handles the VT / terminal state machine. PTY streams are monitored for OSC 9/99/777 sequences.
 
 ### Agent Integrations
 Three first-class agent integrations, each using the agent's native event system:

--- a/README.md
+++ b/README.md
@@ -1,39 +1,28 @@
-<h1 align="center">amux</h1>
-<p align="center">A cross-platform terminal multiplexer for AI coding agents — Claude Code, Gemini CLI, and Codex CLI, all first-class</p>
+# amux
 
-<p align="center">
-  <a href="https://github.com/daveowenatl/amux/releases"><img src="https://img.shields.io/github/v/release/daveowenatl/amux?color=555&label=latest" alt="Latest release" /></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-555" alt="License: MIT" /></a>
-  <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20macOS%20%7C%20Linux-555" alt="Platforms" />
-  <img src="https://img.shields.io/badge/built%20with-Rust-555?logo=rust" alt="Built with Rust" />
-</p>
+amux is a terminal multiplexer for AI coding agents (Claude Code, Gemini CLI, Codex CLI). It's a clone of [cmux](https://github.com/manaflow-ai/cmux), rebuilt in Rust to run on Windows and Linux alongside macOS. The sidebar, notification ring, and "which pane needs my attention" model are cmux's design; credit goes there.
 
-## Features
+**Status: MVP.** Pre-1.0. The UI, CLI, and socket protocol still move between commits; don't depend on them being stable yet. Windows is the newest platform and the least tested. Codex-on-Windows is not wired up yet (Claude Code and Gemini CLI work on Windows; Codex still passthroughs).
 
-### Notification rings
-Panes get a blue ring and sidebar tabs light up when agents need your attention — works across Claude Code, Gemini CLI, and Codex CLI.
+[![Latest release](https://img.shields.io/github/v/release/daveowenatl/amux?color=555&label=latest)](https://github.com/daveowenatl/amux/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-555)](LICENSE)
+![Platforms](https://img.shields.io/badge/platforms-Windows%20%7C%20macOS%20%7C%20Linux-555)
+![Built with Rust](https://img.shields.io/badge/built%20with-Rust-555?logo=rust)
 
-### Notification panel
-See all pending notifications in one place. Jump to the most recent unread across all workspaces and agents.
+## What it does
 
-### Agent status sidebar
-Live status pills per workspace — which agent is thinking, which tool it's running, and which pane needs your input right now.
-
-### Vertical + horizontal tabs
-Sidebar shows git branch, PR status, working directory, listening ports, and latest notification text. Split panes horizontally and vertically.
-
----
-
-- **All three agentic CLIs, first-class** — Claude Code, Gemini CLI, and Codex CLI each get hook integration, live status indicators, and tool visibility in the sidebar. Hooks inject automatically when the agent launches inside an amux pane, without touching the user's native agent config. Unix uses bash wrappers; Windows uses a compiled Rust wrapper (`amux-agent-wrapper.exe`) that ships alongside `amux.exe`. Zero-setup on Unix for all three agents, and on Windows for Claude Code and Gemini CLI; **Codex on Windows is tracked as follow-up work** because its wrapper needs a symlinked `CODEX_HOME`, which in turn requires Windows Developer Mode.
-- **Scriptable** — CLI and socket API to create workspaces, split panes, send keystrokes, and drive agents programmatically. tmux-compat shim included for agent scripts that call tmux directly.
-- **Native on every platform** — Built in Rust with wgpu for GPU-accelerated rendering. Runs natively on Windows (DX12/Vulkan), macOS (Metal), and Linux (Vulkan). Not Electron. Not Tauri.
-- **Cross-platform config** — Reads `~/.config/amux/config.toml`. No platform-specific config format.
+- Runs Claude Code, Gemini CLI, and Codex CLI in panes. A blue ring appears on any pane whose agent needs input.
+- Sidebar shows per-workspace status: which agent is active, which tool it's running, which pane is waiting on you.
+- Hook integration is auto-injected. No `install-hooks` step. Your `~/.claude/settings.json`, `~/.gemini/settings.json`, and `~/.codex/` are not touched.
+- Workspaces, horizontal and vertical splits, surface tabs within a workspace.
+- GPU-rendered via wgpu (Metal / DX12 / Vulkan) backed by wezterm-term for the VT state machine.
+- CLI and Unix / named-pipe socket for driving it from scripts. tmux-compat shim so agent scripts calling `tmux` route to amux.
 
 ## Install
 
-### GitHub Releases (recommended)
+### GitHub Releases
 
-Download the latest archive for your platform from the [Releases page](https://github.com/daveowenatl/amux/releases/latest):
+Grab the archive for your platform from the [Releases page](https://github.com/daveowenatl/amux/releases/latest):
 
 | Platform | File |
 |---|---|
@@ -42,172 +31,122 @@ Download the latest archive for your platform from the [Releases page](https://g
 | Linux (x86_64) | `amux-x86_64-unknown-linux-gnu.tar.gz` |
 | Windows (x86_64) | `amux-x86_64-pc-windows-msvc.zip` |
 
-Extract and place the contents on your `PATH`. Each archive contains:
+Extract and put the contents on your `PATH`. Each archive contains:
 
-- `amux` — the CLI (shell integration, notifications, session control)
-- `amux-app` — the GUI terminal multiplexer
-- `amux-agent-wrapper` *(Windows only)* — agent hook injector; runtime dependency used by `amux-app` to wire Claude/Gemini hook integration into new panes
+- `amux` — CLI (shell integration, status, notifications, session control)
+- `amux-app` — the GUI terminal multiplexer itself
+- `amux-agent-wrapper` *(Windows only)* — compiled agent hook injector; copied to `~/.config/amux/bin/{claude,gemini}.exe` on first launch and used by `amux-app` to wire hooks into new panes
 
-### Homebrew (macOS)
-
-```bash
-brew tap daveowenatl/amux
-brew install --cask amux
-```
-
-### Cargo (all platforms)
+### From source
 
 ```bash
-cargo install amux
+git clone https://github.com/daveowenatl/amux
+cd amux
+cargo build --release
+./target/release/amux-app
 ```
 
-### Winget (Windows)
-
-```powershell
-winget install amux
-```
-
-## Why amux?
-
-I run a lot of parallel agent sessions — Claude Code for some projects, Gemini CLI for others, Codex for the rest. No single agentic CLI has won yet and I don't think one will. I wanted a multiplexer that treats all of them the same.
-
-Ghostty and WezTerm are excellent terminals but neither was built for multi-agent workflows. The notification problem is real: agent CLIs fire OS notifications that all say roughly "agent needs input" with no context, and with ten panes open you can't tell which one needs you without tabbing through them all.
-
-cmux solved this beautifully on macOS — the blue ring and sidebar model is exactly right. But it's macOS-only and optimized for Claude Code specifically. amux is the same idea built cross-platform in Rust, with first-class support for all three major agentic CLIs from day one.
-
-The sidebar hooks into each agent's native event system: Claude Code's `PreToolUse`/`Stop` hooks, Gemini CLI's `BeforeTool`/`AfterAgent` hooks, and Codex CLI's `PreToolUse`/`Stop` hooks. You get live "Running: `cargo test`" tool indicators in the sidebar — without writing any glue code. All three agents inject hooks automatically per pane; no manual install step. Richer Codex integration via `codex app-server` — including approval interception from the sidebar — is tracked as future work.
-
-The rendering is wgpu (Metal on macOS, DX12/Vulkan on Windows/Linux) backed by wezterm-term for the VT state machine. It's fast and it's not Electron.
-
-## The Zen of amux
-
-amux is not prescriptive about how developers hold their tools. Which is why it runs on every major operating system and integrates with every major agentic CLI out of the box.
-
-amux is a primitive, not a solution. It gives you a terminal, notifications, workspaces, splits, tabs, agent status indicators, and a CLI to control all of it. It doesn't tell you which AI to use, which OS to run, or how to structure your projects. What you build with the primitives is yours.
-
-The best developers have always built their own tools. Nobody has figured out the best way to work with agents yet, and the teams building closed products definitely haven't either. The developers closest to their own codebases will figure it out first.
-
-Give a million developers composable primitives across every platform and they'll collectively find the most efficient workflows faster than any product team could design top-down.
-
-## Agent Integration
-
-amux auto-detects which agent is running in each pane and activates the appropriate integration. No manual setup for Claude Code or Gemini CLI — launching them inside an amux pane is enough. Wrappers installed to `~/.config/amux/bin/` inject hooks at runtime without touching your global agent settings.
-
-### Claude Code
-
-Hooks into all 9 Claude Code hook events (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStart`, `SubagentStop`, `SessionEnd`). The sidebar shows the current tool name during `PreToolUse` and clears on `PostToolUse`/`Stop`. `Notification` events surface the underlying permission-prompt or error message text. Completion fires an in-app notification and optional OS notification. Hooks are injected via `--settings` per session — your `~/.claude/settings.json` is untouched.
-
-### Gemini CLI
-
-Hooks into Gemini CLI's BeforeAgent, AfterAgent, BeforeTool, Notification, SessionStart, and SessionEnd events. Status updates, tool indicators, and the "needs input" ring flow to the sidebar automatically. Requires Gemini CLI v0.26.0 or newer for hook support; older versions fall back to parsing Gemini's dynamic window title (◇ Ready / ✦ Working / ✋ Action Required / ⏲ Working…) as a best-effort status signal. Hook injection uses `GEMINI_CLI_SYSTEM_SETTINGS_PATH` pointing at a per-pane temp file, so your `~/.gemini/settings.json` is untouched and any user-defined hooks still fire alongside amux's.
-
-### Codex CLI
-
-Hooks into Codex CLI's SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, and Stop events via a wrapper script that creates a per-session `CODEX_HOME` tempdir symlinking your real `~/.codex/` and overlaying amux hook config. No modification of your real Codex config, credentials, or history. Launching `codex` inside an amux pane on macOS or Linux is enough — no manual install step. Amux observes Codex state for the sidebar but does not intercept approvals or drive the model; full `codex app-server` integration with approval interception is tracked as future work.
-
-> **Windows:** Codex integration via `amux-agent-wrapper.exe` is tracked as follow-up work. The Codex wrapper relies on a symlinked `CODEX_HOME` overlay, and creating symlinks on Windows requires either administrator privileges or [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) to be enabled. Until that's wired up, Codex on Windows runs passthrough — you'll still get a working Codex session, just without amux sidebar status / tool indicators. Claude Code and Gemini CLI are unaffected and work with zero setup on Windows.
-
-### Any other agent
-
-Any script or agent can integrate using environment variables that amux injects into every pane:
-
-```bash
-# Read from environment — amux sets these automatically
-echo $AMUX_WORKSPACE_ID
-echo $AMUX_SURFACE_ID
-echo $AMUX_SOCKET_PATH
-
-# Report state to amux sidebar
-amux set-status active "Running evaluations..."
-amux set-status idle
-amux notify "Tests passed — ready for review"
-```
-
-OSC 9/99/777 sequences are intercepted from the PTY stream and shown as in-app notifications without any CLI call.
+Requirements: Rust 1.80+, a C compiler, and platform graphics drivers. Windows needs the MSVC toolchain (`rustup default stable-x86_64-pc-windows-msvc`). Homebrew / Winget / `cargo install amux` are not set up yet — build from source or use the release archive.
 
 ## Keyboard Shortcuts
 
-Keys shown as `Ctrl` map to `Cmd` on macOS.
+Defaults differ between macOS and Windows/Linux. On Windows/Linux, workspace / tab / edit operations use `Ctrl+Shift` instead of bare `Ctrl` so the terminal's own `Ctrl+C` (SIGINT), `Ctrl+N`, `Ctrl+W`, `Ctrl+S` (XOFF), etc. still reach the shell. Every binding is overridable in `config.toml` under `[keybindings]`.
 
 ### Workspaces
 
-| Shortcut | Action |
-|---|---|
-| `Ctrl N` | New workspace |
-| `Ctrl 1–8` | Jump to workspace 1–8 |
-| `Ctrl 9` | Jump to last workspace |
-| `Ctrl Shift ]` | Next workspace |
-| `Ctrl Shift [` | Previous workspace |
-| `Ctrl Shift W` | Close workspace |
-| `Ctrl Shift R` | Rename workspace |
-| `Ctrl B` | Toggle sidebar |
+| Action | macOS | Windows / Linux |
+|---|---|---|
+| New workspace | `Cmd+N` | `Ctrl+Shift+N` |
+| Next workspace | `Cmd+Shift+]` | `Ctrl+Shift+]` |
+| Previous workspace | `Cmd+Shift+[` | `Ctrl+Shift+[` |
+| Jump to workspace 1–8 | `Cmd+1`…`Cmd+8` | `Ctrl+1`…`Ctrl+8` |
+| Jump to last workspace | `Cmd+9` | `Ctrl+9` |
+| Toggle sidebar | `Cmd+B` | `Ctrl+B` |
 
-### Surfaces (tabs)
+### Surfaces (tabs within a workspace)
 
-| Shortcut | Action |
-|---|---|
-| `Ctrl T` | New surface |
-| `Ctrl Shift ]` | Next surface |
-| `Ctrl Shift [` | Previous surface |
-| `Ctrl Tab` | Next surface |
-| `Ctrl Shift Tab` | Previous surface |
-| `Ctrl 1–8` | Jump to surface 1–8 |
-| `Ctrl W` | Close surface |
+| Action | macOS | Windows / Linux |
+|---|---|---|
+| New tab | `Cmd+T` | `Ctrl+Shift+T` |
+| Close tab | `Cmd+W` | `Ctrl+Shift+W` |
+| New browser tab | `Cmd+Shift+L` | `Ctrl+Shift+L` |
+| Next tab in focused pane | `Ctrl+Tab` | `Ctrl+Tab` |
+| Previous tab in focused pane | `Ctrl+Shift+Tab` | `Ctrl+Shift+Tab` |
 
-### Split Panes
+### Panes (splits)
 
-| Shortcut | Action |
-|---|---|
-| `Ctrl D` | Split right |
-| `Ctrl Shift D` | Split down |
-| `Alt ← → ↑ ↓` | Focus pane directionally |
-| `Ctrl Shift H` | Flash focused pane |
-
-### Notifications
-
-| Shortcut | Action |
-|---|---|
-| `Ctrl I` | Show notification panel |
-| `Ctrl Shift U` | Jump to latest unread |
-
-### Find
-
-| Shortcut | Action |
-|---|---|
-| `Ctrl F` | Find |
-| `Ctrl G` / `Ctrl Shift G` | Find next / previous |
-| `Ctrl Shift F` | Hide find bar |
-| `Ctrl E` | Use selection for find |
+| Action | macOS | Windows / Linux |
+|---|---|---|
+| Split right | `Cmd+D` | `Ctrl+D` |
+| Split down | `Cmd+Shift+D` | `Ctrl+Shift+D` |
+| Focus pane left | `Cmd+Alt+←` | `Ctrl+Alt+←` |
+| Focus pane right | `Cmd+Alt+→` | `Ctrl+Alt+→` |
+| Focus pane up | `Cmd+Alt+↑` | `Ctrl+Alt+↑` |
+| Focus pane down | `Cmd+Alt+↓` | `Ctrl+Alt+↓` |
+| Zoom focused pane | `Cmd+Shift+Enter` | `Ctrl+Shift+Enter` |
 
 ### Terminal
 
-| Shortcut | Action |
-|---|---|
-| `Ctrl K` | Clear scrollback |
-| `Ctrl Shift C` | Copy |
-| `Ctrl Shift V` | Paste |
-| `Ctrl +` / `Ctrl -` | Increase / decrease font size |
-| `Ctrl 0` | Reset font size |
+| Action | macOS | Windows / Linux |
+|---|---|---|
+| Copy | `Cmd+C` | `Ctrl+Shift+C` |
+| Paste | `Cmd+V` | `Ctrl+Shift+V` |
+| Select all | `Cmd+A` | `Ctrl+Shift+A` |
+| Find | `Cmd+F` | `Ctrl+F` |
+| Scrollback / copy mode | `Cmd+Shift+X` | `Ctrl+Shift+X` |
+| Clear scrollback | `Cmd+K` | `Ctrl+Shift+K` |
+| Zoom in (font) | `Cmd+=` | `Ctrl+=` |
+| Zoom out (font) | `Cmd+-` | `Ctrl+-` |
+| Reset font size | `Cmd+0` | `Ctrl+0` |
 
-### Window
+### Notifications
 
-| Shortcut | Action |
-|---|---|
-| `Ctrl Shift N` | New window |
-| `Ctrl ,` | Settings |
-| `Ctrl Shift ,` | Reload configuration |
+| Action | macOS | Windows / Linux |
+|---|---|---|
+| Toggle notification panel | `Cmd+I` | `Ctrl+I` |
+| Jump to latest unread | `Cmd+Shift+U` | `Ctrl+Shift+U` |
+
+### Session / dev
+
+| Action | macOS | Windows / Linux |
+|---|---|---|
+| Save session | `Cmd+S` | `Ctrl+Shift+S` |
+| Open dev tools | `Cmd+Alt+I` | `Ctrl+Shift+I` |
+
+## Agent Integration
+
+amux detects which agent is running in a pane by `argv[0]` and wires its hook events into the sidebar. Wrappers are installed to `~/.config/amux/bin/` and that directory is prepended to `PATH` for every pane, so launching `claude`, `gemini`, or `codex` inside amux finds the wrapper first. The wrapper injects hooks for the current session and execs the real agent binary.
+
+### Claude Code
+
+All 9 hook events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStart`, `SubagentStop`, `SessionEnd`. Hooks are injected via `--settings` at launch; nothing is persisted to `~/.claude/`.
+
+### Gemini CLI
+
+Six hook events: `BeforeAgent`, `AfterAgent`, `BeforeTool`, `Notification`, `SessionStart`, `SessionEnd`. Requires Gemini CLI `v0.26.0` or newer for hook support. Older versions fall back to parsing Gemini's window-title state machine (`◇ Ready` / `✦ Working` / `✋ Action Required` / `⏲ Working…`) as a best-effort status signal. Hook injection uses `GEMINI_CLI_SYSTEM_SETTINGS_PATH`; `~/.gemini/settings.json` is untouched and any user-defined hooks still fire alongside amux's.
+
+### Codex CLI
+
+Five hook events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`. The wrapper creates a per-session `CODEX_HOME` tempdir that symlinks your real `~/.codex/` and overlays amux's hook config. Your Codex config, credentials, and history are never touched. amux observes Codex state for the sidebar but does not intercept approvals or drive the model.
+
+Codex on Windows is not wired up yet. The wrapper needs a symlinked `CODEX_HOME` overlay, which requires [Windows Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) (or admin) to create symlinks. Until that's wired, `codex` on Windows runs passthrough — you get a working Codex session, just without sidebar status or tool indicators. Claude Code and Gemini CLI are unaffected on Windows.
+
+### Any other agent
+
+amux injects `AMUX_WORKSPACE_ID`, `AMUX_SURFACE_ID`, and `AMUX_SOCKET_PATH` into every pane. Any script can report state back:
+
+```bash
+amux set-status active "Running evaluations..."
+amux set-status idle
+amux notify "Tests passed"
+```
+
+OSC 9 / 99 / 777 sequences on the PTY stream also surface as in-app notifications without a CLI call.
 
 ## tmux Compatibility
 
-Agent scripts written for tmux work with amux via the built-in shim:
-
 ```bash
-# Install the shim so `tmux` calls route to amux
-amux install-tmux-shim
-```
-
-Or call directly:
-```bash
+amux install-tmux-shim                              # route `tmux` calls to amux
 amux __tmux-compat new-session -s myproject
 amux __tmux-compat send-keys -t myproject "claude" Enter
 ```
@@ -237,30 +176,23 @@ Full reference: `amux help`.
 
 ## Session Restore
 
-On relaunch, amux restores:
-- Window, workspace, and pane layout
-- Working directories
-- Terminal scrollback (up to 4,000 lines per surface, best-effort)
-- Agent status pills and notification history
-
-amux does **not** restore live process state (active Claude Code / Gemini / Codex sessions are not resumed after restart).
+On relaunch amux restores window, workspace, and pane layout; working directories; terminal scrollback (up to 4,000 lines per surface, best-effort); status pills; and notification history. Live agent process state is **not** restored — Claude, Gemini, and Codex sessions have to be restarted manually after an amux restart.
 
 ## Configuration
 
-Config lives at `~/.config/amux/config.toml` (or `%APPDATA%\amux\config.toml` on Windows):
+Config lives at `~/.config/amux/config.toml` on Unix and `%APPDATA%\amux\config.toml` on Windows. Every section and key is optional.
 
 ```toml
-# Shell to spawn in new panes. Accepts a bare name ("pwsh", "bash", "fish")
-# that amux resolves against PATH, or an absolute path.
-# When unset, amux uses $SHELL on Unix and prefers pwsh.exe on Windows if
-# installed, otherwise falls back to $COMSPEC (cmd.exe).
+# Shell to spawn in new panes. Bare name ("pwsh", "bash", "fish") is
+# resolved against PATH, or an absolute path. Defaults to $SHELL on Unix
+# and prefers pwsh.exe on Windows, falling back to $COMSPEC (cmd.exe).
 # shell = "pwsh"
 
 [appearance]
 sidebar_width = 220
-font_family = "JetBrains Mono"
-font_size = 13.0
-theme = "dark"            # dark | light | system
+font_family = "IBM Plex Mono"
+font_size = 14.0
+theme = "dark"             # dark | light | system
 
 [notifications]
 sound = true
@@ -269,34 +201,30 @@ ring = true
 auto_reorder_workspaces = true
 
 [keybindings]
-new_workspace = "ctrl+n"
-toggle_sidebar = "ctrl+b"
-# ... full list in docs
-
-[agents]
-# Override auto-detection if needed
-# default_agent = "claude"   # claude | gemini | codex
+# Override any default. Use "cmd+…" on macOS or "ctrl+…" on Win/Linux.
+# Full list of actions: see `KeybindingsConfig` in
+# crates/amux-core/src/config.rs.
+new_workspace = "cmd+n"
+toggle_sidebar = "cmd+b"
 ```
 
 ## Building from Source
 
-Requirements: Rust 1.80+, a C compiler, and platform graphics drivers.
-
 ```bash
 git clone https://github.com/daveowenatl/amux
 cd amux
-cargo build --release
-./target/release/amux
+cargo build --workspace
+cargo test --workspace
 ```
 
-On Windows, the MSVC toolchain is required (`rustup default stable-x86_64-pc-windows-msvc`).
+Requirements: Rust 1.80+, a C compiler, platform graphics drivers. Windows needs the MSVC toolchain. Before pushing, run `cargo fmt --check` and `cargo clippy --workspace -- -D warnings`; CI enforces both.
 
 ## Contributing
 
-- Open [GitHub Issues](https://github.com/daveowenatl/amux/issues) for bugs and feature requests
-- Start a [Discussion](https://github.com/daveowenatl/amux/discussions) for questions and ideas
-- PRs welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md)
+- Bugs and feature requests: [GitHub Issues](https://github.com/daveowenatl/amux/issues)
+- Questions and ideas: [Discussions](https://github.com/daveowenatl/amux/discussions)
+- PRs welcome.
 
 ## License
 
-MIT — see [LICENSE](./LICENSE) for the full text.
+MIT. See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ amux is a terminal multiplexer for AI coding agents (Claude Code, Gemini CLI, Co
 
 - Runs Claude Code, Gemini CLI, and Codex CLI in panes. A blue ring appears on any pane whose agent needs input.
 - Sidebar shows per-workspace status: which agent is active, which tool it's running, which pane is waiting on you.
-- Hook integration is auto-injected. No `install-hooks` step. Your `~/.claude/settings.json`, `~/.gemini/settings.json`, and `~/.codex/` are not touched.
+- Hook integration is auto-injected. No `install-hooks` step. amux does not add persistent hook entries to `~/.claude/settings.json`, `~/.gemini/settings.json`, or `~/.codex/`. (Older installs get a one-time startup cleanup that removes legacy amux hook entries left in `~/.claude/settings.json` by earlier versions — a migration, not ongoing writes.)
 - Workspaces, horizontal and vertical splits, surface tabs within a workspace.
 - GPU-rendered via wgpu (Metal / DX12 / Vulkan) backed by [libghostty-vt](https://github.com/uzaaft/libghostty-rs) for the VT state machine.
 - CLI and Unix / named-pipe socket for driving it from scripts. tmux-compat shim so agent scripts calling `tmux` route to amux.
@@ -42,15 +42,16 @@ Extract and put the contents on your `PATH`. Each archive contains:
 ```bash
 git clone https://github.com/daveowenatl/amux
 cd amux
-cargo build --release
-./target/release/amux-app
+cargo run -p amux-app --release
 ```
+
+`cargo run -p amux-app --release` builds and launches the GUI in one step and works on every platform without hard-coding the binary path.
 
 Requirements: Rust 1.80+, a C compiler, and platform graphics drivers. Windows needs the MSVC toolchain (`rustup default stable-x86_64-pc-windows-msvc`). Homebrew / Winget / `cargo install amux` are not set up yet — build from source or use the release archive.
 
 ## Keyboard Shortcuts
 
-Defaults differ between macOS and Windows/Linux. On Windows/Linux, workspace / tab / edit operations use `Ctrl+Shift` instead of bare `Ctrl` so the terminal's own `Ctrl+C` (SIGINT), `Ctrl+N`, `Ctrl+W`, `Ctrl+S` (XOFF), etc. still reach the shell. Every binding is overridable in `config.toml` under `[keybindings]`.
+Defaults differ between macOS and Windows/Linux. On Windows/Linux, most workspace, tab, and edit operations use `Ctrl+Shift` instead of bare `Ctrl` so the terminal's own `Ctrl+C` (SIGINT), `Ctrl+N`, `Ctrl+T`, `Ctrl+S` (XOFF), etc. still reach the shell. `Ctrl+W` is the exception — amux claims it as the close-pane binding on non-macOS (shells tend not to rely on it). Every binding is overridable in `config.toml` under `[keybindings]`.
 
 ### Workspaces
 
@@ -68,7 +69,7 @@ Defaults differ between macOS and Windows/Linux. On Windows/Linux, workspace / t
 | Action | macOS | Windows / Linux |
 |---|---|---|
 | New tab | `Cmd+T` | `Ctrl+Shift+T` |
-| Close tab | `Cmd+W` | `Ctrl+Shift+W` |
+| Close tab | `Cmd+W` | `Ctrl+W` |
 | New browser tab | `Cmd+Shift+L` | `Ctrl+Shift+L` |
 | Next tab in focused pane | `Ctrl+Tab` | `Ctrl+Tab` |
 | Previous tab in focused pane | `Ctrl+Shift+Tab` | `Ctrl+Shift+Tab` |
@@ -113,13 +114,20 @@ Defaults differ between macOS and Windows/Linux. On Windows/Linux, workspace / t
 | Save session | `Cmd+S` | `Ctrl+Shift+S` |
 | Open dev tools | `Cmd+Alt+I` | `Ctrl+Shift+I` |
 
+### Platform caveats
+
+A few actions are fired through the native menu bar rather than the configurable keybinding handler. That matters because:
+
+- **Linux has no menu bar yet.** The GTK menu bar is not wired up (`muda` supports it but eframe doesn't yet expose the `GtkWindow`). So `Cmd`/`Ctrl+=`, `Ctrl+-`, `Ctrl+0` (font zoom) and `Cmd`/`Ctrl+Shift+S` (save session) currently don't fire on Linux. Track `crates/amux-app/src/menu_bar.rs`.
+- **`Open dev tools` on Windows.** `Ctrl+Shift+I` is bound both to `Action::DevTools` in the keybinding handler and to "Toggle Notifications" in the Windows native menu bar. The menu bar consumes the key event first, so on Windows this combo opens the notification panel instead of the dev tools. macOS and Linux are unaffected. A fix is tracked as a code-level follow-up.
+
 ## Agent Integration
 
 amux detects which agent is running in a pane by `argv[0]` and wires its hook events into the sidebar. Wrappers are installed to `~/.config/amux/bin/` and that directory is prepended to `PATH` for every pane, so launching `claude`, `gemini`, or `codex` inside amux finds the wrapper first. The wrapper injects hooks for the current session and execs the real agent binary.
 
 ### Claude Code
 
-All 9 hook events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStart`, `SubagentStop`, `SessionEnd`. Hooks are injected via `--settings` at launch; nothing is persisted to `~/.claude/`.
+All 9 hook events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStart`, `SubagentStop`, `SessionEnd`. Hooks are injected via `--settings` at launch; amux does not add persistent hook entries to `~/.claude/settings.json`. Startup may perform a one-time migration that removes legacy amux hook entries left there by older installs.
 
 ### Gemini CLI
 
@@ -201,23 +209,33 @@ ring = true
 auto_reorder_workspaces = true
 
 [keybindings]
-# Override any default. Use "cmd+…" on macOS or "ctrl+…" on Win/Linux.
+# Override any default. On non-macOS the parser treats `cmd` as `ctrl`,
+# so mac-style combos aren't safe to copy verbatim — a bare `ctrl+n`
+# would collide with the terminal's own Ctrl+N.
 # Full list of actions: see `KeybindingsConfig` in
 # crates/amux-core/src/config.rs.
-new_workspace = "cmd+n"
-toggle_sidebar = "cmd+b"
+#
+# macOS:
+# new_workspace = "cmd+n"
+# toggle_sidebar = "cmd+b"
+#
+# Windows / Linux (these ARE the defaults — shown for reference):
+# new_workspace = "ctrl+shift+n"
+# toggle_sidebar = "ctrl+b"
 ```
 
 ## Building from Source
 
+For contributors. The [From source](#from-source) section above covers the quick-start path for *using* amux; this section covers the workspace-wide commands you'll want when *developing* it.
+
 ```bash
-git clone https://github.com/daveowenatl/amux
-cd amux
 cargo build --workspace
 cargo test --workspace
+cargo fmt --check
+cargo clippy --workspace -- -D warnings
 ```
 
-Requirements: Rust 1.80+, a C compiler, platform graphics drivers. Windows needs the MSVC toolchain. Before pushing, run `cargo fmt --check` and `cargo clippy --workspace -- -D warnings`; CI enforces both.
+Requirements: Rust 1.80+, a C compiler, platform graphics drivers. Windows needs the MSVC toolchain. CI enforces `fmt --check` and `clippy -D warnings` on every PR — run both before pushing.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ amux is a terminal multiplexer for AI coding agents (Claude Code, Gemini CLI, Co
 - Sidebar shows per-workspace status: which agent is active, which tool it's running, which pane is waiting on you.
 - Hook integration is auto-injected. No `install-hooks` step. Your `~/.claude/settings.json`, `~/.gemini/settings.json`, and `~/.codex/` are not touched.
 - Workspaces, horizontal and vertical splits, surface tabs within a workspace.
-- GPU-rendered via wgpu (Metal / DX12 / Vulkan) backed by wezterm-term for the VT state machine.
+- GPU-rendered via wgpu (Metal / DX12 / Vulkan) backed by [libghostty-vt](https://github.com/uzaaft/libghostty-rs) for the VT state machine.
 - CLI and Unix / named-pipe socket for driving it from scripts. tmux-compat shim so agent scripts calling `tmux` route to amux.
 
 ## Install

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -5,8 +5,6 @@
 //! input handling, sidebar, tab-bar, panes, modals, notifications,
 //! and repaint scheduling) and `on_exit()` which saves or clears the
 //! session.
-//!
-//! Top-level per-frame entry that dispatches to per-concern helpers.
 
 use crate::*;
 

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -6,8 +6,7 @@
 //! and repaint scheduling) and `on_exit()` which saves or clears the
 //! session.
 //!
-//! Mirrors wezterm-gui's `termwindow/render/paint.rs` — the top-level
-//! per-frame entry that dispatches to per-concern helpers.
+//! Top-level per-frame entry that dispatches to per-concern helpers.
 
 use crate::*;
 

--- a/crates/amux-app/src/layout_ops.rs
+++ b/crates/amux-app/src/layout_ops.rs
@@ -1,8 +1,6 @@
 //! Pane layout operations: PTY resize when a pane's rect changes, and
-//! interactive divider dragging to resize splits.
-//!
-//! Split rendering and resize handling are grouped in one module because
-//! both operate on the `PaneTree` layout.
+//! interactive divider dragging to resize splits. Both live in this
+//! module because both operate on the `PaneTree` layout.
 
 use crate::*;
 

--- a/crates/amux-app/src/layout_ops.rs
+++ b/crates/amux-app/src/layout_ops.rs
@@ -1,8 +1,8 @@
 //! Pane layout operations: PTY resize when a pane's rect changes, and
 //! interactive divider dragging to resize splits.
 //!
-//! Mirrors wezterm-gui's `termwindow/render/split.rs` and `resize.rs`
-//! (grouped here because both operate on the PaneTree layout).
+//! Split rendering and resize handling are grouped in one module because
+//! both operate on the `PaneTree` layout.
 
 use crate::*;
 

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -4,8 +4,6 @@
 //! content rendering to either the GPU or software renderer. Handles
 //! tab interactions: click to activate, middle-click to close, right-click
 //! context menu, drag to reorder, and the trailing "+" to add a surface.
-//!
-//! Per-pane renderer: emits tab chrome and the terminal content call.
 
 use crate::*;
 

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -5,8 +5,7 @@
 //! tab interactions: click to activate, middle-click to close, right-click
 //! context menu, drag to reorder, and the trailing "+" to add a surface.
 //!
-//! Mirrors wezterm-gui's `termwindow/render/pane.rs` — the per-pane
-//! renderer that emits tab chrome plus the terminal content call.
+//! Per-pane renderer: emits tab chrome and the terminal content call.
 
 use crate::*;
 

--- a/crates/amux-render-gpu/src/callback.rs
+++ b/crates/amux-render-gpu/src/callback.rs
@@ -3,7 +3,7 @@
 //! This struct carries the terminal snapshot and physical rect for a single
 //! pane into egui's render pass. The `CallbackTrait` implementation that
 //! actually walks the snapshot, shapes glyphs, and emits GPU instances lives
-//! in `screen_line.rs` (modeled on wezterm-gui's `termwindow/render/`).
+//! in `screen_line.rs`.
 
 use crate::snapshot::TerminalSnapshot;
 use crate::state::PhysRect;

--- a/crates/amux-render-gpu/src/custom_glyphs.rs
+++ b/crates/amux-render-gpu/src/custom_glyphs.rs
@@ -5,9 +5,6 @@
 //! rectangles in normalized cell coordinates (0.0–1.0). The GPU callback
 //! emits these as foreground-colored background quads, producing pixel-perfect
 //! lines that connect seamlessly across adjacent cells.
-//!
-//! This matches the approach used by wezterm and Ghostty, both of which render
-//! these characters procedurally rather than from fonts.
 
 /// A filled rectangle in normalized cell coordinates.
 /// (0.0, 0.0) is the top-left corner; (1.0, 1.0) is the bottom-right.

--- a/crates/amux-render-gpu/src/quad.rs
+++ b/crates/amux-render-gpu/src/quad.rs
@@ -2,9 +2,8 @@
 //!
 //! The three `*Instance` structs below are the per-cell (or per-glyph / per-image)
 //! records uploaded into the instance buffers consumed by the background,
-//! foreground, and image render pipelines. Modeled on wezterm-gui's `quad.rs`,
-//! which similarly separates instance/vertex type definitions from pipeline
-//! construction.
+//! foreground, and image render pipelines. Instance / vertex type definitions
+//! live here; pipeline construction lives in the pipelines module.
 //!
 //! `ensure_instance_buffer` is a shared helper for creating or growing an
 //! instance buffer when the number of instances exceeds the current capacity.

--- a/crates/amux-render-gpu/src/quad.rs
+++ b/crates/amux-render-gpu/src/quad.rs
@@ -2,8 +2,8 @@
 //!
 //! The three `*Instance` structs below are the per-cell (or per-glyph / per-image)
 //! records uploaded into the instance buffers consumed by the background,
-//! foreground, and image render pipelines. Instance / vertex type definitions
-//! live here; pipeline construction lives in the pipelines module.
+//! foreground, and image render pipelines. Instance and vertex type
+//! definitions live here; pipeline construction lives in `pipeline.rs`.
 //!
 //! `ensure_instance_buffer` is a shared helper for creating or growing an
 //! instance buffer when the number of instances exceeds the current capacity.

--- a/crates/amux-render-gpu/src/screen_line.rs
+++ b/crates/amux-render-gpu/src/screen_line.rs
@@ -4,8 +4,7 @@
 //! `TerminalPaintCallback` — the large `prepare()` method that walks
 //! the `TerminalSnapshot`, builds text runs, shapes them via cosmic-text,
 //! emits background/foreground/image instances, rasterizes decorations,
-//! and uploads the per-pane instance buffers. Modeled on wezterm-gui's
-//! `termwindow/render/screen_line.rs`.
+//! and uploads the per-pane instance buffers.
 //!
 //! The `paint()` method (draw call submission) also lives here; it is
 //! trivially small but must be part of the same `impl` block.


### PR DESCRIPTION
Closes #184.

## What changed

### Intro (first ~10 lines)
- States the cmux origin plainly. amux is a clone of [cmux](https://github.com/manaflow-ai/cmux) rebuilt in Rust for Windows and Linux; the sidebar and notification-ring UI is cmux's design.
- States MVP status plainly. Pre-1.0. APIs move. Windows newest / least tested. Codex-on-Windows not wired up yet.

### Deletions
- **\"The Zen of amux\"** — gone entirely.
- **\"Why amux?\"** monologue — gone. Replaced by the two-sentence intro.
- **Per-feature marketing blurbs** under \"Features\" — collapsed into one short bullet list under \"What it does\".
- **Fake install channels** — Homebrew tap, \`cargo install amux\`, Winget. None of those are set up; MVP honesty.

### Keybindings — the big fix

The old keybinding tables had substantial drift from the actual defaults in \`crates/amux-core/src/config.rs\` (\`KeybindingsConfig::platform_defaults\`) and \`crates/amux-app/src/menu_bar.rs\` (\`build()\` accelerators). I audited every row against both.

**Fabricated bindings that don't exist in code** (removed):
- \`Ctrl Shift R\` → Rename workspace
- \`Ctrl Shift H\` → Flash focused pane
- \`Ctrl G\` / \`Ctrl Shift G\` → Find next / previous
- \`Ctrl Shift F\` → Hide find bar
- \`Ctrl E\` → Use selection for find
- \`Ctrl ,\` → Settings
- \`Ctrl Shift ,\` → Reload configuration
- \`Ctrl Shift N\` → \"New window\" *(this was actually \"new workspace\" on Win/Linux, mislabeled)*

**Wrong for Windows/Linux** (the old README assumed a simple Ctrl→Cmd swap, but non-mac deliberately uses \`Ctrl+Shift\` for workspace / tab / edit ops so the terminal's own \`Ctrl+C\` (SIGINT), \`Ctrl+N\`, \`Ctrl+W\`, \`Ctrl+S\` (XOFF), \`Ctrl+T\` still reach the shell):
- New workspace: Win/Linux is \`Ctrl+Shift+N\`, not \`Ctrl+N\`
- New tab: \`Ctrl+Shift+T\`
- Close tab: \`Ctrl+Shift+W\`
- Copy / Paste / Select All: all \`Ctrl+Shift+…\`
- Clear scrollback: \`Ctrl+Shift+K\`
- Save session: \`Ctrl+Shift+S\`

**Missing from the old README but actually real:**
- New browser tab (\`Cmd/Ctrl+Shift+L\`)
- Scrollback / copy mode (\`…+Shift+X\`)
- Save session
- Zoom focused pane (\`…+Shift+Enter\`)
- Open dev tools

**Same binding, two labels:** \`Ctrl+Shift+]\` / \`Ctrl+Shift+[\` was listed for both \"next workspace\" and \"next surface\". Surface/tab nav within a pane is actually \`Ctrl+Tab\` / \`Ctrl+Shift+Tab\`; the bracket shortcut is always workspace nav.

**Structural change:** the new tables are split into two columns (macOS / Windows+Linux) instead of one \"Ctrl column plus 'maps to Cmd on macOS' caption\" — the platform asymmetry is too significant to hide in a footnote.

### Kept and tightened
- Install (GitHub Releases + From source only)
- Agent Integration (Claude / Gemini / Codex + \"Any other agent\" — condensed)
- tmux Compatibility
- CLI Reference
- Session Restore
- Configuration
- Building from Source
- Contributing / License

## Size

| | Lines |
|---|---|
| Before | 302 |
| After  | 230 |
| Net    | **-72** (110 ins / 182 del) |

Shorter overall even though the keybinding tables got *bigger* (two platform columns, more rows) — the savings come entirely from deleted marketing prose.

## Acceptance check

- [x] Shorter than the current version (302 → 230)
- [x] No \"Zen of amux\" section
- [x] cmux origin acknowledged in the first ~10 lines (line 3)
- [x] MVP status acknowledged in the first ~10 lines (line 5)
- [x] Keyboard reference tables still present and verified against current defaults
- [x] Tone: read it out loud — no VC-pitch sentences, no \"first-class\", no \"beautifully\", no \"composable primitives\", no \"from day one\", no \"not X, not Y\" constructions, em dashes used sparingly

## Out of scope (per the issue)
- No code changes, no new features.
- No CONTRIBUTING.md or ARCHITECTURE.md rewrites.
- No screenshots / GIFs.

## Follow-ups surfaced while auditing

During the keybinding audit I noticed a latent conflict between \`crates/amux-core/src/config.rs\` (\`DevTools = ctrl+shift+i\`, \`NotificationPanel = ctrl+i\` on non-mac) and \`crates/amux-app/src/menu_bar.rs\` (which maps \"Toggle Notifications\" to \`Ctrl+Shift+I\` on non-mac, same combo as DevTools). Both handlers may fire depending on event ordering. Out of scope for this README change, but worth a separate issue — I'll file one if you don't already have it tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build and installation instructions to reflect current workspace structure.
  * Revised configuration examples and default values for clarity.
  * Condensed feature overview and agent integration documentation for easier onboarding.
  * Clarified platform-specific behaviors and limitations (e.g., Windows support status).
  * Refreshed module-level documentation throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->