### PR TITLE
Fix cosmic-text wrap dropping trailing glyphs in text runs

### DIFF
--- a/crates/amux-core/src/shell.rs
+++ b/crates/amux-core/src/shell.rs
@@ -416,6 +416,19 @@ mod tests {
     fn resolve_shell_ignores_empty_or_whitespace_override() {
         // `shell = ""` or `shell = "   "` in config.toml falls back to
         // default_shell() — we don't want to spawn an empty command.
+        //
+        // On Windows this test must hold `WINDOWS_PATH_TEST_LOCK` because
+        // `default_shell()` reads `PATH` (via `find_on_path("pwsh.exe")`),
+        // and the `windows_find_on_path_*` tests in this module mutate
+        // `PATH` via `EnvGuard`. Without the lock, a concurrent mutation
+        // can cause `resolve_shell` and `default_shell` to observe
+        // different `PATH` values mid-assertion and return cmd.exe vs
+        // pwsh.exe non-deterministically. See #187 CI run where this
+        // race finally tripped.
+        #[cfg(windows)]
+        let _guard = WINDOWS_PATH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let fallback = default_shell();
         assert_eq!(resolve_shell(Some("")), fallback);
         assert_eq!(resolve_shell(Some("   ")), fallback);
@@ -423,6 +436,12 @@ mod tests {
 
     #[test]
     fn resolve_shell_none_falls_back_to_default() {
+        // Same Windows PATH race fix as
+        // `resolve_shell_ignores_empty_or_whitespace_override`.
+        #[cfg(windows)]
+        let _guard = WINDOWS_PATH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         assert_eq!(resolve_shell(None), default_shell());
     }
 

--- a/crates/amux-render-gpu/src/shape.rs
+++ b/crates/amux-render-gpu/src/shape.rs
@@ -98,11 +98,28 @@ pub(crate) fn shape_run(
         resources.metrics.font_size * pixels_per_point,
         resources.metrics.line_height * pixels_per_point,
     );
-    let buffer_width = f32::max(run.col_count as f32 * cell_width, cell_width * 2.0);
+    // `None` for width disables cosmic-text's word wrapping entirely: the
+    // whole run is laid out on a single line regardless of its shaped width.
+    //
+    // An earlier version of this code passed `Some(run.col_count * cell_width)`
+    // (plus a 2-cell minimum) as the buffer width. That was subtly wrong —
+    // if HarfBuzz's shaped advance for the run exceeded that width by even a
+    // fraction of a pixel (kerning, contextual shaping, fallback-font metrics
+    // on Windows, sub-pixel accumulation), cosmic-text would wrap the
+    // trailing character to a second visual line. The glyph loop below then
+    // positioned wrapped glyphs at `base_y + layout_run.line_y + physical.y`,
+    // placing them one terminal row below their intended column and leaving
+    // a blank cell behind. See amux #186 — manifested as random trailing
+    // characters dropping from `dir` output, git log, Claude Code banners,
+    // etc. on Windows.
+    //
+    // A run is always exactly one terminal row by construction (the
+    // run-builder in `screen_line.rs` breaks runs on row changes), so
+    // wrapping is never the right behavior here.
     let mut buffer = Buffer::new_empty(phys_metrics);
     {
         let mut borrowed = buffer.borrow_with(&mut resources.font_system);
-        borrowed.set_size(Some(buffer_width), Some(cell_height));
+        borrowed.set_size(None, Some(cell_height));
         borrowed.set_text(&run.text, attrs, Shaping::Advanced);
         borrowed.shape_until_scroll(true);
     }
@@ -110,6 +127,18 @@ pub(crate) fn shape_run(
     let mut shaped_entries = Vec::new();
 
     for layout_run in buffer.layout_runs() {
+        // Defense in depth: even with `set_size(None, ..)`, if cosmic-text
+        // somehow produces a second layout line (future regression, font
+        // quirk, whatever), skip it loudly rather than silently drawing
+        // glyphs at the wrong row.
+        if layout_run.line_i != 0 {
+            tracing::warn!(
+                "shape_run: unexpected wrapped layout line {} for run {:?} — skipping",
+                layout_run.line_i,
+                run.text
+            );
+            continue;
+        }
         for glyph in layout_run.glyphs.iter() {
             let physical = glyph.physical((0.0, 0.0), 1.0);
 
@@ -247,10 +276,16 @@ pub(crate) fn shape_and_rasterize(
         resources.metrics.font_size * pixels_per_point,
         resources.metrics.line_height * pixels_per_point,
     );
+    // See `shape_run` for the full explanation of why this is `None`.
+    // Short version: we never want cosmic-text to wrap our single-cell
+    // text to a second line, and passing a finite width here opens the
+    // door to the same wrap-at-sub-pixel-overflow bug that dropped
+    // trailing characters on Windows in amux #186.
+    let _ = cell_width; // still used by callers for positioning, kept in sig
     let mut buffer = Buffer::new_empty(phys_metrics);
     {
         let mut borrowed = buffer.borrow_with(&mut resources.font_system);
-        borrowed.set_size(Some(cell_width * 2.0), Some(cell_height));
+        borrowed.set_size(None, Some(cell_height));
         borrowed.set_text(text, attrs, Shaping::Advanced);
         borrowed.shape_until_scroll(true);
     }
@@ -258,6 +293,14 @@ pub(crate) fn shape_and_rasterize(
     let mut shaped_entries = Vec::new();
 
     for run in buffer.layout_runs() {
+        if run.line_i != 0 {
+            tracing::warn!(
+                "shape_and_rasterize: unexpected wrapped layout line {} for text {:?} — skipping",
+                run.line_i,
+                text
+            );
+            continue;
+        }
         for glyph in run.glyphs.iter() {
             let physical = glyph.physical((0.0, 0.0), 1.0);
 


### PR DESCRIPTION
## Summary

Fixes Windows terminal rendering bug where `amux-app.exe` was silently dropping random trailing characters from `dir`, Claude Code banner output, git log tool output, and cmd.exe's startup banner. Grid cell data was always correct (confirmed via copy-paste); the bug lived in the GPU render path.

Refs #186

## Root cause

\`shape_run\` in \`shape.rs\` was passing a finite buffer width to cosmic-text's \`Buffer::set_size\`:

\`\`\`rust
let buffer_width = f32::max(run.col_count as f32 * cell_width, cell_width * 2.0);
borrowed.set_size(Some(buffer_width), Some(cell_height));
\`\`\`

When HarfBuzz's shaped advance width for the run edged over \`buffer_width\` by even a fraction of a pixel — kerning, contextual shaping, fallback-font metric mismatch on Windows, sub-pixel drift — cosmic-text would wrap the trailing character to a second visual line. \`buffer.layout_runs()\` then yielded two \`LayoutRun\`s, and the glyph loop positioned wrapped glyphs at \`base_y + layout_run.line_y + physical.y\`, placing them one terminal row below their intended column. The intended cell stayed blank; a stray glyph floated one row down. Visually: \`Windows\` → \`Window \`.

## Fix

Pass \`None\` for buffer width. That disables cosmic-text's wrap-on-width behavior entirely, which is what we want — a run is always exactly one terminal row by construction (the run builder in \`screen_line.rs\` breaks runs on row changes), so wrapping was never the right behavior in this code path.

Also added a defensive \`line_i != 0\` skip + \`tracing::warn!\` so a future regression or weird font quirk surfaces loudly instead of silently dropping glyphs.

Applied the same fix to \`shape_and_rasterize\` (cursor overlay path) for consistency.

## Why it manifested on Windows specifically

Not strictly Windows-only in theory — any fractional-pixel overflow triggers it. In practice, the Windows font stack (fallback resolution through fontdb → cosmic-text), the DPI scaling path, and the x64-on-ARM64 emulation float-point behavior combine to hit the race far more often than macOS or Linux. Users on macOS probably saw rare drops too and shrugged them off as \"weird fonts.\"

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -p amux-render-gpu -- -D warnings\` clean
- [x] \`cargo test -p amux-render-gpu\` passes
- [ ] CI green on all 3 platforms
- [ ] Re-trigger release workflow, download new Windows artifact, run on ARM64 Windows 11 VM
- [ ] Confirm \`dir\` output no longer drops trailing characters
- [ ] Confirm Claude Code banner renders \`Claude\` (not \`Claud\`) and git log tool output is intact
- [ ] Confirm cmd.exe startup banner reads \`Microsoft Windows [Version ...]\` and \`All rights reserved.\` with all their \`s\`es

Once VM validation confirms the fix, I'll close #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where text could unexpectedly wrap to extra lines during rendering; wrapped runs are now detected and skipped with a warning to avoid incorrect glyph rendering.
* **Tests**
  * Stabilized Windows shell-resolution tests by serializing environment access to prevent nondeterministic outcomes when tests modify PATH-like variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->