### PR TITLE
Pivot uucode workaround: bypass uucode_build_tables via pre-generated tables.zig

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Cargo workspace with 9 crates under `crates/`:
 | `amux-notify` | lib | OSC notification parsing + in-app store |
 | `amux-session` | lib | Session persistence (save/restore JSON) |
 
-Key dependency: `libghostty-vt` is patched to a fork at `github.com/daveowenatl/libghostty-rs` rev `cabcfb81cc3f4f20ef9b62312df6bb04c929abb5`. The fork cherry-picks unpublished fixes for Windows — upstream's `build.rs` hardcodes `libghostty-vt.so.0.1.0` as the expected shared-library filename, which panics on Windows where Zig emits `ghostty-vt.dll` + `ghostty-vt.lib`.
+Key dependency: `libghostty-vt` is patched to a fork at `github.com/daveowenatl/libghostty-rs`. The authoritative rev lives in the workspace `Cargo.toml` `[patch.crates-io]` block — don't reference a specific rev in this doc, it will drift. The fork carries Windows-specific fixes not yet upstreamed: (1) the artifact-detection patches (upstream hardcodes `libghostty-vt.so.0.1.0` as the expected shared-library filename, which panics on Windows where Zig emits `ghostty-vt.dll` + `ghostty-vt.lib`), and (2) a uucode v0.2.0 workaround that bypasses `uucode_build_tables` via a pre-generated `tables.zig` committed to the fork (avoids a runtime-CWD bug in uucode's build.zig that breaks ARM64 Windows builds — see amux #188). Both workarounds should be dropped when upstream libghostty-rs ships a new crates.io version and/or ghostty bumps past uucode 0.2.0.
 
 ## Architecture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,7 +2665,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libghostty-vt"
 version = "0.1.1"
-source = "git+https://github.com/daveowenatl/libghostty-rs?rev=2adc1fb03225a970a801a1aa02c1efe8ea168db0#2adc1fb03225a970a801a1aa02c1efe8ea168db0"
+source = "git+https://github.com/daveowenatl/libghostty-rs?rev=6153355ae9ca440a933477614e38bdc324ab4d0d#6153355ae9ca440a933477614e38bdc324ab4d0d"
 dependencies = [
  "bitflags 2.11.0",
  "int-enum",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "libghostty-vt-sys"
 version = "0.1.1"
-source = "git+https://github.com/daveowenatl/libghostty-rs?rev=2adc1fb03225a970a801a1aa02c1efe8ea168db0#2adc1fb03225a970a801a1aa02c1efe8ea168db0"
+source = "git+https://github.com/daveowenatl/libghostty-rs?rev=6153355ae9ca440a933477614e38bdc324ab4d0d#6153355ae9ca440a933477614e38bdc324ab4d0d"
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,5 +122,5 @@ amux-browser = { path = "crates/amux-browser" }
 # entirely once ghostty bumps past uucode 0.2.0 or upstream uucode fixes the
 # `b.path("")` resolution bug.
 [patch.crates-io]
-libghostty-vt = { git = "https://github.com/daveowenatl/libghostty-rs", rev = "2adc1fb03225a970a801a1aa02c1efe8ea168db0" }
-libghostty-vt-sys = { git = "https://github.com/daveowenatl/libghostty-rs", rev = "2adc1fb03225a970a801a1aa02c1efe8ea168db0" }
+libghostty-vt = { git = "https://github.com/daveowenatl/libghostty-rs", rev = "6153355ae9ca440a933477614e38bdc324ab4d0d" }
+libghostty-vt-sys = { git = "https://github.com/daveowenatl/libghostty-rs", rev = "6153355ae9ca440a933477614e38bdc324ab4d0d" }


### PR DESCRIPTION
## Summary

PR #192 tried to fix the ARM64 Windows build by rewriting uucode's \`setCwd(b.path(\"\"))\` to \`setCwd(.{ .cwd_relative = b.build_root.path.? })\`. The patch successfully wrote to the cached uucode \`build.zig\` on the VM, but the resulting build still failed with \`error.FileNotFound\` from \`parseUnicodeData\` — either because \`b.build_root.path.?\` doesn't resolve to the uucode package root in that build context, or because zig's Run step ignores the rewritten cwd on that host.

This PR bumps the libghostty-rs fork to a new rev that sidesteps the problem entirely: instead of trying to fix \`uucode_build_tables\`'s CWD, it bypasses the run step altogether and substitutes a pre-generated \`tables.zig\`.

Refs #188.

## Why bypass works

\`tables.zig\` (the file that \`uucode_build_tables\` generates) is a pure function of ghostty's pinned uucode config. Since \`GHOSTTY_COMMIT\` is fixed at \`bebca84\` in libghostty-vt-sys's \`build.rs\`, the generated \`tables.zig\` is also fixed — a different ghostty would mean a different config, but we pin ghostty.

The libghostty-rs fork now:

1. Ships \`resources/uucode-v0.2.0-tables.zig\` (168 KB, captured from a clean Mac build against the same \`GHOSTTY_COMMIT\`)
2. At build time, writes that committed file to \`<uucode_pkg_dir>/tables.zig\`
3. Patches \`<uucode_pkg_dir>/build.zig\` so \`tables_path\` points at \`b.path(\"tables.zig\")\` instead of the run step's output
4. Marks \`run_build_tables_exe\` as explicitly unused via \`_ =\`

The build graph never pulls on the run step, zig never spawns the broken child exe, and the CWD-resolution bug becomes moot regardless of host OS, CPU arch, or zig runtime path behavior.

## What's different from #192

| | #192 | This PR |
|---|---|---|
| Target of patch | uucode \`build.zig\` setCwd only | uucode \`build.zig\` + committed \`tables.zig\` |
| Does uucode_build_tables run? | Yes — and fails on ARM64 Windows | No — bypassed entirely |
| Requires CWD plumbing to work | Yes | No |
| New file in libghostty-rs fork | None | \`crates/libghostty-vt-sys/resources/uucode-v0.2.0-tables.zig\` |
| Maintenance when ghostty bumps | None | Regenerate committed \`tables.zig\` |

## Regenerating the committed tables.zig

Only needed when \`GHOSTTY_COMMIT\` is bumped (since ghostty controls the uucode config). Steps are documented in the \`UUCODE_TABLES_ZIG\` doc comment inside libghostty-vt-sys's \`build.rs\` on the fork:

1. Revert \`patch_uucode_cache\` to a no-op temporarily
2. \`rm -rf ~/.cache/zig/p/uucode-0.2.0-*\`
3. \`cargo build\` on a working host (any x86_64 Mac/Linux/native-x64-Windows)
4. \`find target -name tables.zig -path '*libghostty-vt-sys*'\`
5. Copy the first hit over \`resources/uucode-v0.2.0-tables.zig\`
6. Re-enable \`patch_uucode_cache\`

## Test plan

- [x] \`cargo build -p amux-app\` on macOS  — passes
- [x] \`cargo fmt --check\`  — clean
- [x] \`cargo clippy --workspace -- -D warnings\`  — clean
- [x] \`cargo test --workspace\`  — passes (with pre-existing \`exit_status_reports_failure\` parallel-test flake that's unrelated)
- [x] Post-build verification of cached uucode state:
    - \`tables.zig\` at uucode package root (committed bytes match)
    - \`build.zig\` line 464 rewritten to \`_ = run_build_tables_exe; // patched by libghostty-vt-sys build.rs @bypass v3\`
    - \`build.zig\` line 465 rewritten to \`const tables_path = b.path(\"tables.zig\");\`
    - \`Ucd.zig\` is pristine (the broken runtime CWD plumbing is no longer reachable)
- [ ] CI: Linux / macOS / Windows green
- [ ] ARM64 Windows VM: \`cargo run -p amux-app\` succeeds post-merge — closes #188

## Fork changes

In [daveowenatl/libghostty-rs commit 6153355](https://github.com/daveowenatl/libghostty-rs/commit/6153355ae9ca440a933477614e38bdc324ab4d0d):
- \`crates/libghostty-vt-sys/build.rs\`: rewrite \`patch_uucode_cache\`
- \`crates/libghostty-vt-sys/resources/uucode-v0.2.0-tables.zig\`: new file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated patched build dependencies to a newer revision to keep builds aligned with the workspace.
* **Documentation**
  * Clarified notes about Windows/ARM64 build workarounds and when those fork-specific fixes can be removed once upstream releases catch up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->