### PR TITLE
Unblock local amux build on ARM64 Windows via uucode cache patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,7 +2665,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libghostty-vt"
 version = "0.1.1"
-source = "git+https://github.com/daveowenatl/libghostty-rs?rev=cabcfb81cc3f4f20ef9b62312df6bb04c929abb5#cabcfb81cc3f4f20ef9b62312df6bb04c929abb5"
+source = "git+https://github.com/daveowenatl/libghostty-rs?rev=2adc1fb03225a970a801a1aa02c1efe8ea168db0#2adc1fb03225a970a801a1aa02c1efe8ea168db0"
 dependencies = [
  "bitflags 2.11.0",
  "int-enum",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "libghostty-vt-sys"
 version = "0.1.1"
-source = "git+https://github.com/daveowenatl/libghostty-rs?rev=cabcfb81cc3f4f20ef9b62312df6bb04c929abb5#cabcfb81cc3f4f20ef9b62312df6bb04c929abb5"
+source = "git+https://github.com/daveowenatl/libghostty-rs?rev=2adc1fb03225a970a801a1aa02c1efe8ea168db0#2adc1fb03225a970a801a1aa02c1efe8ea168db0"
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,18 +104,23 @@ amux-ghostty-config = { path = "crates/amux-ghostty-config" }
 amux-browser = { path = "crates/amux-browser" }
 
 # Patch libghostty-vt and libghostty-vt-sys to a fork that extends the build
-# script's artifact detection to Windows (MSVC + GNU targets). The crates.io
-# release hardcodes `libghostty-vt.so.0.1.0` as the expected shared library
-# filename, which panics on Windows because Zig emits `ghostty-vt.dll` +
-# `ghostty-vt.lib` instead. The fork cherry-picks the two unpublished
-# `feat/windows-ci` commits from upstream on top of upstream/master, with the
-# ghostty commit pinned back to `bebca84` (matching crates.io 0.1.1) to avoid
-# a newer ghostty xcframework build-step regression that breaks macOS.
+# script's artifact detection to Windows (MSVC + GNU targets) AND patches
+# uucode v0.2.0 in the zig global cache to work around its `setCwd(b.path(""))`
+# bug that breaks builds on ARM64 Windows (both native and x86_64-under-
+# emulation). The crates.io release hardcodes `libghostty-vt.so.0.1.0` as the
+# expected shared library filename, which panics on Windows because Zig emits
+# `ghostty-vt.dll` + `ghostty-vt.lib` instead. The fork cherry-picks the two
+# unpublished `feat/windows-ci` commits from upstream on top of
+# upstream/master, with the ghostty commit pinned back to `bebca84` (matching
+# crates.io 0.1.1) to avoid a newer ghostty xcframework build-step regression
+# that breaks macOS, plus a uucode cache-patch commit on top (refs amux #188).
 #
 # Upstream tracking: https://github.com/uzaaft/libghostty-rs branches
 # `feat/windows-ci` + `static-linking`. Plan: open a PR against upstream once
 # amux's Windows CI is green with this patch, then drop the patch block when
-# a new crates.io version ships.
+# a new crates.io version ships. Also: the uucode patch can be dropped
+# entirely once ghostty bumps past uucode 0.2.0 or upstream uucode fixes the
+# `b.path("")` resolution bug.
 [patch.crates-io]
-libghostty-vt = { git = "https://github.com/daveowenatl/libghostty-rs", rev = "cabcfb81cc3f4f20ef9b62312df6bb04c929abb5" }
-libghostty-vt-sys = { git = "https://github.com/daveowenatl/libghostty-rs", rev = "cabcfb81cc3f4f20ef9b62312df6bb04c929abb5" }
+libghostty-vt = { git = "https://github.com/daveowenatl/libghostty-rs", rev = "2adc1fb03225a970a801a1aa02c1efe8ea168db0" }
+libghostty-vt-sys = { git = "https://github.com/daveowenatl/libghostty-rs", rev = "2adc1fb03225a970a801a1aa02c1efe8ea168db0" }


### PR DESCRIPTION
## Summary

Fixes the \`uucode v0.2.0\` zig build bug that blocks \`cargo build\` / \`cargo run -p amux-app\` on ARM64 Windows. After this lands, we can iterate on Windows-specific bugs locally on the VM in ~2 minutes per iteration instead of round-tripping 10+ minutes through CI per attempt.

Closes #188.

## Root cause (quick version, full version in fork commit)

\`uucode/build.zig:464\` has:

\`\`\`zig
const run_build_tables_exe = b.addRunArtifact(build_tables_exe);
run_build_tables_exe.setCwd(b.path(\"\"));
\`\`\`

On native x86_64 Windows (GitHub CI runners) this resolves to the uucode package root and the spawned \`uucode_build_tables\` process sees \`ucd/UnicodeData.txt\` at its CWD. On ARM64 Windows — both native aarch64 zig and x86_64 zig under WoW emulation — \`b.path(\"\")\` resolves to an empty LazyPath that zig's Run step treats as \"don't change cwd,\" and the child inherits the parent zig process's CWD (ghostty build root, not uucode package root). \`parseUnicodeData\` then panics with \`error.FileNotFound\` and the build fails before ghostty's library ever compiles.

Two things we'd already tried that don't help, documented in #188:
- Native aarch64 zig: fails the same way
- x86_64 zig under emulation: fails the same way

## Fix shape

Rather than forking uucode AND ghostty (ghostty pins uucode by hash so a uucode fork alone is useless), we patch uucode in zig's global cache during \`libghostty-vt-sys\`'s \`build.rs\`. The patch rewrites the one problematic line to:

\`\`\`zig
run_build_tables_exe.setCwd(.{ .cwd_relative = b.build_root.path.? }); // patched by libghostty-vt-sys build.rs
\`\`\`

\`b.build_root.path\` is an absolute filesystem path that zig computes deterministically for every package regardless of host OS or CPU architecture. Using \`.cwd_relative\` wraps it as a LazyPath that bypasses the resolution bug entirely.

All the patching logic lives in the libghostty-rs fork's \`patch_uucode_cache\` function — see [\`daveowenatl/libghostty-rs@2adc1fb0\`](https://github.com/daveowenatl/libghostty-rs/commit/2adc1fb03225a970a801a1aa02c1efe8ea168db0). This PR just bumps the fork rev in amux's \`[patch.crates-io]\` block.

### Properties of the patch

- **Idempotent**: checks for a sentinel comment before rewriting
- **Safe**: if the expected source line isn't found (uucode updated upstream, package structure changed), the patch silently skips and lets zig build either succeed or fail loudly as it would without the patch
- **No runtime change**: only touches build-time behavior on hosts where \`b.path(\"\")\` already worked (CI, native x86_64 Linux/Mac/Windows)
- **Removable**: drop the \`patch_uucode_cache\` function entirely when ghostty bumps past uucode 0.2.0 or upstream uucode fixes \`b.path(\"\")\` resolution

## Verification

### Mac (local)
\`\`\`
cargo build -p amux-app   # passes
cargo fmt --check          # clean
cargo clippy --workspace -- -D warnings   # clean
\`\`\`

Confirmed post-build that \`~/.cache/zig/p/uucode-0.2.0-<hash>/build.zig\` line 464 was rewritten:

\`\`\`
run_build_tables_exe.setCwd(.{ .cwd_relative = b.build_root.path.? }); // patched by libghostty-vt-sys build.rs
\`\`\`

### ARM64 Windows VM
Pending — will test as soon as CI is green and the PR is merged. First successful \`cargo run -p amux-app\` on the VM confirms the fix and closes #188.

## Test plan

- [ ] Linux CI green
- [ ] macOS CI green
- [ ] Windows CI green (this tests that the patch doesn't regress the native-x64 build path, which is what CI runs)
- [ ] ARM64 Windows VM: \`cargo run -p amux-app\` succeeds post-merge

## Out of scope (follow-ups)

- \`amux-term/tests/ghostty_integration.rs\` has pre-existing parallel-test flakiness (\`exit_status_reports_failure\` has no polling loop for child exit, \`read_screen_cells_has_content\` can hit pty exhaustion) — separate issue, not a regression of this PR
- Upstream fix to uucode's \`b.path(\"\")\` resolution — would let us drop this patch entirely, but isn't worth chasing until amux's needs stabilize

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated upstream dependencies to latest revisions for enhanced stability.
  * Added workaround to improve ARM64 Windows build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->