### PR TITLE
Windows: enable dark-mode chrome for title bar + themed controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "windows-sys 0.60.2",
  "winit",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,9 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
 dependencies = [
  "crossbeam-channel",
  "dpi",

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -33,7 +33,6 @@ open = { workspace = true }
 toml = { workspace = true }
 notify-rust = { workspace = true }
 rodio = { workspace = true }
-muda = { workspace = true }
 winit = { workspace = true }
 uuid = { workspace = true }
 amux-browser = { workspace = true }
@@ -43,6 +42,10 @@ image = { workspace = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-foundation = { workspace = true }
 objc2-app-kit = { workspace = true }
+# muda builds the macOS app-global menu bar installed into NSApp.
+# Windows/Linux draw their menu bar via egui (see `menu_bar::draw_egui_menu_bar`)
+# and don't need muda at all.
+muda = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # Used by `windows_chrome` to enable dark-mode themed controls + dark

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -45,3 +45,11 @@ objc2-foundation = { workspace = true }
 objc2-app-kit = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+# Used by `windows_chrome` to enable dark-mode themed controls + dark
+# title bar (see amux #190). Kept on 0.60 to align with versions
+# already in Cargo.lock via transitive deps.
+windows-sys = { version = "0.60", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Dwm",
+    "Win32_System_LibraryLoader",
+] }

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -208,17 +208,15 @@ impl eframe::App for AmuxApp {
             }
         }
 
-        // Non-macOS: draw the menu bar via egui into a TopBottomPanel.
-        // Must happen before the sidebar panel so the menu bar sits
-        // above the sidebar rather than under it — egui layout is
-        // pull-based and panels claim space in call order.
+        // The non-macOS menu bar (File / Edit / View) is rendered as
+        // clickable labels inside the existing titlebar icon row —
+        // see `menu_bar::draw_menu_buttons`, called from
+        // `notifications_ui::render_titlebar_icons_inner`. One top
+        // strip, one coordinate system, no competing panels.
         //
         // macOS uses the native NSApp menu bar installed via muda in
         // `menu_bar::build`, which lives at the top of the screen
-        // outside the app window entirely, so there's nothing to draw
-        // here.
-        #[cfg(not(target_os = "macos"))]
-        menu_bar::draw_egui_menu_bar(ctx, &self.theme);
+        // outside the app window entirely.
 
         // Render sidebar
         if self.sidebar.visible {

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -218,7 +218,7 @@ impl eframe::App for AmuxApp {
         // outside the app window entirely, so there's nothing to draw
         // here.
         #[cfg(not(target_os = "macos"))]
-        menu_bar::draw_egui_menu_bar(ctx);
+        menu_bar::draw_egui_menu_bar(ctx, &self.theme);
 
         // Render sidebar
         if self.sidebar.visible {

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -15,11 +15,20 @@ impl eframe::App for AmuxApp {
             return;
         }
 
-        // Attach native menu bar to the window (Windows: per-HWND).
-        // Retries each frame until the HWND is available.
+        // Apply dark-mode window chrome to the Win32 HWND. Retries each
+        // frame until the HWND is available via `eframe::Frame::window_handle`,
+        // then flips `window_chrome_applied` so we don't keep re-poking
+        // Windows on every frame. The call is cheap and idempotent but
+        // there's no reason to run it more than once.
         #[cfg(target_os = "windows")]
-        if !self.menu_attached {
-            self.menu_attached = menu_bar::attach_to_window(&self.menu, _frame);
+        if !self.window_chrome_applied {
+            use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+            if let Ok(handle) = _frame.window_handle() {
+                if let RawWindowHandle::Win32(win32) = handle.as_raw() {
+                    crate::windows_chrome::apply_dark_mode_to_window(win32.hwnd.get());
+                    self.window_chrome_applied = true;
+                }
+            }
         }
 
         // Create any pending browser panes (needs window handle from frame)
@@ -198,6 +207,18 @@ impl eframe::App for AmuxApp {
                 self.cursor_blink_since = Instant::now();
             }
         }
+
+        // Non-macOS: draw the menu bar via egui into a TopBottomPanel.
+        // Must happen before the sidebar panel so the menu bar sits
+        // above the sidebar rather than under it — egui layout is
+        // pull-based and panels claim space in call order.
+        //
+        // macOS uses the native NSApp menu bar installed via muda in
+        // `menu_bar::build`, which lives at the top of the screen
+        // outside the app window entirely, so there's nothing to draw
+        // here.
+        #[cfg(not(target_os = "macos"))]
+        menu_bar::draw_egui_menu_bar(ctx);
 
         // Render sidebar
         if self.sidebar.visible {

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -154,12 +154,19 @@ struct AmuxApp {
     cursor_blink_since: Instant,
     /// Notification sound player (None if no audio device).
     sound_player: Option<system_notify::SoundPlayer>,
-    /// Native menu bar (kept alive for the process lifetime).
+    /// macOS native menu bar (kept alive for the process lifetime).
+    /// Windows/Linux render their menu bar via egui in `menu_bar::draw_egui_menu_bar`
+    /// and don't need a `muda::Menu` instance at all.
+    #[cfg(target_os = "macos")]
     #[allow(dead_code)]
     menu: muda::Menu,
-    /// Whether the menu has been attached to the window (Windows only).
+    /// On Windows, whether the DWM dark title bar chrome has been applied
+    /// to the main window yet. The call needs to happen from the first
+    /// `App::update()` frame because that's the earliest the HWND is
+    /// available via `eframe::Frame::window_handle`. Flipped to `true`
+    /// once successful so we only do it once.
     #[cfg(target_os = "windows")]
-    menu_attached: bool,
+    window_chrome_applied: bool,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
     /// Pending browser pane creation requests (originating_pane_id, URL).

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -20,6 +20,8 @@ mod startup;
 mod system_notify;
 mod tab_icons;
 mod theme;
+#[cfg(target_os = "windows")]
+mod windows_chrome;
 mod workspace_ops;
 
 use std::collections::HashMap;

--- a/crates/amux-app/src/menu_bar.rs
+++ b/crates/amux-app/src/menu_bar.rs
@@ -1,22 +1,54 @@
-/// Cross-platform native menu bar using `muda`.
-///
-/// macOS: top-of-screen system menu bar.
-/// Windows: per-window native Win32 menu bar.
-/// Linux: GTK menu bar (requires GTK window access — not yet wired up).
-///
-/// Menu item clicks are delivered via `muda::MenuEvent::receiver()`, drained
-/// each frame in the egui update loop.
-///
-/// Accelerators match the keybindings in `handle_shortcuts()`: Cmd on macOS,
-/// Ctrl+Shift on Windows/Linux for workspace/tab ops, Ctrl for view ops.
-/// On both platforms the system menu bar consumes the key event before it
-/// reaches the egui event loop, so the shortcut handlers will not double-fire.
-use muda::accelerator::{Accelerator, Code, Modifiers};
-#[cfg(target_os = "macos")]
-use muda::AboutMetadata;
-use muda::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
+//! Cross-platform menu bar.
+//!
+//! # Two rendering paths
+//!
+//! - **macOS**: native app-global menu bar via [`muda`], installed into
+//!   NSApp's top-of-screen strip. That's the idiomatic macOS pattern —
+//!   Mac apps don't draw menus inside their own windows.
+//! - **Windows / Linux**: egui-drawn [`egui::TopBottomPanel::top`] +
+//!   [`egui::menu::bar`], rendered from [`AmuxApp::update`] every frame.
+//!   Native menu chrome is off the table on Windows 11 because the
+//!   native menu rendering path ignores the undocumented dark-mode
+//!   ordinals VS Code / Windows Terminal used to use — the egui-drawn
+//!   approach gives us full theme control and cross-platform visual
+//!   parity. On Linux it means amux has a working menu bar at all:
+//!   `muda`'s GTK path isn't wired through `eframe`, so the native
+//!   approach produces nothing.
+//!
+//! # Shared action model
+//!
+//! Both paths emit [`MenuAction`] values into the process-wide
+//! [`PENDING_ACTIONS`] queue, which is drained per frame by
+//! [`AmuxApp::handle_menu_actions`]. The dispatcher code in
+//! `workspace_ops.rs` doesn't know or care which path produced the
+//! action.
+//!
+//! # Keyboard shortcuts
+//!
+//! Menu items display shortcut text (e.g. `Ctrl+Shift+N`) for
+//! discoverability, but the menu bar does **not** dispatch keyboard
+//! events. All shortcuts go through [`AmuxApp::handle_shortcuts`] in
+//! `input.rs`, which reads the configured keybindings and matches
+//! against `egui::Event::Key` directly. The shortcut strings here are
+//! purely cosmetic — changing them does not affect what keys fire what
+//! action.
 
-/// Actions that can be triggered from the native menu bar.
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+#[cfg(target_os = "macos")]
+use muda::{
+    accelerator::{Accelerator, Code, Modifiers},
+    AboutMetadata, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu,
+};
+
+// ---------------------------------------------------------------------
+// Action vocabulary
+// ---------------------------------------------------------------------
+
+/// Actions that can be triggered from the menu bar. Stable across both
+/// rendering paths so `workspace_ops::handle_menu_actions` can treat
+/// them uniformly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MenuAction {
     NewWorkspace,
@@ -34,8 +66,194 @@ pub(crate) enum MenuAction {
     SelectAll,
 }
 
-/// Stored menu item IDs, used to match incoming `MenuEvent`s to actions.
-struct MenuItems {
+// ---------------------------------------------------------------------
+// Platform-agnostic menu model (non-macOS only)
+// ---------------------------------------------------------------------
+//
+// macOS builds its native menu via the inlined code in `build()`
+// below using muda's typed accelerators directly, so these data
+// types would be dead code on that platform. Gated to non-macOS so
+// the compiler doesn't flag them.
+
+/// A single item inside a submenu — either a clickable action or a
+/// visual separator.
+#[cfg(not(target_os = "macos"))]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum MenuItemDef {
+    Separator,
+    Action {
+        label: &'static str,
+        /// Display-only shortcut hint (e.g. `"Ctrl+Shift+N"`). Purely
+        /// cosmetic — actual dispatch is in `input::handle_shortcuts`.
+        shortcut: Option<&'static str>,
+        action: MenuAction,
+    },
+}
+
+/// A top-level submenu (`File`, `Edit`, `View`, `Window`).
+#[cfg(not(target_os = "macos"))]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SubmenuDef {
+    pub label: &'static str,
+    pub items: &'static [MenuItemDef],
+}
+
+// Platform-specific shortcut display strings. macOS uses the Cmd glyph
+// (⌘) + letter; Windows/Linux use Ctrl+Shift+letter for workspace/tab
+// ops to avoid stealing terminal control keys (Ctrl+N = new line,
+// Ctrl+W = word erase, Ctrl+S = XOFF), and Ctrl+letter for view ops
+// that don't conflict. These strings must match what
+// `input::handle_shortcuts` actually listens for.
+
+// Shortcut display strings — only used by the non-macOS egui menu
+// renderer. macOS uses muda's typed `Accelerator` directly in
+// `build()` below and doesn't need these string forms.
+#[cfg(not(target_os = "macos"))]
+mod shortcuts {
+    pub const NEW_WORKSPACE: &str = "Ctrl+Shift+N";
+    pub const NEW_TAB: &str = "Ctrl+Shift+T";
+    pub const NEW_BROWSER_TAB: &str = "Ctrl+Shift+L";
+    pub const CLOSE_TAB: &str = "Ctrl+Shift+W";
+    pub const SAVE_SESSION: &str = "Ctrl+Shift+S";
+    pub const TOGGLE_SIDEBAR: &str = "Ctrl+B";
+    pub const TOGGLE_NOTIFICATIONS: &str = "Ctrl+Shift+I";
+    pub const ZOOM_IN: &str = "Ctrl+=";
+    pub const ZOOM_OUT: &str = "Ctrl+-";
+    pub const ZOOM_RESET: &str = "Ctrl+0";
+    pub const COPY: &str = "Ctrl+Shift+C";
+    pub const PASTE: &str = "Ctrl+Shift+V";
+    pub const SELECT_ALL: &str = "Ctrl+Shift+A";
+}
+
+/// The non-macOS menu structure consumed by [`draw_egui_menu_bar`].
+/// macOS builds its native menu separately in [`build`] using muda's
+/// typed accelerators, so this const isn't referenced there.
+///
+/// Window > Minimize / Maximize is not in this list — on Windows the
+/// title bar already provides those controls, and on Linux there's no
+/// portable winit API to wire from an egui click. If we need them on
+/// non-macOS later, route through `eframe::Frame::set_minimized` or
+/// similar in the dispatcher.
+#[cfg(not(target_os = "macos"))]
+pub(crate) const MENU_MODEL: &[SubmenuDef] = &[
+    SubmenuDef {
+        label: "File",
+        items: &[
+            MenuItemDef::Action {
+                label: "New Workspace",
+                shortcut: Some(shortcuts::NEW_WORKSPACE),
+                action: MenuAction::NewWorkspace,
+            },
+            MenuItemDef::Action {
+                label: "New Tab",
+                shortcut: Some(shortcuts::NEW_TAB),
+                action: MenuAction::NewTab,
+            },
+            MenuItemDef::Action {
+                label: "New Browser Tab",
+                shortcut: Some(shortcuts::NEW_BROWSER_TAB),
+                action: MenuAction::NewBrowserTab,
+            },
+            MenuItemDef::Separator,
+            MenuItemDef::Action {
+                label: "Close Tab",
+                shortcut: Some(shortcuts::CLOSE_TAB),
+                action: MenuAction::CloseTab,
+            },
+            MenuItemDef::Separator,
+            MenuItemDef::Action {
+                label: "Save Session",
+                shortcut: Some(shortcuts::SAVE_SESSION),
+                action: MenuAction::SaveSession,
+            },
+        ],
+    },
+    SubmenuDef {
+        label: "Edit",
+        items: &[
+            MenuItemDef::Action {
+                label: "Copy",
+                shortcut: Some(shortcuts::COPY),
+                action: MenuAction::Copy,
+            },
+            MenuItemDef::Action {
+                label: "Paste",
+                shortcut: Some(shortcuts::PASTE),
+                action: MenuAction::Paste,
+            },
+            MenuItemDef::Separator,
+            MenuItemDef::Action {
+                label: "Select All",
+                shortcut: Some(shortcuts::SELECT_ALL),
+                action: MenuAction::SelectAll,
+            },
+        ],
+    },
+    SubmenuDef {
+        label: "View",
+        items: &[
+            MenuItemDef::Action {
+                label: "Toggle Sidebar",
+                shortcut: Some(shortcuts::TOGGLE_SIDEBAR),
+                action: MenuAction::ToggleSidebar,
+            },
+            MenuItemDef::Action {
+                label: "Toggle Notifications",
+                shortcut: Some(shortcuts::TOGGLE_NOTIFICATIONS),
+                action: MenuAction::ToggleNotificationPanel,
+            },
+            MenuItemDef::Separator,
+            MenuItemDef::Action {
+                label: "Zoom In",
+                shortcut: Some(shortcuts::ZOOM_IN),
+                action: MenuAction::ZoomIn,
+            },
+            MenuItemDef::Action {
+                label: "Zoom Out",
+                shortcut: Some(shortcuts::ZOOM_OUT),
+                action: MenuAction::ZoomOut,
+            },
+            MenuItemDef::Action {
+                label: "Actual Size",
+                shortcut: Some(shortcuts::ZOOM_RESET),
+                action: MenuAction::ZoomReset,
+            },
+        ],
+    },
+];
+
+// ---------------------------------------------------------------------
+// Shared action queue
+// ---------------------------------------------------------------------
+
+/// Process-wide queue of menu-driven actions. Both the macOS muda path
+/// (via `drain_muda_events`) and the non-macOS egui path (via direct
+/// `push_action` calls from click handlers) push here. The queue is
+/// drained once per frame by `AmuxApp::handle_menu_actions`.
+static PENDING_ACTIONS: Mutex<VecDeque<MenuAction>> = Mutex::new(VecDeque::new());
+
+/// Enqueue a menu action. Called by both render paths.
+pub(crate) fn push_action(action: MenuAction) {
+    if let Ok(mut queue) = PENDING_ACTIONS.lock() {
+        queue.push_back(action);
+    }
+}
+
+/// Pop the next queued menu action, if any. On macOS, also drains
+/// `muda::MenuEvent`s from muda's channel into the queue first.
+pub(crate) fn take_pending_action() -> Option<MenuAction> {
+    #[cfg(target_os = "macos")]
+    drain_muda_events();
+
+    PENDING_ACTIONS.lock().ok()?.pop_front()
+}
+
+// ---------------------------------------------------------------------
+// macOS path (muda native menu bar)
+// ---------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+struct MacMenuItems {
     new_workspace: muda::MenuId,
     new_tab: muda::MenuId,
     new_browser_tab: muda::MenuId,
@@ -51,93 +269,50 @@ struct MenuItems {
     select_all: muda::MenuId,
 }
 
-static MENU_ITEMS: std::sync::OnceLock<MenuItems> = std::sync::OnceLock::new();
+#[cfg(target_os = "macos")]
+static MAC_MENU_ITEMS: std::sync::OnceLock<MacMenuItems> = std::sync::OnceLock::new();
 
-/// Platform modifier: Cmd on macOS, Ctrl on Windows/Linux.
 #[cfg(target_os = "macos")]
 const CMD: Modifiers = Modifiers::SUPER;
-#[cfg(not(target_os = "macos"))]
-const CMD: Modifiers = Modifiers::CONTROL;
 
-/// Ctrl+Shift on non-macOS — matches `handle_shortcuts()` which uses
-/// Ctrl+Shift for workspace/tab operations to avoid stealing terminal
-/// control keys (Ctrl+N/T/W/S).
-#[cfg(not(target_os = "macos"))]
-const CMD_SHIFT: Modifiers = Modifiers::CONTROL.union(Modifiers::SHIFT);
-
+#[cfg(target_os = "macos")]
 fn accel(mods: Modifiers, code: Code) -> Option<Accelerator> {
     Some(Accelerator::new(Some(mods), code))
 }
 
-/// Build and install the native menu bar. Call once at startup.
+/// Build and install the macOS native menu bar. Call once at startup.
+/// Returns the [`muda::Menu`] — the caller must keep it alive for the
+/// process lifetime (muda drops its event wiring when the Menu is
+/// dropped).
 ///
-/// On macOS this sets the app-global menu bar via `init_for_nsapp()`.
-/// On Windows, call `init_for_hwnd()` once the window handle is available
-/// (see `attach_to_window()`).
-///
-/// Accelerators match the existing keybindings in `handle_shortcuts()`:
-/// - macOS: Cmd+key
-/// - Windows/Linux: Ctrl+Shift+key for workspace/tab ops; Ctrl+key for
-///   view ops (sidebar, zoom) that don't conflict with terminal control chars.
+/// `init_for_nsapp` is called internally, so the menu bar is visible
+/// immediately when this returns.
+#[cfg(target_os = "macos")]
 pub(crate) fn build() -> Menu {
-    // --- Custom action items ---
-    // On non-macOS, workspace/tab operations use Ctrl+Shift to avoid
-    // stealing terminal control keys (Ctrl+N = new line, Ctrl+W = word
-    // erase, Ctrl+S = XOFF).
-    #[cfg(target_os = "macos")]
+    // Build menu items with accelerators.
     let new_workspace = MenuItem::new("New Workspace", true, accel(CMD, Code::KeyN));
-    #[cfg(not(target_os = "macos"))]
-    let new_workspace = MenuItem::new("New Workspace", true, accel(CMD_SHIFT, Code::KeyN));
-
-    #[cfg(target_os = "macos")]
     let new_tab = MenuItem::new("New Tab", true, accel(CMD, Code::KeyT));
-    #[cfg(not(target_os = "macos"))]
-    let new_tab = MenuItem::new("New Tab", true, accel(CMD_SHIFT, Code::KeyT));
-
     let new_browser_tab = MenuItem::new(
         "New Browser Tab",
         true,
         accel(CMD.union(Modifiers::SHIFT), Code::KeyL),
     );
-
-    #[cfg(target_os = "macos")]
     let close_tab = MenuItem::new("Close Tab", true, accel(CMD, Code::KeyW));
-    #[cfg(not(target_os = "macos"))]
-    let close_tab = MenuItem::new("Close Tab", true, accel(CMD_SHIFT, Code::KeyW));
-
-    #[cfg(target_os = "macos")]
     let save_session = MenuItem::new("Save Session", true, accel(CMD, Code::KeyS));
-    #[cfg(not(target_os = "macos"))]
-    let save_session = MenuItem::new("Save Session", true, accel(CMD_SHIFT, Code::KeyS));
-
     let toggle_sidebar = MenuItem::new("Toggle Sidebar", true, accel(CMD, Code::KeyB));
-    #[cfg(target_os = "macos")]
     let toggle_notifications = MenuItem::new("Toggle Notifications", true, accel(CMD, Code::KeyI));
-    #[cfg(not(target_os = "macos"))]
-    let toggle_notifications =
-        MenuItem::new("Toggle Notifications", true, accel(CMD_SHIFT, Code::KeyI));
     let zoom_in = MenuItem::new("Zoom In", true, accel(CMD, Code::Equal));
     let zoom_out = MenuItem::new("Zoom Out", true, accel(CMD, Code::Minus));
     let zoom_reset = MenuItem::new("Actual Size", true, accel(CMD, Code::Digit0));
-
-    // Edit menu items — use custom MenuItems (not PredefinedMenuItem) so we
-    // receive the event in our handler instead of it being consumed by the OS.
-    #[cfg(target_os = "macos")]
     let copy = MenuItem::new("Copy", true, accel(CMD, Code::KeyC));
-    #[cfg(not(target_os = "macos"))]
-    let copy = MenuItem::new("Copy", true, accel(CMD_SHIFT, Code::KeyC));
-    #[cfg(target_os = "macos")]
     let paste = MenuItem::new("Paste", true, accel(CMD, Code::KeyV));
-    #[cfg(not(target_os = "macos"))]
-    let paste = MenuItem::new("Paste", true, accel(CMD_SHIFT, Code::KeyV));
-    #[cfg(target_os = "macos")]
     let select_all = MenuItem::new("Select All", true, accel(CMD, Code::KeyA));
-    #[cfg(not(target_os = "macos"))]
-    let select_all = MenuItem::new("Select All", true, accel(CMD_SHIFT, Code::KeyA));
 
-    // Store IDs for event matching
-    if MENU_ITEMS
-        .set(MenuItems {
+    // Stash IDs for event matching before the items get moved into
+    // their submenus — muda's MenuId is cheap to clone but we need to
+    // capture it before handing ownership off.
+    if MAC_MENU_ITEMS
+        .set(MacMenuItems {
             new_workspace: new_workspace.id().clone(),
             new_tab: new_tab.id().clone(),
             new_browser_tab: new_browser_tab.id().clone(),
@@ -159,170 +334,162 @@ pub(crate) fn build() -> Menu {
 
     let menu = Menu::new();
 
-    // --- App menu (macOS only, ignored on other platforms) ---
-    #[cfg(target_os = "macos")]
-    {
-        let app_menu = Submenu::new("amux", true);
-        let _ = app_menu.append_items(&[
-            &PredefinedMenuItem::about(
-                None,
-                Some(AboutMetadata {
-                    name: Some("amux".to_string()),
-                    ..Default::default()
-                }),
-            ),
-            &PredefinedMenuItem::separator(),
-            &PredefinedMenuItem::services(None),
-            &PredefinedMenuItem::separator(),
-            &PredefinedMenuItem::hide(None),
-            &PredefinedMenuItem::hide_others(None),
-            &PredefinedMenuItem::show_all(None),
-            &PredefinedMenuItem::separator(),
-            &PredefinedMenuItem::quit(None),
-        ]);
-        let _ = menu.append(&app_menu);
-    }
+    // App menu (macOS standard: About / Services / Hide / Quit).
+    let app_menu = Submenu::new("amux", true);
+    let _ = app_menu.append_items(&[
+        &PredefinedMenuItem::about(
+            None,
+            Some(AboutMetadata {
+                name: Some("amux".to_string()),
+                ..Default::default()
+            }),
+        ),
+        &PredefinedMenuItem::separator(),
+        &PredefinedMenuItem::services(None),
+        &PredefinedMenuItem::separator(),
+        &PredefinedMenuItem::hide(None),
+        &PredefinedMenuItem::hide_others(None),
+        &PredefinedMenuItem::show_all(None),
+        &PredefinedMenuItem::separator(),
+        &PredefinedMenuItem::quit(None),
+    ]);
+    let _ = menu.append(&app_menu);
 
-    // --- File menu ---
-    {
-        let file_menu = Submenu::new("File", true);
-        let _ = file_menu.append_items(&[
-            &new_workspace,
-            &new_tab,
-            &new_browser_tab,
-            &PredefinedMenuItem::separator(),
-            &close_tab,
-            &PredefinedMenuItem::separator(),
-            &save_session,
-        ]);
-        let _ = menu.append(&file_menu);
-    }
+    // File menu.
+    let file_menu = Submenu::new("File", true);
+    let _ = file_menu.append_items(&[
+        &new_workspace,
+        &new_tab,
+        &new_browser_tab,
+        &PredefinedMenuItem::separator(),
+        &close_tab,
+        &PredefinedMenuItem::separator(),
+        &save_session,
+    ]);
+    let _ = menu.append(&file_menu);
 
-    // --- Edit menu ---
-    {
-        let edit_menu = Submenu::new("Edit", true);
-        let _ =
-            edit_menu.append_items(&[&copy, &paste, &PredefinedMenuItem::separator(), &select_all]);
-        let _ = menu.append(&edit_menu);
-    }
+    // Edit menu.
+    let edit_menu = Submenu::new("Edit", true);
+    let _ = edit_menu.append_items(&[&copy, &paste, &PredefinedMenuItem::separator(), &select_all]);
+    let _ = menu.append(&edit_menu);
 
-    // --- View menu ---
-    {
-        let view_menu = Submenu::new("View", true);
-        let _ = view_menu.append_items(&[
-            &toggle_sidebar,
-            &toggle_notifications,
-            &PredefinedMenuItem::separator(),
-            &zoom_in,
-            &zoom_out,
-            &zoom_reset,
-        ]);
-        let _ = menu.append(&view_menu);
-    }
+    // View menu.
+    let view_menu = Submenu::new("View", true);
+    let _ = view_menu.append_items(&[
+        &toggle_sidebar,
+        &toggle_notifications,
+        &PredefinedMenuItem::separator(),
+        &zoom_in,
+        &zoom_out,
+        &zoom_reset,
+    ]);
+    let _ = menu.append(&view_menu);
 
-    // --- Window menu ---
-    {
-        let window_menu = Submenu::new("Window", true);
-        let _ = window_menu.append_items(&[
-            &PredefinedMenuItem::minimize(None),
-            &PredefinedMenuItem::maximize(None),
-        ]);
-        let _ = menu.append(&window_menu);
+    // Window menu — minimize/maximize/window list. macOS has native
+    // predefined items for these that hook into NSWindow.
+    let window_menu = Submenu::new("Window", true);
+    let _ = window_menu.append_items(&[
+        &PredefinedMenuItem::minimize(None),
+        &PredefinedMenuItem::maximize(None),
+    ]);
+    let _ = menu.append(&window_menu);
+    window_menu.set_as_windows_menu_for_nsapp();
 
-        #[cfg(target_os = "macos")]
-        window_menu.set_as_windows_menu_for_nsapp();
-    }
+    // Help menu — empty container, but set_as_help_menu_for_nsapp
+    // wires the system-provided search field into it.
+    let help_menu = Submenu::new("Help", true);
+    let _ = menu.append(&help_menu);
+    help_menu.set_as_help_menu_for_nsapp();
 
-    // --- Help menu (macOS only — includes system search field; empty on other platforms) ---
-    #[cfg(target_os = "macos")]
-    {
-        let help_menu = Submenu::new("Help", true);
-        let _ = menu.append(&help_menu);
-        help_menu.set_as_help_menu_for_nsapp();
-    }
-
-    // Install for macOS immediately (app-global menu bar).
-    #[cfg(target_os = "macos")]
     menu.init_for_nsapp();
-
-    // Linux: muda supports GTK menus via `init_for_gtk_window()`, but eframe
-    // does not expose the underlying GtkWindow. When Linux support is needed,
-    // the GTK window can be obtained from the raw Xlib/Wayland handle or by
-    // patching eframe to surface it.
-
     menu
 }
 
-/// On Windows, attach the menu bar to the window once the HWND is available.
-/// Call from the first `App::update()` frame. Returns `true` if the menu was
-/// successfully attached; `false` if the window handle wasn't ready yet.
-///
-/// Before attaching the menu, this function also applies the per-window
-/// dark-mode chrome (title bar + themed controls) via `windows_chrome`.
-/// The per-window call needs to happen before `menu.init_for_hwnd` so the
-/// menu bar paints in dark mode from its first draw — `init_for_hwnd`
-/// triggers an immediate `DrawMenuBar`, and if dark mode isn't enabled
-/// on the HWND yet the menu bar caches light-mode chrome and doesn't
-/// re-theme until the next WM_THEMECHANGED.
-#[cfg(target_os = "windows")]
-pub(crate) fn attach_to_window(menu: &Menu, frame: &eframe::Frame) -> bool {
-    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-    if let Ok(handle) = frame.window_handle() {
-        if let RawWindowHandle::Win32(win32) = handle.as_raw() {
-            // `raw_window_handle::Win32WindowHandle::hwnd` is an
-            // `NonZeroIsize`. Both `muda::Menu::init_for_hwnd` and
-            // our `windows_chrome::apply_dark_mode_to_window` take
-            // the handle as a plain `isize`, so we extract it once
-            // and share.
-            let hwnd: isize = win32.hwnd.get();
-            crate::windows_chrome::apply_dark_mode_to_window(hwnd);
-            match unsafe { menu.init_for_hwnd(hwnd) } {
-                Ok(()) => return true,
-                Err(e) => {
-                    tracing::error!("Failed to attach menu bar to HWND: {e}");
-                    return false;
-                }
-            }
+/// Drain any pending muda events into the shared action queue. No-op
+/// if the menu hasn't been built yet (early in startup).
+#[cfg(target_os = "macos")]
+fn drain_muda_events() {
+    let Some(items) = MAC_MENU_ITEMS.get() else {
+        return;
+    };
+    while let Ok(event) = MenuEvent::receiver().try_recv() {
+        let id = &event.id;
+        let action = if *id == items.new_workspace {
+            Some(MenuAction::NewWorkspace)
+        } else if *id == items.new_tab {
+            Some(MenuAction::NewTab)
+        } else if *id == items.new_browser_tab {
+            Some(MenuAction::NewBrowserTab)
+        } else if *id == items.close_tab {
+            Some(MenuAction::CloseTab)
+        } else if *id == items.save_session {
+            Some(MenuAction::SaveSession)
+        } else if *id == items.toggle_sidebar {
+            Some(MenuAction::ToggleSidebar)
+        } else if *id == items.toggle_notifications {
+            Some(MenuAction::ToggleNotificationPanel)
+        } else if *id == items.zoom_in {
+            Some(MenuAction::ZoomIn)
+        } else if *id == items.zoom_out {
+            Some(MenuAction::ZoomOut)
+        } else if *id == items.zoom_reset {
+            Some(MenuAction::ZoomReset)
+        } else if *id == items.copy {
+            Some(MenuAction::Copy)
+        } else if *id == items.paste {
+            Some(MenuAction::Paste)
+        } else if *id == items.select_all {
+            Some(MenuAction::SelectAll)
+        } else {
+            // Predefined OS item or unknown — no local handler.
+            None
+        };
+        if let Some(action) = action {
+            push_action(action);
         }
     }
-    false
 }
 
-/// Drain pending menu events and return the next recognized action, if any.
-/// Skips unrecognized event IDs (e.g. from predefined items handled by the OS)
-/// so they don't block processing of subsequent events in the queue.
-pub(crate) fn take_pending_action() -> Option<MenuAction> {
-    let items = MENU_ITEMS.get()?;
-    loop {
-        let event = MenuEvent::receiver().try_recv().ok()?;
-        let id = &event.id;
-        if *id == items.new_workspace {
-            return Some(MenuAction::NewWorkspace);
-        } else if *id == items.new_tab {
-            return Some(MenuAction::NewTab);
-        } else if *id == items.new_browser_tab {
-            return Some(MenuAction::NewBrowserTab);
-        } else if *id == items.close_tab {
-            return Some(MenuAction::CloseTab);
-        } else if *id == items.save_session {
-            return Some(MenuAction::SaveSession);
-        } else if *id == items.toggle_sidebar {
-            return Some(MenuAction::ToggleSidebar);
-        } else if *id == items.toggle_notifications {
-            return Some(MenuAction::ToggleNotificationPanel);
-        } else if *id == items.zoom_in {
-            return Some(MenuAction::ZoomIn);
-        } else if *id == items.zoom_out {
-            return Some(MenuAction::ZoomOut);
-        } else if *id == items.zoom_reset {
-            return Some(MenuAction::ZoomReset);
-        } else if *id == items.copy {
-            return Some(MenuAction::Copy);
-        } else if *id == items.paste {
-            return Some(MenuAction::Paste);
-        } else if *id == items.select_all {
-            return Some(MenuAction::SelectAll);
-        }
-        // Unknown ID (predefined OS item, etc.) — skip and keep draining.
-    }
+// ---------------------------------------------------------------------
+// Non-macOS path (egui TopBottomPanel + menu::bar)
+// ---------------------------------------------------------------------
+
+/// Draw the menu bar into a [`egui::TopBottomPanel::top`] and push any
+/// clicked actions into the shared [`PENDING_ACTIONS`] queue. Must be
+/// called before any other top-level panels (sidebar, central) claim
+/// vertical space — egui panels nest in call order.
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn draw_egui_menu_bar(ctx: &egui::Context) {
+    egui::TopBottomPanel::top("amux_menu_bar").show(ctx, |ui| {
+        egui::menu::bar(ui, |ui| {
+            for submenu in MENU_MODEL {
+                ui.menu_button(submenu.label, |ui| {
+                    for item in submenu.items {
+                        match item {
+                            MenuItemDef::Separator => {
+                                ui.separator();
+                            }
+                            MenuItemDef::Action {
+                                label,
+                                shortcut,
+                                action,
+                            } => {
+                                // Build the button: with shortcut text
+                                // on the right when one is configured,
+                                // plain otherwise.
+                                let button = match shortcut {
+                                    Some(sc) => egui::Button::new(*label).shortcut_text(*sc),
+                                    None => egui::Button::new(*label),
+                                };
+                                if ui.add(button).clicked() {
+                                    push_action(*action);
+                                    ui.close_menu();
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+    });
 }

--- a/crates/amux-app/src/menu_bar.rs
+++ b/crates/amux-app/src/menu_bar.rs
@@ -269,7 +269,12 @@ pub(crate) fn attach_to_window(menu: &Menu, frame: &eframe::Frame) -> bool {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     if let Ok(handle) = frame.window_handle() {
         if let RawWindowHandle::Win32(win32) = handle.as_raw() {
-            let hwnd = win32.hwnd.get() as _;
+            // `raw_window_handle::Win32WindowHandle::hwnd` is an
+            // `NonZeroIsize`. Both `muda::Menu::init_for_hwnd` and
+            // our `windows_chrome::apply_dark_mode_to_window` take
+            // the handle as a plain `isize`, so we extract it once
+            // and share.
+            let hwnd: isize = win32.hwnd.get();
             crate::windows_chrome::apply_dark_mode_to_window(hwnd);
             match unsafe { menu.init_for_hwnd(hwnd) } {
                 Ok(()) => return true,

--- a/crates/amux-app/src/menu_bar.rs
+++ b/crates/amux-app/src/menu_bar.rs
@@ -451,14 +451,31 @@ fn drain_muda_events() {
 }
 
 // ---------------------------------------------------------------------
-// Non-macOS path (egui TopBottomPanel + menu::bar)
+// Non-macOS path (integrated into the existing titlebar strip)
 // ---------------------------------------------------------------------
+//
+// amux already owns the top-of-window chrome on Windows/Linux: a
+// 28px-tall strip (`TERMINAL_TOP_PAD`) whose background is painted in
+// a background layer from `frame_update.rs`, with the sidebar/bell/+
+// icons drawn over it via a fixed-position `egui::Area` from
+// `notifications_ui::render_titlebar_icons`. A first attempt at the
+// menu bar used `egui::TopBottomPanel::top` as a separate panel, but
+// that created two competing top strips and the menu labels ended up
+// invisible — the foreground icon Area painted over them and the
+// layout math got confused.
+//
+// This implementation plugs the menu directly into the same titlebar
+// strip: `draw_menu_buttons` below is called from
+// `render_titlebar_icons_inner` after the icons are laid out, at the
+// same `y` position, drawing File/Edit/View as clickable labels in
+// the remaining horizontal space. One strip, one coordinate system,
+// no layer fights.
 
 /// Pick a readable foreground color for a given background by checking
 /// its perceived luminance. Matches what amux does elsewhere (sidebar,
 /// tab bar) to keep chrome text legible against any user theme.
 #[cfg(not(target_os = "macos"))]
-fn contrast_text(bg: egui::Color32) -> egui::Color32 {
+pub(crate) fn contrast_text(bg: egui::Color32) -> egui::Color32 {
     // Rec. 601 luma — the approximation most UI toolkits use.
     let r = bg.r() as f32;
     let g = bg.g() as f32;
@@ -471,137 +488,107 @@ fn contrast_text(bg: egui::Color32) -> egui::Color32 {
     }
 }
 
-/// Draw the menu bar into a [`egui::TopBottomPanel::top`] and push any
-/// clicked actions into the shared [`PENDING_ACTIONS`] queue. Must be
-/// called before any other top-level panels (sidebar, central) claim
-/// vertical space — egui panels nest in call order.
+/// Draw the File/Edit/View menu labels as clickable text inside the
+/// existing titlebar icon row. `start_x` is the window-x coordinate
+/// where the labels should start (just past the last icon, with a
+/// small gap); `y` is the same y the icons are drawn at.
 ///
-/// Theming: the panel's background uses `theme.titlebar_bg()` (same
-/// resolution chain as the tab bar) so the menu bar looks like a
-/// natural extension of amux's chrome. Foreground text is overridden
-/// via `style.visuals.override_text_color` with a contrast-aware color
-/// derived from the background, which ensures labels and shortcut
-/// hints are legible regardless of what theme the user configured.
-///
-/// The dropdown popups opened by `ui.menu_button` inherit the same
-/// `override_text_color` and the modified `widgets.*.weak_bg_fill`
-/// hover colors, so opened menus also render in amux's palette.
+/// Clicking a label toggles a popup dropdown below that label with
+/// the submenu's items. Item clicks push their `MenuAction` into the
+/// shared `PENDING_ACTIONS` queue, same as the macOS muda path.
 #[cfg(not(target_os = "macos"))]
-pub(crate) fn draw_egui_menu_bar(ctx: &egui::Context, theme: &crate::theme::Theme) {
+pub(crate) fn draw_menu_buttons(
+    ui: &mut egui::Ui,
+    start_x: f32,
+    y: f32,
+    row_height: f32,
+    theme: &crate::theme::Theme,
+) {
     let bg = theme.titlebar_bg();
     let fg = contrast_text(bg);
-    // Hover background: slightly lighter/darker variant of bg so
-    // hovered items are visually distinct. Use gamma_multiply to
-    // shift luminance without messing with saturation.
-    let hover_bg = if fg == egui::Color32::from_rgb(0xE6, 0xE6, 0xE6) {
-        // Dark theme — brighten the bg for hover.
-        bg.gamma_multiply(1.4)
+    let luma_sum: u16 = bg.r() as u16 + bg.g() as u16 + (bg.b() as u16);
+    let hover_bg = if luma_sum < 384 {
+        bg.gamma_multiply(1.5) // dark theme → brighten on hover
     } else {
-        // Light theme — darken the bg for hover.
-        bg.gamma_multiply(0.85)
+        bg.gamma_multiply(0.85) // light theme → darken on hover
     };
 
-    egui::TopBottomPanel::top("amux_menu_bar")
-        .exact_height(28.0)
-        .frame(
-            egui::Frame::new()
-                .fill(bg)
-                .inner_margin(egui::Margin::symmetric(6, 2)),
-        )
-        .show(ctx, |ui| {
-            // First call of the session: log that we got here at all.
-            // Drop the log on subsequent frames to avoid flooding stderr.
-            static LOGGED: std::sync::atomic::AtomicBool =
-                std::sync::atomic::AtomicBool::new(false);
-            if !LOGGED.swap(true, std::sync::atomic::Ordering::Relaxed) {
-                tracing::info!(
-                    "draw_egui_menu_bar: first frame — bg={:?} fg={:?} model_len={}",
-                    bg,
-                    fg,
-                    MENU_MODEL.len()
-                );
-            }
+    // Layout constants for the label row.
+    const LABEL_GAP: f32 = 8.0; // gap between icons and the first label
+    const LABEL_PAD_X: f32 = 8.0; // horizontal padding inside each label rect
+    const LABEL_FONT_SIZE: f32 = 13.5;
 
-            // Inner UI is wrapped below via `egui::menu::bar`.
-            // Override the palette for everything rendered inside this
-            // panel and its popup children. Egui's dropdown popups
-            // inherit style from the UI that opened them, so these
-            // tweaks propagate into the menu dropdowns too.
-            let visuals = &mut ui.style_mut().visuals;
-            visuals.override_text_color = Some(fg);
-            visuals.widgets.inactive.weak_bg_fill = egui::Color32::TRANSPARENT;
-            visuals.widgets.inactive.bg_fill = egui::Color32::TRANSPARENT;
-            visuals.widgets.hovered.weak_bg_fill = hover_bg;
-            visuals.widgets.hovered.bg_fill = hover_bg;
-            visuals.widgets.active.weak_bg_fill = hover_bg;
-            visuals.widgets.active.bg_fill = hover_bg;
-            // Dropdown popup background (the window-like container
-            // that opens below a top-level menu button).
-            visuals.window_fill = bg;
-            visuals.panel_fill = bg;
+    let mut x = start_x + LABEL_GAP;
+    for submenu in MENU_MODEL {
+        // Measure the label's text so the hit rect fits it exactly.
+        let galley = ui.painter().layout_no_wrap(
+            submenu.label.to_string(),
+            egui::FontId::proportional(LABEL_FONT_SIZE),
+            fg,
+        );
+        let label_w = galley.size().x + LABEL_PAD_X * 2.0;
+        let rect = egui::Rect::from_min_size(egui::pos2(x, y), egui::vec2(label_w, row_height));
 
-            // Diagnostic: draw a plain colored label first. If this is
-            // visible but the menu buttons below aren't, we know the
-            // problem is `egui::menu::bar` or `ui.menu_button` eating
-            // the style — not the panel itself being invisible.
-            ui.horizontal(|ui| {
-                ui.label(
-                    egui::RichText::new("[DEBUG: menu bar is rendering]")
-                        .color(fg)
-                        .strong(),
-                );
-                ui.separator();
+        let id = ui.id().with(("amux_menu_label", submenu.label));
+        let response = ui.interact(rect, id, egui::Sense::click());
 
-                // Use plain `ui.horizontal` + top-level buttons instead
-                // of `egui::menu::bar` + `ui.menu_button` so we can
-                // isolate whether menu::bar's internal `set_menu_style`
-                // is clobbering the text color override.
-                //
-                // Each top-level entry is a plain button; clicking one
-                // opens an egui popup with its items. This gives us
-                // full control of the button rendering.
-                for submenu in MENU_MODEL {
-                    let label_button = egui::Button::new(
-                        egui::RichText::new(submenu.label).color(fg),
-                    )
-                    .frame(false);
-                    let response = ui.add(label_button);
-                    let popup_id = ui.make_persistent_id(("amux_menu_popup", submenu.label));
-                    if response.clicked() {
-                        ui.memory_mut(|m| m.toggle_popup(popup_id));
-                    }
-                    egui::popup::popup_below_widget(
-                        ui,
-                        popup_id,
-                        &response,
-                        egui::PopupCloseBehavior::CloseOnClickOutside,
-                        |ui| {
-                            ui.set_min_width(180.0);
-                            for item in submenu.items {
-                                match item {
-                                    MenuItemDef::Separator => {
-                                        ui.separator();
-                                    }
-                                    MenuItemDef::Action {
-                                        label,
-                                        shortcut,
-                                        action,
-                                    } => {
-                                        let button = match shortcut {
-                                            Some(sc) => egui::Button::new(*label)
-                                                .shortcut_text(*sc),
-                                            None => egui::Button::new(*label),
-                                        };
-                                        if ui.add(button).clicked() {
-                                            push_action(*action);
-                                            ui.memory_mut(|m| m.close_popup());
-                                        }
-                                    }
-                                }
+        // Background fill on hover.
+        if response.hovered() {
+            ui.painter().rect_filled(rect, 4.0, hover_bg);
+        }
+
+        // Draw the label text centered vertically inside the rect.
+        let text_pos = egui::pos2(
+            rect.min.x + LABEL_PAD_X,
+            rect.center().y - galley.size().y / 2.0,
+        );
+        ui.painter().galley(text_pos, galley, fg);
+
+        // Popup handling.
+        let popup_id = ui.make_persistent_id(("amux_menu_popup", submenu.label));
+        if response.clicked() {
+            ui.memory_mut(|m| m.toggle_popup(popup_id));
+        }
+        egui::popup::popup_below_widget(
+            ui,
+            popup_id,
+            &response,
+            egui::PopupCloseBehavior::CloseOnClickOutside,
+            |ui| {
+                // Theme the popup to match amux's chrome.
+                let visuals = &mut ui.style_mut().visuals;
+                visuals.override_text_color = Some(fg);
+                visuals.window_fill = bg;
+                visuals.panel_fill = bg;
+                visuals.widgets.inactive.weak_bg_fill = egui::Color32::TRANSPARENT;
+                visuals.widgets.hovered.weak_bg_fill = hover_bg;
+                visuals.widgets.active.weak_bg_fill = hover_bg;
+
+                ui.set_min_width(200.0);
+                for item in submenu.items {
+                    match item {
+                        MenuItemDef::Separator => {
+                            ui.separator();
+                        }
+                        MenuItemDef::Action {
+                            label,
+                            shortcut,
+                            action,
+                        } => {
+                            let button = match shortcut {
+                                Some(sc) => egui::Button::new(*label).shortcut_text(*sc),
+                                None => egui::Button::new(*label),
+                            };
+                            if ui.add(button).clicked() {
+                                push_action(*action);
+                                ui.memory_mut(|m| m.close_popup());
                             }
-                        },
-                    );
+                        }
+                    }
                 }
-            });
-        });
+            },
+        );
+
+        x += label_w;
+    }
 }

--- a/crates/amux-app/src/menu_bar.rs
+++ b/crates/amux-app/src/menu_bar.rs
@@ -502,12 +502,27 @@ pub(crate) fn draw_egui_menu_bar(ctx: &egui::Context, theme: &crate::theme::Them
     };
 
     egui::TopBottomPanel::top("amux_menu_bar")
+        .exact_height(28.0)
         .frame(
             egui::Frame::new()
                 .fill(bg)
                 .inner_margin(egui::Margin::symmetric(6, 2)),
         )
         .show(ctx, |ui| {
+            // First call of the session: log that we got here at all.
+            // Drop the log on subsequent frames to avoid flooding stderr.
+            static LOGGED: std::sync::atomic::AtomicBool =
+                std::sync::atomic::AtomicBool::new(false);
+            if !LOGGED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                tracing::info!(
+                    "draw_egui_menu_bar: first frame — bg={:?} fg={:?} model_len={}",
+                    bg,
+                    fg,
+                    MENU_MODEL.len()
+                );
+            }
+
+            // Inner UI is wrapped below via `egui::menu::bar`.
             // Override the palette for everything rendered inside this
             // panel and its popup children. Egui's dropdown popups
             // inherit style from the UI that opened them, so these

--- a/crates/amux-app/src/menu_bar.rs
+++ b/crates/amux-app/src/menu_bar.rs
@@ -256,12 +256,22 @@ pub(crate) fn build() -> Menu {
 /// On Windows, attach the menu bar to the window once the HWND is available.
 /// Call from the first `App::update()` frame. Returns `true` if the menu was
 /// successfully attached; `false` if the window handle wasn't ready yet.
+///
+/// Before attaching the menu, this function also applies the per-window
+/// dark-mode chrome (title bar + themed controls) via `windows_chrome`.
+/// The per-window call needs to happen before `menu.init_for_hwnd` so the
+/// menu bar paints in dark mode from its first draw — `init_for_hwnd`
+/// triggers an immediate `DrawMenuBar`, and if dark mode isn't enabled
+/// on the HWND yet the menu bar caches light-mode chrome and doesn't
+/// re-theme until the next WM_THEMECHANGED.
 #[cfg(target_os = "windows")]
 pub(crate) fn attach_to_window(menu: &Menu, frame: &eframe::Frame) -> bool {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     if let Ok(handle) = frame.window_handle() {
         if let RawWindowHandle::Win32(win32) = handle.as_raw() {
-            match unsafe { menu.init_for_hwnd(win32.hwnd.get() as _) } {
+            let hwnd = win32.hwnd.get() as _;
+            crate::windows_chrome::apply_dark_mode_to_window(hwnd);
+            match unsafe { menu.init_for_hwnd(hwnd) } {
                 Ok(()) => return true,
                 Err(e) => {
                     tracing::error!("Failed to attach menu bar to HWND: {e}");

--- a/crates/amux-app/src/menu_bar.rs
+++ b/crates/amux-app/src/menu_bar.rs
@@ -540,34 +540,67 @@ pub(crate) fn draw_egui_menu_bar(ctx: &egui::Context, theme: &crate::theme::Them
             visuals.window_fill = bg;
             visuals.panel_fill = bg;
 
-            egui::menu::bar(ui, |ui| {
+            // Diagnostic: draw a plain colored label first. If this is
+            // visible but the menu buttons below aren't, we know the
+            // problem is `egui::menu::bar` or `ui.menu_button` eating
+            // the style — not the panel itself being invisible.
+            ui.horizontal(|ui| {
+                ui.label(
+                    egui::RichText::new("[DEBUG: menu bar is rendering]")
+                        .color(fg)
+                        .strong(),
+                );
+                ui.separator();
+
+                // Use plain `ui.horizontal` + top-level buttons instead
+                // of `egui::menu::bar` + `ui.menu_button` so we can
+                // isolate whether menu::bar's internal `set_menu_style`
+                // is clobbering the text color override.
+                //
+                // Each top-level entry is a plain button; clicking one
+                // opens an egui popup with its items. This gives us
+                // full control of the button rendering.
                 for submenu in MENU_MODEL {
-                    ui.menu_button(submenu.label, |ui| {
-                        for item in submenu.items {
-                            match item {
-                                MenuItemDef::Separator => {
-                                    ui.separator();
-                                }
-                                MenuItemDef::Action {
-                                    label,
-                                    shortcut,
-                                    action,
-                                } => {
-                                    // Build the button: with shortcut
-                                    // text on the right when one is
-                                    // configured, plain otherwise.
-                                    let button = match shortcut {
-                                        Some(sc) => egui::Button::new(*label).shortcut_text(*sc),
-                                        None => egui::Button::new(*label),
-                                    };
-                                    if ui.add(button).clicked() {
-                                        push_action(*action);
-                                        ui.close_menu();
+                    let label_button = egui::Button::new(
+                        egui::RichText::new(submenu.label).color(fg),
+                    )
+                    .frame(false);
+                    let response = ui.add(label_button);
+                    let popup_id = ui.make_persistent_id(("amux_menu_popup", submenu.label));
+                    if response.clicked() {
+                        ui.memory_mut(|m| m.toggle_popup(popup_id));
+                    }
+                    egui::popup::popup_below_widget(
+                        ui,
+                        popup_id,
+                        &response,
+                        egui::PopupCloseBehavior::CloseOnClickOutside,
+                        |ui| {
+                            ui.set_min_width(180.0);
+                            for item in submenu.items {
+                                match item {
+                                    MenuItemDef::Separator => {
+                                        ui.separator();
+                                    }
+                                    MenuItemDef::Action {
+                                        label,
+                                        shortcut,
+                                        action,
+                                    } => {
+                                        let button = match shortcut {
+                                            Some(sc) => egui::Button::new(*label)
+                                                .shortcut_text(*sc),
+                                            None => egui::Button::new(*label),
+                                        };
+                                        if ui.add(button).clicked() {
+                                            push_action(*action);
+                                            ui.memory_mut(|m| m.close_popup());
+                                        }
                                     }
                                 }
                             }
-                        }
-                    });
+                        },
+                    );
                 }
             });
         });

--- a/crates/amux-app/src/menu_bar.rs
+++ b/crates/amux-app/src/menu_bar.rs
@@ -454,42 +454,106 @@ fn drain_muda_events() {
 // Non-macOS path (egui TopBottomPanel + menu::bar)
 // ---------------------------------------------------------------------
 
+/// Pick a readable foreground color for a given background by checking
+/// its perceived luminance. Matches what amux does elsewhere (sidebar,
+/// tab bar) to keep chrome text legible against any user theme.
+#[cfg(not(target_os = "macos"))]
+fn contrast_text(bg: egui::Color32) -> egui::Color32 {
+    // Rec. 601 luma — the approximation most UI toolkits use.
+    let r = bg.r() as f32;
+    let g = bg.g() as f32;
+    let b = bg.b() as f32;
+    let luma = 0.299 * r + 0.587 * g + 0.114 * b;
+    if luma < 128.0 {
+        egui::Color32::from_rgb(0xE6, 0xE6, 0xE6) // soft white
+    } else {
+        egui::Color32::from_rgb(0x20, 0x20, 0x20) // near black
+    }
+}
+
 /// Draw the menu bar into a [`egui::TopBottomPanel::top`] and push any
 /// clicked actions into the shared [`PENDING_ACTIONS`] queue. Must be
 /// called before any other top-level panels (sidebar, central) claim
 /// vertical space — egui panels nest in call order.
+///
+/// Theming: the panel's background uses `theme.titlebar_bg()` (same
+/// resolution chain as the tab bar) so the menu bar looks like a
+/// natural extension of amux's chrome. Foreground text is overridden
+/// via `style.visuals.override_text_color` with a contrast-aware color
+/// derived from the background, which ensures labels and shortcut
+/// hints are legible regardless of what theme the user configured.
+///
+/// The dropdown popups opened by `ui.menu_button` inherit the same
+/// `override_text_color` and the modified `widgets.*.weak_bg_fill`
+/// hover colors, so opened menus also render in amux's palette.
 #[cfg(not(target_os = "macos"))]
-pub(crate) fn draw_egui_menu_bar(ctx: &egui::Context) {
-    egui::TopBottomPanel::top("amux_menu_bar").show(ctx, |ui| {
-        egui::menu::bar(ui, |ui| {
-            for submenu in MENU_MODEL {
-                ui.menu_button(submenu.label, |ui| {
-                    for item in submenu.items {
-                        match item {
-                            MenuItemDef::Separator => {
-                                ui.separator();
-                            }
-                            MenuItemDef::Action {
-                                label,
-                                shortcut,
-                                action,
-                            } => {
-                                // Build the button: with shortcut text
-                                // on the right when one is configured,
-                                // plain otherwise.
-                                let button = match shortcut {
-                                    Some(sc) => egui::Button::new(*label).shortcut_text(*sc),
-                                    None => egui::Button::new(*label),
-                                };
-                                if ui.add(button).clicked() {
-                                    push_action(*action);
-                                    ui.close_menu();
+pub(crate) fn draw_egui_menu_bar(ctx: &egui::Context, theme: &crate::theme::Theme) {
+    let bg = theme.titlebar_bg();
+    let fg = contrast_text(bg);
+    // Hover background: slightly lighter/darker variant of bg so
+    // hovered items are visually distinct. Use gamma_multiply to
+    // shift luminance without messing with saturation.
+    let hover_bg = if fg == egui::Color32::from_rgb(0xE6, 0xE6, 0xE6) {
+        // Dark theme — brighten the bg for hover.
+        bg.gamma_multiply(1.4)
+    } else {
+        // Light theme — darken the bg for hover.
+        bg.gamma_multiply(0.85)
+    };
+
+    egui::TopBottomPanel::top("amux_menu_bar")
+        .frame(
+            egui::Frame::new()
+                .fill(bg)
+                .inner_margin(egui::Margin::symmetric(6, 2)),
+        )
+        .show(ctx, |ui| {
+            // Override the palette for everything rendered inside this
+            // panel and its popup children. Egui's dropdown popups
+            // inherit style from the UI that opened them, so these
+            // tweaks propagate into the menu dropdowns too.
+            let visuals = &mut ui.style_mut().visuals;
+            visuals.override_text_color = Some(fg);
+            visuals.widgets.inactive.weak_bg_fill = egui::Color32::TRANSPARENT;
+            visuals.widgets.inactive.bg_fill = egui::Color32::TRANSPARENT;
+            visuals.widgets.hovered.weak_bg_fill = hover_bg;
+            visuals.widgets.hovered.bg_fill = hover_bg;
+            visuals.widgets.active.weak_bg_fill = hover_bg;
+            visuals.widgets.active.bg_fill = hover_bg;
+            // Dropdown popup background (the window-like container
+            // that opens below a top-level menu button).
+            visuals.window_fill = bg;
+            visuals.panel_fill = bg;
+
+            egui::menu::bar(ui, |ui| {
+                for submenu in MENU_MODEL {
+                    ui.menu_button(submenu.label, |ui| {
+                        for item in submenu.items {
+                            match item {
+                                MenuItemDef::Separator => {
+                                    ui.separator();
+                                }
+                                MenuItemDef::Action {
+                                    label,
+                                    shortcut,
+                                    action,
+                                } => {
+                                    // Build the button: with shortcut
+                                    // text on the right when one is
+                                    // configured, plain otherwise.
+                                    let button = match shortcut {
+                                        Some(sc) => egui::Button::new(*label).shortcut_text(*sc),
+                                        None => egui::Button::new(*label),
+                                    };
+                                    if ui.add(button).clicked() {
+                                        push_action(*action);
+                                        ui.close_menu();
+                                    }
                                 }
                             }
                         }
-                    }
-                });
-            }
+                    });
+                }
+            });
         });
-    });
 }

--- a/crates/amux-app/src/notifications_ui.rs
+++ b/crates/amux-app/src/notifications_ui.rs
@@ -368,6 +368,20 @@ impl AmuxApp {
         if resp_new.clicked() {
             self.create_workspace(None);
         }
+
+        // --- File / Edit / View menu labels (Windows/Linux only) ---
+        // On macOS these live in the native NSApp menu bar at the top
+        // of the screen; here we draw them as clickable text inside
+        // the same titlebar strip as the icons, right after the last
+        // icon. Each label opens a popup with its submenu items.
+        //
+        // The `+ icon_size.x` advances past the last icon's right edge
+        // (the `x` variable above points at the icon's LEFT edge).
+        #[cfg(not(target_os = "macos"))]
+        {
+            let menu_start_x = x + icon_size.x;
+            crate::menu_bar::draw_menu_buttons(ui, menu_start_x, top_y, icon_size.y, &self.theme);
+        }
     }
 
     pub(crate) fn render_notification_panel(&mut self, ctx: &egui::Context) {

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -386,7 +386,10 @@ pub(crate) fn run() -> anyhow::Result<()> {
         }
     }
 
-    // Build the native menu bar (cross-platform via muda).
+    // Build the native menu bar. macOS only — Windows/Linux draw
+    // their menu bar via egui in `menu_bar::draw_egui_menu_bar` from
+    // the main update loop, so there's no muda::Menu to build.
+    #[cfg(target_os = "macos")]
     let menu = menu_bar::build();
 
     let viewport = egui::ViewportBuilder::default()
@@ -459,9 +462,10 @@ pub(crate) fn run() -> anyhow::Result<()> {
                 last_badge_count: 0,
                 cursor_blink_since: Instant::now(),
                 sound_player,
+                #[cfg(target_os = "macos")]
                 menu,
                 #[cfg(target_os = "windows")]
-                menu_attached: false,
+                window_chrome_applied: false,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
                 pending_browser_panes: Vec::new(),

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -272,6 +272,15 @@ fn cleanup_legacy_claude_hooks_in_settings() {
 
 pub(crate) fn run() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
+
+    // Windows: opt the process into dark-mode themed controls before any
+    // windows are created. Must happen before `eframe::run_native` so the
+    // main window is born with dark chrome — the per-window follow-up
+    // call (in menu_bar::attach_to_window) handles controls whose state
+    // is HWND-scoped. See `windows_chrome.rs` for the full rationale.
+    #[cfg(target_os = "windows")]
+    crate::windows_chrome::enable_process_dark_mode();
+
     cleanup_stale_scrollback_files();
     cleanup_stale_gemini_settings_files();
     cleanup_stale_codex_home_dirs();

--- a/crates/amux-app/src/windows_chrome.rs
+++ b/crates/amux-app/src/windows_chrome.rs
@@ -1,37 +1,47 @@
 //! Windows-only dark-mode chrome helpers.
 //!
-//! Enables dark-mode themed controls (title bar + common controls, best-
-//! effort for the native menu bar) on Windows 10/11. Called once at
-//! startup from `menu_bar::attach_to_window` right before the menu bar
-//! is initialized on the window's HWND, so the menu paints in dark mode
-//! from its first frame.
+//! Two entry points:
+//!
+//! - [`enable_process_dark_mode`]: called once from `startup::run`
+//!   before any windows are created. Opts the whole process into
+//!   dark-mode themed Win32 common controls (scrollbars, edit
+//!   controls, etc.) via undocumented `uxtheme.dll` ordinals.
+//!   Harmless on builds that don't have the ordinals — silently
+//!   no-ops and the process stays in light mode for any Win32
+//!   chrome we happen to host.
+//!
+//! - [`apply_dark_mode_to_window`]: called from `frame_update.rs` on
+//!   the first frame where the HWND is available. Sets the dark
+//!   title bar via `DwmSetWindowAttribute` (documented, stable since
+//!   Windows 10 2004) and opts the per-HWND dark mode in via
+//!   undocumented `AllowDarkModeForWindow`.
 //!
 //! Approach:
 //!
-//! 1. **Title bar**: documented `DwmSetWindowAttribute` with
+//! 1. **Title bar** (documented): `DwmSetWindowAttribute` with
 //!    `DWMWA_USE_IMMERSIVE_DARK_MODE` (attribute 20). Stable since
 //!    Windows 10 2004.
-//! 2. **Process-wide dark mode**: undocumented `SetPreferredAppMode` at
-//!    uxtheme.dll ordinal 135 (Windows 10 1903+), called with
-//!    `AllowDark`. This opts the process into dark-themed common
-//!    controls and is what VS Code, Windows Terminal, and File Explorer
-//!    all use internally.
-//! 3. **Per-window dark mode**: undocumented `AllowDarkModeForWindow`
-//!    at uxtheme.dll ordinal 133, called on the HWND. Required in
-//!    addition to the process-wide call for some themed controls.
-//! 4. **Policy refresh**: undocumented `RefreshImmersiveColorPolicyState`
-//!    at uxtheme.dll ordinal 104, to force Windows to reapply dark mode
-//!    to already-created windows.
+//! 2. **Process-wide dark mode** (undocumented): `SetPreferredAppMode`
+//!    at `uxtheme.dll` ordinal 135 (Windows 10 1903+), called with
+//!    `AllowDark`. Same approach VS Code, Windows Terminal, and File
+//!    Explorer use internally.
+//! 3. **Per-window dark mode** (undocumented): `AllowDarkModeForWindow`
+//!    at `uxtheme.dll` ordinal 133, called on the HWND.
+//! 4. **Policy refresh** (undocumented): `RefreshImmersiveColorPolicyState`
+//!    at `uxtheme.dll` ordinal 104, to force Windows to reapply the
+//!    dark-mode policy to already-created windows.
 //!
-//! The undocumented ordinals may break or be renumbered on future
-//! Windows builds. Every call site is defensive: if the function
-//! can't be loaded, we silently no-op and the user sees whatever
-//! chrome they would have seen without amux trying. No crashes.
+//! **Menu bar is NOT rendered via native Win32** — amux draws its own
+//! menu bar with egui on Windows/Linux (see `menu_bar::draw_egui_menu_bar`),
+//! so the undocumented ordinals don't need to theme a Win32 `HMENU`.
+//! They're kept here as defense in depth for any stray Win32 controls
+//! that might appear inside the window (e.g. file dialogs hosted via
+//! system shell APIs).
 //!
-//! If this still doesn't make the native menu bar follow dark mode
-//! (Windows 11 has made the Win32 menu rendering path more stubborn
-//! than it used to be), the follow-up fix is to replace muda's native
-//! menu with an egui-drawn top bar. Tracked in amux #190.
+//! Every undocumented ordinal is resolved via `LoadLibraryW` +
+//! `GetProcAddress`. If an ordinal can't be found (future Windows
+//! removed or renumbered it), the specific call silently skips — no
+//! crash, no tracing noise, just degrades to the pre-amux baseline.
 
 #![cfg(target_os = "windows")]
 
@@ -130,15 +140,20 @@ pub fn enable_process_dark_mode() {
 
 /// Enable dark mode for a specific window. Applies both the documented
 /// DWM title-bar flag AND the undocumented uxtheme per-window
-/// `AllowDarkModeForWindow` ordinal, which is required in addition to
-/// the process-wide `SetPreferredAppMode` for themed Win32 controls
-/// hosted inside the window.
+/// `AllowDarkModeForWindow` ordinal.
 ///
-/// Takes the HWND as a raw `isize` to match the shape that
-/// `raw_window_handle::Win32WindowHandle::hwnd` and `muda::Menu::init_for_hwnd`
-/// both use — this lets the caller pass the same handle to both APIs
-/// without fighting two different pointer types. We convert internally
-/// to `windows-sys`'s `HWND` (which is `*mut c_void`).
+/// The DWM call is what actually darkens the title bar (including the
+/// title text, the window icon, and the min/max/close buttons on
+/// Windows 10 2004+). The per-window uxtheme call opts themed Win32
+/// controls hosted inside the HWND into dark mode — we don't rely on
+/// it for the menu bar (amux draws that with egui on Windows), but
+/// it's retained as defense in depth for any Win32 controls that
+/// might surface later (shell file dialogs, etc.).
+///
+/// Takes the HWND as a raw `isize` to match
+/// `raw_window_handle::Win32WindowHandle::hwnd.get()`, which returns
+/// `NonZeroIsize`. We convert internally to `windows-sys`'s `HWND`
+/// (which is `*mut c_void`).
 ///
 /// Call after `enable_process_dark_mode()`, once the window's HWND is
 /// available (first `App::update()` frame).

--- a/crates/amux-app/src/windows_chrome.rs
+++ b/crates/amux-app/src/windows_chrome.rs
@@ -1,0 +1,159 @@
+//! Windows-only dark-mode chrome helpers.
+//!
+//! Enables dark-mode themed controls (title bar + common controls, best-
+//! effort for the native menu bar) on Windows 10/11. Called once at
+//! startup from `menu_bar::attach_to_window` right before the menu bar
+//! is initialized on the window's HWND, so the menu paints in dark mode
+//! from its first frame.
+//!
+//! Approach:
+//!
+//! 1. **Title bar**: documented `DwmSetWindowAttribute` with
+//!    `DWMWA_USE_IMMERSIVE_DARK_MODE` (attribute 20). Stable since
+//!    Windows 10 2004.
+//! 2. **Process-wide dark mode**: undocumented `SetPreferredAppMode` at
+//!    uxtheme.dll ordinal 135 (Windows 10 1903+), called with
+//!    `AllowDark`. This opts the process into dark-themed common
+//!    controls and is what VS Code, Windows Terminal, and File Explorer
+//!    all use internally.
+//! 3. **Per-window dark mode**: undocumented `AllowDarkModeForWindow`
+//!    at uxtheme.dll ordinal 133, called on the HWND. Required in
+//!    addition to the process-wide call for some themed controls.
+//! 4. **Policy refresh**: undocumented `RefreshImmersiveColorPolicyState`
+//!    at uxtheme.dll ordinal 104, to force Windows to reapply dark mode
+//!    to already-created windows.
+//!
+//! The undocumented ordinals may break or be renumbered on future
+//! Windows builds. Every call site is defensive: if the function
+//! can't be loaded, we silently no-op and the user sees whatever
+//! chrome they would have seen without amux trying. No crashes.
+//!
+//! If this still doesn't make the native menu bar follow dark mode
+//! (Windows 11 has made the Win32 menu rendering path more stubborn
+//! than it used to be), the follow-up fix is to replace muda's native
+//! menu with an egui-drawn top bar. Tracked in amux #190.
+
+#![cfg(target_os = "windows")]
+
+use windows_sys::Win32::Foundation::{BOOL, HMODULE, HWND, TRUE};
+use windows_sys::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_USE_IMMERSIVE_DARK_MODE};
+use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
+
+/// PreferredAppMode — the arg to `SetPreferredAppMode` (uxtheme.dll
+/// ordinal 135). Values are from leaked Windows SDK headers and match
+/// the enum used internally by Explorer.
+#[repr(C)]
+#[allow(dead_code)]
+enum PreferredAppMode {
+    Default = 0,
+    AllowDark = 1,
+    ForceDark = 2,
+    ForceLight = 3,
+}
+
+/// UTF-16 NUL-terminated literal for `LoadLibraryW`.
+const UXTHEME_DLL_W: [u16; 12] = [
+    b'u' as u16,
+    b'x' as u16,
+    b't' as u16,
+    b'h' as u16,
+    b'e' as u16,
+    b'm' as u16,
+    b'e' as u16,
+    b'.' as u16,
+    b'd' as u16,
+    b'l' as u16,
+    b'l' as u16,
+    0,
+];
+
+/// Load uxtheme.dll once. Returns null if the load fails (unrealistic
+/// on any Windows system that runs amux, but we handle it anyway).
+///
+/// We intentionally never `FreeLibrary` the handle: uxtheme is a core
+/// system DLL that stays loaded for the process lifetime regardless,
+/// so leaking our one reference is a no-op.
+unsafe fn uxtheme() -> HMODULE {
+    LoadLibraryW(UXTHEME_DLL_W.as_ptr())
+}
+
+/// Enable process-wide dark mode. Call once at startup, before any
+/// windows are created or shown. Safe to call multiple times — the
+/// underlying ordinals are idempotent.
+///
+/// Reaches two undocumented uxtheme ordinals: 135 `SetPreferredAppMode`
+/// and 104 `RefreshImmersiveColorPolicyState`. If either ordinal can't
+/// be resolved (future Windows build that removed or renumbered them),
+/// we silently skip that step and the process stays in light mode —
+/// no crash, no tracing-level noise, just the pre-amux baseline.
+pub fn enable_process_dark_mode() {
+    unsafe {
+        let dll = uxtheme();
+        if dll.is_null() {
+            return;
+        }
+
+        // Ordinal 135: SetPreferredAppMode(PreferredAppMode) -> PreferredAppMode
+        // Returns the previous mode, which we discard. The ordinal is passed
+        // to `GetProcAddress` as a LPCSTR whose low WORD is the ordinal
+        // number (Win32 convention; equivalent to the C `MAKEINTRESOURCEA`
+        // macro).
+        if let Some(fn_ptr) = GetProcAddress(dll, 135usize as *const u8) {
+            type SetPreferredAppMode =
+                unsafe extern "system" fn(PreferredAppMode) -> PreferredAppMode;
+            let set_preferred_app_mode: SetPreferredAppMode = std::mem::transmute(fn_ptr);
+            // AllowDark = follow system setting when system is in dark mode.
+            // We deliberately don't use ForceDark because some users may
+            // configure Windows in light mode intentionally — following the
+            // system preference is the least surprising choice.
+            let _previous = set_preferred_app_mode(PreferredAppMode::AllowDark);
+        }
+
+        // Ordinal 104: RefreshImmersiveColorPolicyState() -> void
+        // Forces Windows to reapply the policy to existing windows.
+        if let Some(fn_ptr) = GetProcAddress(dll, 104usize as *const u8) {
+            type RefreshImmersiveColorPolicyState = unsafe extern "system" fn();
+            let refresh: RefreshImmersiveColorPolicyState = std::mem::transmute(fn_ptr);
+            refresh();
+        }
+    }
+}
+
+/// Enable dark mode for a specific window. Applies both the documented
+/// DWM title-bar flag AND the undocumented uxtheme per-window
+/// `AllowDarkModeForWindow` ordinal, which is required in addition to
+/// the process-wide `SetPreferredAppMode` for themed Win32 controls
+/// hosted inside the window.
+///
+/// Call after `enable_process_dark_mode()`, once the window's HWND is
+/// available (first `App::update()` frame).
+pub fn apply_dark_mode_to_window(hwnd: HWND) {
+    unsafe {
+        // Documented path: immersive dark mode for the title bar.
+        // Attribute 20 (`DWMWA_USE_IMMERSIVE_DARK_MODE`) on Windows
+        // 10 2004+. Older Windows 10 builds used attribute 19 — we
+        // only target modern builds.
+        let enable: BOOL = TRUE;
+        let _ = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_USE_IMMERSIVE_DARK_MODE,
+            &enable as *const BOOL as _,
+            std::mem::size_of::<BOOL>() as u32,
+        );
+
+        // Undocumented path: per-window dark mode opt-in. Required for
+        // themed common controls to draw in dark mode when hosted
+        // inside this specific HWND.
+        let dll = uxtheme();
+        if dll.is_null() {
+            return;
+        }
+
+        // Ordinal 133: AllowDarkModeForWindow(HWND, BOOL) -> BOOL
+        if let Some(fn_ptr) = GetProcAddress(dll, 133usize as *const u8) {
+            type AllowDarkModeForWindow = unsafe extern "system" fn(HWND, BOOL) -> BOOL;
+            let allow_dark_mode_for_window: AllowDarkModeForWindow = std::mem::transmute(fn_ptr);
+            let _ = allow_dark_mode_for_window(hwnd, TRUE);
+        }
+    }
+}

--- a/crates/amux-app/src/windows_chrome.rs
+++ b/crates/amux-app/src/windows_chrome.rs
@@ -35,9 +35,18 @@
 
 #![cfg(target_os = "windows")]
 
-use windows_sys::Win32::Foundation::{BOOL, HMODULE, HWND, TRUE};
+use windows_sys::Win32::Foundation::{HMODULE, HWND};
 use windows_sys::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_USE_IMMERSIVE_DARK_MODE};
 use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
+
+// `BOOL` / `TRUE` used to live in `windows_sys::Win32::Foundation`, but
+// windows-sys 0.60 moved or renamed them. We only need them as a plain
+// 4-byte integer for the DWM attribute, so declare them locally instead
+// of chasing the re-export. `BOOL` on Win32 is always a signed 32-bit
+// int where 0 = FALSE and any non-zero value = TRUE.
+#[allow(non_camel_case_types)]
+type BOOL = i32;
+const TRUE: BOOL = 1;
 
 /// PreferredAppMode — the arg to `SetPreferredAppMode` (uxtheme.dll
 /// ordinal 135). Values are from leaked Windows SDK headers and match
@@ -125,18 +134,28 @@ pub fn enable_process_dark_mode() {
 /// the process-wide `SetPreferredAppMode` for themed Win32 controls
 /// hosted inside the window.
 ///
+/// Takes the HWND as a raw `isize` to match the shape that
+/// `raw_window_handle::Win32WindowHandle::hwnd` and `muda::Menu::init_for_hwnd`
+/// both use — this lets the caller pass the same handle to both APIs
+/// without fighting two different pointer types. We convert internally
+/// to `windows-sys`'s `HWND` (which is `*mut c_void`).
+///
 /// Call after `enable_process_dark_mode()`, once the window's HWND is
 /// available (first `App::update()` frame).
-pub fn apply_dark_mode_to_window(hwnd: HWND) {
+pub fn apply_dark_mode_to_window(hwnd_raw: isize) {
+    let hwnd: HWND = hwnd_raw as HWND;
     unsafe {
         // Documented path: immersive dark mode for the title bar.
         // Attribute 20 (`DWMWA_USE_IMMERSIVE_DARK_MODE`) on Windows
         // 10 2004+. Older Windows 10 builds used attribute 19 — we
         // only target modern builds.
+        //
+        // windows-sys 0.60 declares the attribute constant as `i32`
+        // but `DwmSetWindowAttribute` takes `u32`, so we have to cast.
         let enable: BOOL = TRUE;
         let _ = DwmSetWindowAttribute(
             hwnd,
-            DWMWA_USE_IMMERSIVE_DARK_MODE,
+            DWMWA_USE_IMMERSIVE_DARK_MODE as u32,
             &enable as *const BOOL as _,
             std::mem::size_of::<BOOL>() as u32,
         );

--- a/crates/amux-app/src/windows_chrome.rs
+++ b/crates/amux-app/src/windows_chrome.rs
@@ -54,7 +54,12 @@ use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
 // 4-byte integer for the DWM attribute, so declare them locally instead
 // of chasing the re-export. `BOOL` on Win32 is always a signed 32-bit
 // int where 0 = FALSE and any non-zero value = TRUE.
-#[allow(non_camel_case_types)]
+//
+// `BOOL` (all-caps) is the documented Win32 type name — keep it as-is
+// to match the platform conventions the rest of this module uses
+// (HWND, HMODULE, etc.). Suppress the clippy lint that would otherwise
+// rename it to `Bool`.
+#[allow(clippy::upper_case_acronyms)]
 type BOOL = i32;
 const TRUE: BOOL = 1;
 


### PR DESCRIPTION
## Summary

Adds dark-mode chrome to amux on Windows — previously the title bar and native menu bar both rendered in bright light mode against amux's dark terminal area, which was the most visible "Windows port of a Mac app" tell on first launch.

Fixes #190.

## What landed

New \`crates/amux-app/src/windows_chrome.rs\` module (cfg-gated to \`target_os = \"windows\"\`) with two entry points:

- \`enable_process_dark_mode()\` — called once at the top of \`startup::run\` before \`eframe::run_native\`. Uses the undocumented \`uxtheme.dll\` ordinal 135 \`SetPreferredAppMode(AllowDark)\` to opt the whole process into dark-mode themed controls, then ordinal 104 \`RefreshImmersiveColorPolicyState\` to force Windows to reapply the policy.
- \`apply_dark_mode_to_window(hwnd)\` — called from \`menu_bar::attach_to_window\` right before \`menu.init_for_hwnd\`. Uses documented \`DwmSetWindowAttribute\` with \`DWMWA_USE_IMMERSIVE_DARK_MODE\` (stable since Windows 10 2004) for the title bar, plus undocumented \`uxtheme.dll\` ordinal 133 \`AllowDarkModeForWindow\` for themed Win32 controls inside the HWND.

Ordering is important: the per-window dark-mode call fires BEFORE \`menu.init_for_hwnd\` because \`init_for_hwnd\` triggers an immediate \`DrawMenuBar\`, and if dark mode isn't enabled on the HWND yet the menu bar caches light-mode chrome and doesn't re-theme until the next \`WM_THEMECHANGED\`.

## Fallback behaviour

Every undocumented ordinal is resolved via \`LoadLibraryW\` + \`GetProcAddress\`. If a specific ordinal can't be resolved (future Windows build that renumbered or removed it), that call silently skips — no crash, no panic, no tracing noise, just a graceful degradation to whatever the pre-amux Windows chrome looks like. The documented \`DwmSetWindowAttribute\` call is independent and keeps working regardless.

## Dependency added

\`windows-sys = \"0.60\"\` as a Windows-only target dep of \`amux-app\`, with the three feature gates the module actually needs (\`Win32_Foundation\`, \`Win32_Graphics_Dwm\`, \`Win32_System_LibraryLoader\`). Pinned to 0.60 to align with versions already in \`Cargo.lock\` via transitive deps — no new crate-tree generation added.

## Test plan

- [x] \`cargo build -p amux-app\` on macOS — passes (Windows-only code is cfg-gated out)
- [x] \`cargo fmt --check\`, \`cargo clippy --workspace -- -D warnings\` — clean
- [ ] Windows CI green (first real compile of the new module)
- [ ] ARM64 Windows VM: local build + launch, screenshot comparison vs pre-change screenshot showing:
  - Title bar now dark (instead of light)
  - Native menu bar either dark-themed OR still light (tells us whether the undocumented approach works on Windows 11 ARM64 x64 emulation)
- [ ] If the menu bar is still stubbornly white, follow up with option B (egui-drawn top bar) in a separate PR

## Out of scope

Option B (replace muda's native menu with an egui-drawn top bar) is the nuclear-option fallback if the undocumented ordinals turn out to not affect Windows 11 menu rendering anymore. Documented in #190 as a follow-up. This PR tries the cheap approach first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic dark title bar and themed window controls on Windows.
  * Built-in in-app menu bar for Windows/Linux (renders menus inside the app).

* **Bug Fixes / Improvements**
  * More consistent menu action handling across platforms; menu clicks from both native and in-app menus are now reliably processed.
  * macOS continues to use the native system menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->