### PR TITLE
Windows polish cleanup: default theme + dark popups + title sanitizer + configuration docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,11 +66,11 @@ Three first-class agent integrations, each using the agent's native event system
 - **tmux compat shim**: `amux install-tmux-shim` routes `tmux` calls to amux for agent scripts written for tmux
 
 ### Configuration
-Config file: `~/.config/amux/config.toml` (or `%APPDATA%\amux\config.toml` on Windows). Covers appearance, notifications, keybindings, and agent overrides. Notable fields:
+Config file: `~/.config/amux/config.toml` (or `%APPDATA%\amux\config.toml` on Windows). Covers appearance, notifications, keybindings, and agent overrides. **Full reference in [`docs/configuration.md`](docs/configuration.md)** — it documents every field, the three-layer theme resolution (built-in defaults → `theme_source` → `[colors]` overrides), keybinding syntax, and per-platform defaults. Quick summary of the notable fields:
 
-- `theme_source` — `"default"` (built-in) or `"ghostty"` (reads `~/.config/ghostty/config`)
+- `theme_source` — `"default"` (amux built-in neutral dark palette) or `"ghostty"` (reads `~/.config/ghostty/config`)
 - `font_family` / `font_size` — cosmic-text resolved against system fonts
-- `menu_bar_style` — in-window menu presentation on Windows/Linux: `"menubar"` (File/Edit/View strip above the icon row, default on Win/Linux), `"hamburger"` (single `≡` button in the icon row, space-efficient), or `"none"` (no in-window menu, default on macOS where the NSApp native menu bar provides menu access). Requires restart to take effect. macOS always uses the NSApp native menu bar regardless of this setting — the in-window paths are non-macOS only.
+- `menu_bar_style` — in-window menu presentation on Windows/Linux: `"menubar"` (File/Edit/View strip above the icon row, default on Win/Linux), `"hamburger"` (single `≡` button, space-efficient), or `"none"` (no in-window menu, default on macOS). macOS always uses the NSApp native menu bar regardless of this setting
 - `colors` — per-element overrides on top of the resolved theme
 - `keybindings` — user-customized action bindings merged with platform defaults
 

--- a/crates/amux-app/src/find_bar.rs
+++ b/crates/amux-app/src/find_bar.rs
@@ -21,90 +21,96 @@ impl AmuxApp {
         let mut close = false;
         let mut navigate: Option<isize> = None; // +1 = next, -1 = prev
 
-        egui::Window::new("Find")
-            .collapsible(false)
-            .resizable(false)
-            .anchor(egui::Align2::RIGHT_TOP, [-8.0, 8.0])
-            .fixed_size([300.0, 0.0])
-            .show(ctx, |ui| {
-                ui.horizontal(|ui| {
-                    let response =
-                        ui.text_edit_singleline(&mut self.find_state.as_mut().unwrap().query);
+        // Dark-mode the `egui::Window` Frame; see rename_modal.rs
+        // for the full rationale. Uses `with_modal_palette` so
+        // widget chrome (buttons, text field) stays default.
+        let palette = crate::popup_theme::MenuPalette::from_theme(&self.theme);
+        crate::popup_theme::with_modal_palette(ctx, palette, || {
+            egui::Window::new("Find")
+                .collapsible(false)
+                .resizable(false)
+                .anchor(egui::Align2::RIGHT_TOP, [-8.0, 8.0])
+                .fixed_size([300.0, 0.0])
+                .show(ctx, |ui| {
+                    ui.horizontal(|ui| {
+                        let response =
+                            ui.text_edit_singleline(&mut self.find_state.as_mut().unwrap().query);
 
-                    // Auto-focus the text field on first show
-                    if let Some(fs) = self.find_state.as_mut() {
-                        if fs.just_opened {
-                            response.request_focus();
-                            fs.just_opened = false;
-                        }
-                    }
-
-                    // Apply pending select-all from menu bar (Cmd+A consumed by muda).
-                    if pending_select_all && response.has_focus() {
-                        let query = &self.find_state.as_ref().unwrap().query;
-                        if let Some(mut text_state) =
-                            egui::TextEdit::load_state(ui.ctx(), response.id)
-                        {
-                            let char_count = query.chars().count();
-                            text_state
-                                .cursor
-                                .set_char_range(Some(egui::text::CCursorRange::two(
-                                    egui::text::CCursor::new(0),
-                                    egui::text::CCursor::new(char_count),
-                                )));
-                            text_state.store(ui.ctx(), response.id);
-                        }
-                    }
-
-                    // Enter = next, Shift+Enter = prev
-                    if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-                        if ui.input(|i| i.modifiers.shift) {
-                            navigate = Some(-1);
-                        } else {
-                            navigate = Some(1);
-                        }
-                        response.request_focus();
-                    }
-
-                    // Trigger search on text change
-                    if response.changed() {
-                        let find = self.find_state.as_ref().unwrap();
-                        let query = find.query.clone();
-                        let pane_id = find.pane_id;
-                        if let Some(PaneEntry::Terminal(managed)) = self.panes.get(&pane_id) {
-                            let matches = managed
-                                .active_surface()
-                                .map(|sf| sf.pane.search_scrollback(&query))
-                                .unwrap_or_default();
-                            let find = self.find_state.as_mut().unwrap();
-                            find.matches = matches;
-                            find.current_match = 0;
-                        }
-                    }
-
-                    if ui.button("X").clicked() {
-                        close = true;
-                    }
-                });
-
-                // Show match count
-                if let Some(find) = &self.find_state {
-                    let total = find.matches.len();
-                    if total > 0 {
-                        ui.horizontal(|ui| {
-                            ui.label(format!("{}/{}", find.current_match + 1, total));
-                            if ui.button("<").clicked() {
-                                navigate = Some(-1);
+                        // Auto-focus the text field on first show
+                        if let Some(fs) = self.find_state.as_mut() {
+                            if fs.just_opened {
+                                response.request_focus();
+                                fs.just_opened = false;
                             }
-                            if ui.button(">").clicked() {
+                        }
+
+                        // Apply pending select-all from menu bar (Cmd+A consumed by muda).
+                        if pending_select_all && response.has_focus() {
+                            let query = &self.find_state.as_ref().unwrap().query;
+                            if let Some(mut text_state) =
+                                egui::TextEdit::load_state(ui.ctx(), response.id)
+                            {
+                                let char_count = query.chars().count();
+                                text_state.cursor.set_char_range(Some(
+                                    egui::text::CCursorRange::two(
+                                        egui::text::CCursor::new(0),
+                                        egui::text::CCursor::new(char_count),
+                                    ),
+                                ));
+                                text_state.store(ui.ctx(), response.id);
+                            }
+                        }
+
+                        // Enter = next, Shift+Enter = prev
+                        if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                            if ui.input(|i| i.modifiers.shift) {
+                                navigate = Some(-1);
+                            } else {
                                 navigate = Some(1);
                             }
-                        });
-                    } else if !find.query.is_empty() {
-                        ui.label("No matches");
+                            response.request_focus();
+                        }
+
+                        // Trigger search on text change
+                        if response.changed() {
+                            let find = self.find_state.as_ref().unwrap();
+                            let query = find.query.clone();
+                            let pane_id = find.pane_id;
+                            if let Some(PaneEntry::Terminal(managed)) = self.panes.get(&pane_id) {
+                                let matches = managed
+                                    .active_surface()
+                                    .map(|sf| sf.pane.search_scrollback(&query))
+                                    .unwrap_or_default();
+                                let find = self.find_state.as_mut().unwrap();
+                                find.matches = matches;
+                                find.current_match = 0;
+                            }
+                        }
+
+                        if ui.button("X").clicked() {
+                            close = true;
+                        }
+                    });
+
+                    // Show match count
+                    if let Some(find) = &self.find_state {
+                        let total = find.matches.len();
+                        if total > 0 {
+                            ui.horizontal(|ui| {
+                                ui.label(format!("{}/{}", find.current_match + 1, total));
+                                if ui.button("<").clicked() {
+                                    navigate = Some(-1);
+                                }
+                                if ui.button(">").clicked() {
+                                    navigate = Some(1);
+                                }
+                            });
+                        } else if !find.query.is_empty() {
+                            ui.label("No matches");
+                        }
                     }
-                }
-            });
+                });
+        });
 
         if close {
             self.find_state = None;

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -15,6 +15,29 @@ impl eframe::App for AmuxApp {
             return;
         }
 
+        // Apply amux's popup palette to the ctx's style so that
+        // every egui popup / context menu / menu_button in the app
+        // renders in amux's chrome colors instead of egui's
+        // default light theme.
+        //
+        // This is the ONLY place `Response::context_menu` popups
+        // pick up their theme from — egui's context_menu reads
+        // `button.ctx.style()` directly when constructing its Frame
+        // (see `egui/src/menu.rs:392` / `Frame::menu(&button.ctx.style())`),
+        // not the parent ui's style. Per-call-site
+        // `apply_menu_palette(ui, palette)` has no effect on
+        // context menus.
+        //
+        // Done once per frame so theme changes (e.g. the user
+        // editing `theme_source` in the config) propagate on the
+        // next frame without a restart. The operation is cheap:
+        // one `Arc::make_mut` on the ctx style + a handful of
+        // field writes.
+        {
+            let palette = crate::popup_theme::MenuPalette::from_theme(&self.theme);
+            crate::popup_theme::apply_menu_palette_to_ctx(ctx, palette);
+        }
+
         // Apply dark-mode window chrome to the Win32 HWND. Retries each
         // frame until the HWND is available via `eframe::Frame::window_handle`,
         // then flips `window_chrome_applied` so we don't keep re-poking

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -459,14 +459,16 @@ impl eframe::App for AmuxApp {
         // Hyperlink hover detection + Cmd+click handling
         self.handle_hyperlinks(ctx);
 
-        // Update window title from focused pane's active tab
+        // Update window title from focused pane's active tab.
+        // Uses `managed.title()` for the terminal path so the
+        // raw pane title gets run through `title_sanitize::sanitize_pane_title`
+        // first — collapses ugly absolute shell exe paths (e.g.
+        // Windows' `C:\Program Files\WindowsApps\…\pwsh.exe`) to
+        // a clean basename like `pwsh`.
         let focused_id = self.focused_pane_id();
         if let Some(PaneEntry::Terminal(managed)) = self.panes.get(&focused_id) {
             let title = match managed.active_tab() {
-                managed_pane::ActiveTab::Terminal(_) => managed
-                    .active_surface()
-                    .map(|sf| sf.pane.title().to_string())
-                    .unwrap_or_default(),
+                managed_pane::ActiveTab::Terminal(_) => managed.title(),
                 managed_pane::ActiveTab::Browser(bid) => {
                     self.panes.get(&bid).map(|e| e.title()).unwrap_or_default()
                 }

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -15,28 +15,16 @@ impl eframe::App for AmuxApp {
             return;
         }
 
-        // Apply amux's popup palette to the ctx's style so that
-        // every egui popup / context menu / menu_button in the app
-        // renders in amux's chrome colors instead of egui's
-        // default light theme.
-        //
-        // This is the ONLY place `Response::context_menu` popups
-        // pick up their theme from — egui's context_menu reads
-        // `button.ctx.style()` directly when constructing its Frame
-        // (see `egui/src/menu.rs:392` / `Frame::menu(&button.ctx.style())`),
-        // not the parent ui's style. Per-call-site
-        // `apply_menu_palette(ui, palette)` has no effect on
-        // context menus.
-        //
-        // Done once per frame so theme changes (e.g. the user
-        // editing `theme_source` in the config) propagate on the
-        // next frame without a restart. The operation is cheap:
-        // one `Arc::make_mut` on the ctx style + a handful of
-        // field writes.
-        {
-            let palette = crate::popup_theme::MenuPalette::from_theme(&self.theme);
-            crate::popup_theme::apply_menu_palette_to_ctx(ctx, palette);
-        }
+        // NOTE: popup palette is NOT applied to `ctx.style()`
+        // globally here. Mutating `ctx.style()` for the whole frame
+        // would also restyle non-menu widgets (modals, text fields,
+        // buttons) that read from the ctx style, because the menu
+        // palette sets widget fills to transparent and widget
+        // strokes to none. Instead, popup theming is applied
+        // per-call-site via `popup_theme::with_menu_palette`, which
+        // scopes the ctx-style mutation to a single
+        // `Response::context_menu` / popup call and restores the
+        // original style immediately afterward.
 
         // Apply dark-mode window chrome to the Win32 HWND. Retries each
         // frame until the HWND is available via `eframe::Frame::window_handle`,

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -12,6 +12,7 @@ mod managed_pane;
 mod menu_bar;
 mod notifications_ui;
 mod pane_render;
+mod popup_theme;
 mod rename_modal;
 mod render;
 mod selection;
@@ -20,6 +21,7 @@ mod startup;
 mod system_notify;
 mod tab_icons;
 mod theme;
+mod title_sanitize;
 #[cfg(target_os = "windows")]
 mod windows_chrome;
 mod workspace_ops;
@@ -529,7 +531,11 @@ impl AmuxApp {
                                 let (cols, rows) = sf.pane.dimensions();
                                 amux_session::SavedSurface {
                                     id: sf.id,
-                                    title: sf.pane.title().to_string(),
+                                    // Sanitize before saving so a
+                                    // restored session shows `pwsh`
+                                    // not the full WindowsApps path.
+                                    title: title_sanitize::sanitize_pane_title(sf.pane.title())
+                                        .into_owned(),
                                     working_dir,
                                     scrollback,
                                     scrollback_vt,

--- a/crates/amux-app/src/managed_pane.rs
+++ b/crates/amux-app/src/managed_pane.rs
@@ -274,6 +274,15 @@ impl ManagedPane {
     }
 
     /// Display title for this pane (user title > OSC title > shell fallback).
+    ///
+    /// The `pane.title()` fallback — which is the raw ghostty-vt
+    /// terminal title — gets run through [`title_sanitize::sanitize_pane_title`]
+    /// to collapse ugly absolute shell exe paths (notably Windows'
+    /// `C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.0.0_arm64__8wekyb3d8bbwe\pwsh.exe`)
+    /// down to a clean shell basename (`pwsh`, `cmd`, `bash`).
+    /// `user_title` and `surface_title` are passed through
+    /// unchanged because those are user-set and we shouldn't
+    /// second-guess what the user typed.
     pub(crate) fn title(&self) -> String {
         if self.active_is_browser() {
             return "Browser".to_string();
@@ -285,7 +294,7 @@ impl ManagedPane {
             if let Some(ref t) = surface.metadata.surface_title {
                 return t.clone();
             }
-            surface.pane.title().to_string()
+            crate::title_sanitize::sanitize_pane_title(surface.pane.title()).into_owned()
         } else {
             String::new()
         }

--- a/crates/amux-app/src/menu_bar.rs
+++ b/crates/amux-app/src/menu_bar.rs
@@ -471,117 +471,12 @@ fn drain_muda_events() {
 // the remaining horizontal space. One strip, one coordinate system,
 // no layer fights.
 
-/// Pick a readable foreground color for a given background by checking
-/// its perceived luminance. Matches what amux does elsewhere (sidebar,
-/// tab bar) to keep chrome text legible against any user theme.
+// `MenuPalette`, `apply_menu_palette`, and `contrast_text` now live
+// in `crate::popup_theme` so they can be shared with the sidebar's
+// context menu and any other popup surface that needs amux-themed
+// chrome. See that module for the full rationale.
 #[cfg(not(target_os = "macos"))]
-pub(crate) fn contrast_text(bg: egui::Color32) -> egui::Color32 {
-    // Rec. 601 luma — the approximation most UI toolkits use.
-    let r = bg.r() as f32;
-    let g = bg.g() as f32;
-    let b = bg.b() as f32;
-    let luma = 0.299 * r + 0.587 * g + 0.114 * b;
-    if luma < 128.0 {
-        egui::Color32::from_rgb(0xE6, 0xE6, 0xE6) // soft white
-    } else {
-        egui::Color32::from_rgb(0x20, 0x20, 0x20) // near black
-    }
-}
-
-/// Bundle of theme-derived colors used by every menu-related
-/// rendering path below. Computed once per top-level call so the
-/// per-item loop doesn't redo the luma math.
-#[cfg(not(target_os = "macos"))]
-#[derive(Clone, Copy)]
-struct MenuPalette {
-    bg: egui::Color32,
-    fg: egui::Color32,
-    hover_bg: egui::Color32,
-    divider: egui::Color32,
-}
-
-#[cfg(not(target_os = "macos"))]
-impl MenuPalette {
-    fn from_theme(theme: &crate::theme::Theme) -> Self {
-        let bg = theme.titlebar_bg();
-        let fg = contrast_text(bg);
-        let luma_sum: u16 = bg.r() as u16 + bg.g() as u16 + (bg.b() as u16);
-        let hover_bg = if luma_sum < 384 {
-            bg.gamma_multiply(1.5) // dark theme → brighten on hover
-        } else {
-            bg.gamma_multiply(0.85) // light theme → darken on hover
-        };
-        // Divider: a faint version of fg for popup borders and
-        // separator lines. Low alpha so it doesn't overpower — this
-        // color is used for a 1px stroke on popup frames, so even
-        // a small alpha bump looks loud. Tune down if future
-        // complaints surface.
-        let divider = egui::Color32::from_rgba_unmultiplied(fg.r(), fg.g(), fg.b(), 24);
-        Self {
-            bg,
-            fg,
-            hover_bg,
-            divider,
-        }
-    }
-}
-
-/// Apply a `MenuPalette` to a UI's visuals so that every widget
-/// drawn inside is rendered in amux's chrome colors. Call this at
-/// the top of any popup closure.
-///
-/// This also styles the popup's OUTER Frame (which egui's
-/// `popup_below_widget` / `menu_button` builds automatically from
-/// `visuals.window_fill` + `visuals.window_stroke`). We don't wrap
-/// our content in an additional inner Frame — doing that stacks
-/// two frames + their inner_margin gap and produces what looks
-/// like an absurdly thick border.
-#[cfg(not(target_os = "macos"))]
-fn apply_menu_palette(ui: &mut egui::Ui, palette: MenuPalette) {
-    let visuals = &mut ui.style_mut().visuals;
-
-    // --- Popup container styling (used by egui's popup Frame) ---
-    visuals.window_fill = palette.bg;
-    visuals.panel_fill = palette.bg;
-    // Thin 1px stroke at the divider color — deliberately subtle
-    // so the popup doesn't look like it's wearing a picture frame.
-    visuals.window_stroke = egui::Stroke::new(1.0, palette.divider);
-
-    // --- Text color ---
-    // egui `Button` uses `widgets.{state}.fg_stroke.color` for label
-    // rendering, NOT `override_text_color` in every code path. Set
-    // both so every widget picks it up.
-    visuals.override_text_color = Some(palette.fg);
-    visuals.widgets.inactive.fg_stroke.color = palette.fg;
-    visuals.widgets.hovered.fg_stroke.color = palette.fg;
-    visuals.widgets.active.fg_stroke.color = palette.fg;
-    visuals.widgets.open.fg_stroke.color = palette.fg;
-
-    // --- Widget backgrounds ---
-    // Inactive state: transparent (button looks like plain text
-    // until the user hovers it).
-    visuals.widgets.inactive.weak_bg_fill = egui::Color32::TRANSPARENT;
-    visuals.widgets.inactive.bg_fill = egui::Color32::TRANSPARENT;
-    // Hover / active / open: subtle highlight.
-    visuals.widgets.hovered.weak_bg_fill = palette.hover_bg;
-    visuals.widgets.hovered.bg_fill = palette.hover_bg;
-    visuals.widgets.active.weak_bg_fill = palette.hover_bg;
-    visuals.widgets.active.bg_fill = palette.hover_bg;
-    visuals.widgets.open.weak_bg_fill = palette.hover_bg;
-    visuals.widgets.open.bg_fill = palette.hover_bg;
-
-    // --- Widget border strokes ---
-    // No borders on buttons — they should look like plain text
-    // links, not boxed controls.
-    visuals.widgets.inactive.bg_stroke = egui::Stroke::NONE;
-    visuals.widgets.hovered.bg_stroke = egui::Stroke::NONE;
-    visuals.widgets.active.bg_stroke = egui::Stroke::NONE;
-    visuals.widgets.open.bg_stroke = egui::Stroke::NONE;
-
-    // --- Separator color ---
-    // `ui.separator()` draws using `noninteractive.bg_stroke`.
-    visuals.widgets.noninteractive.bg_stroke = egui::Stroke::new(1.0, palette.divider);
-}
+use crate::popup_theme::{apply_menu_palette, MenuPalette};
 
 /// Render the items of a single submenu (labels + shortcuts +
 /// separators) into the current UI. Shared between the Menubar

--- a/crates/amux-app/src/notifications_ui.rs
+++ b/crates/amux-app/src/notifications_ui.rs
@@ -245,10 +245,12 @@ impl AmuxApp {
             .and_then(|mp| mp.active_surface())
             .map(|sf| {
                 let mut meta = sf.metadata.clone();
-                // Capture the surface's OSC title for sidebar display
-                let title = sf.pane.title();
-                if !title.is_empty() {
-                    meta.surface_title = Some(title.to_string());
+                // Capture the surface's OSC title for sidebar display.
+                // Sanitize so the sidebar shows `pwsh` instead of
+                // the full WindowsApps package path.
+                let sanitized = crate::title_sanitize::sanitize_pane_title(sf.pane.title());
+                if !sanitized.is_empty() && sanitized.as_ref() != "?" {
+                    meta.surface_title = Some(sanitized.into_owned());
                 }
                 meta
             })

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -88,6 +88,19 @@ impl AmuxApp {
             self.theme.terminal_bg(),
         );
 
+        // Apply amux's popup palette to the tab bar's `ui` once,
+        // BEFORE we take an immutable `painter` borrow below, so
+        // the tab-right-click context menu opened inside this ui
+        // renders in amux's chrome colors instead of egui's
+        // default light theme. The tab-row painting that follows
+        // uses `painter` + explicit colors and ignores the style
+        // overrides this sets (buttons aren't used on the tab row
+        // itself, only inside the context menu popup).
+        {
+            let palette = crate::popup_theme::MenuPalette::from_theme(&self.theme);
+            crate::popup_theme::apply_menu_palette(ui, palette);
+        }
+
         {
             let painter = ui.painter();
             painter.rect_filled(tab_rect, 0.0, self.theme.tab_bar_bg());
@@ -329,7 +342,13 @@ impl AmuxApp {
                     sidebar::paint_close_x(painter, close_center, 3.5, close_color);
                 }
 
-                // Right-click context menu
+                // Right-click context menu. The palette was
+                // already applied to this `ui` at the top of the
+                // tab-bar scope (before the painter borrow), so
+                // the context menu popup inherits amux's chrome
+                // colors via the parent-ui style egui reads at
+                // Frame construction time. Same pattern as the
+                // sidebar workspace context menu.
                 let tab_id = ui.id().with("tab_ctx").with(pane_id).with(idx);
                 let tab_response = ui.interact(this_tab, tab_id, egui::Sense::click());
                 tab_response.context_menu(|ui| {

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -88,18 +88,11 @@ impl AmuxApp {
             self.theme.terminal_bg(),
         );
 
-        // Apply amux's popup palette to the tab bar's `ui` once,
-        // BEFORE we take an immutable `painter` borrow below, so
-        // the tab-right-click context menu opened inside this ui
-        // renders in amux's chrome colors instead of egui's
-        // default light theme. The tab-row painting that follows
-        // uses `painter` + explicit colors and ignores the style
-        // overrides this sets (buttons aren't used on the tab row
-        // itself, only inside the context menu popup).
-        {
-            let palette = crate::popup_theme::MenuPalette::from_theme(&self.theme);
-            crate::popup_theme::apply_menu_palette(ui, palette);
-        }
+        // The tab context menu is themed per-call-site below using
+        // `popup_theme::with_menu_palette` — we no longer mutate
+        // this `ui`'s style here, because that would leak into
+        // every widget rendered later in `render_single_pane`
+        // (terminal overlays, modals, etc.).
 
         {
             let painter = ui.painter();
@@ -342,24 +335,27 @@ impl AmuxApp {
                     sidebar::paint_close_x(painter, close_center, 3.5, close_color);
                 }
 
-                // Right-click context menu. The palette was
-                // already applied to this `ui` at the top of the
-                // tab-bar scope (before the painter borrow), so
-                // the context menu popup inherits amux's chrome
-                // colors via the parent-ui style egui reads at
-                // Frame construction time. Same pattern as the
-                // sidebar workspace context menu.
+                // Right-click context menu. `Response::context_menu`
+                // builds its popup `Frame` from `ui.ctx().style()`,
+                // so we scope the ctx-style mutation via
+                // `with_menu_palette` — the palette is active only
+                // during the synchronous `.context_menu(...)` call,
+                // and the original ctx style is restored before any
+                // other widgets paint.
                 let tab_id = ui.id().with("tab_ctx").with(pane_id).with(idx);
                 let tab_response = ui.interact(this_tab, tab_id, egui::Sense::click());
-                tab_response.context_menu(|ui| {
-                    if !tab.is_browser && ui.button("Rename Tab").clicked() {
-                        start_rename_tab = Some(idx);
-                        ui.close_menu();
-                    }
-                    if ui.button("Close Tab").clicked() {
-                        close_tab = Some(idx);
-                        ui.close_menu();
-                    }
+                let palette = crate::popup_theme::MenuPalette::from_theme(&self.theme);
+                crate::popup_theme::with_menu_palette(ui.ctx(), palette, || {
+                    tab_response.context_menu(|ui| {
+                        if !tab.is_browser && ui.button("Rename Tab").clicked() {
+                            start_rename_tab = Some(idx);
+                            ui.close_menu();
+                        }
+                        if ui.button("Close Tab").clicked() {
+                            close_tab = Some(idx);
+                            ui.close_menu();
+                        }
+                    });
                 });
 
                 // Hit testing (primary button only)

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -132,10 +132,18 @@ impl AmuxApp {
                 .iter()
                 .map(|tab| match tab {
                     managed_pane::TabEntry::Terminal(surface) => {
-                        let raw_title = surface
+                        // Run the pane's own title (the OSC-set /
+                        // ConPTY-inherited value) through
+                        // `sanitize_pane_title` to collapse ugly
+                        // shell exe paths. `user_title` is
+                        // passed through unchanged because that's
+                        // explicitly user-set.
+                        let sanitized_pane_title =
+                            crate::title_sanitize::sanitize_pane_title(surface.pane.title());
+                        let raw_title: &str = surface
                             .user_title
                             .as_deref()
-                            .unwrap_or_else(|| surface.pane.title());
+                            .unwrap_or(sanitized_pane_title.as_ref());
                         let raw = if raw_title.is_empty() || raw_title == "?" {
                             surface
                                 .metadata
@@ -641,14 +649,16 @@ impl AmuxApp {
                 }
             }
 
-            // Open rename modal for tab (terminal tabs only)
+            // Open rename modal for tab (terminal tabs only).
+            // Sanitize the pane title here too so the rename modal
+            // pre-fills with `pwsh` instead of the ugly exe path.
             if let Some(idx) = start_rename_tab {
                 if let Some(PaneEntry::Terminal(managed)) = self.panes.get(&pane_id) {
                     if let Some(surface) = managed.tabs[idx].as_surface() {
-                        let current_title = surface
-                            .user_title
-                            .clone()
-                            .unwrap_or_else(|| surface.pane.title().to_string());
+                        let current_title = surface.user_title.clone().unwrap_or_else(|| {
+                            crate::title_sanitize::sanitize_pane_title(surface.pane.title())
+                                .into_owned()
+                        });
                         self.rename_modal = Some(RenameModal {
                             target: RenameTarget::Tab {
                                 pane_id,

--- a/crates/amux-app/src/popup_theme.rs
+++ b/crates/amux-app/src/popup_theme.rs
@@ -207,6 +207,63 @@ pub(crate) fn with_menu_palette<R>(
     result
 }
 
+/// Apply only the modal-relevant subset of a `MenuPalette` to
+/// `visuals`. Used by [`with_modal_palette`] so every `egui::Window`
+/// call site shares the same set of overrides.
+///
+/// Unlike [`apply_menu_palette_to_visuals`], this does NOT touch
+/// widget `bg_fill` / `bg_stroke`. A modal needs visible button
+/// backgrounds and text-field outlines — the menu-style "transparent
+/// button that becomes a hover highlight" look is wrong for a
+/// modal's OK / Cancel controls.
+fn apply_modal_palette_to_visuals(visuals: &mut egui::Visuals, palette: MenuPalette) {
+    // Outer Window Frame.
+    visuals.window_fill = palette.bg;
+    visuals.panel_fill = palette.bg;
+    visuals.window_stroke = Stroke::new(1.0, palette.divider);
+
+    // Text color — labels, RichText, and the button-label path.
+    // We set `override_text_color` (used by `ui.label`) AND the
+    // per-widget `fg_stroke.color` (used by egui Button's label
+    // paint path) so both code paths render readable text. Widget
+    // `bg_fill` / `bg_stroke` are intentionally left untouched so
+    // egui's default chrome for buttons and text fields still
+    // renders normally.
+    visuals.override_text_color = Some(palette.fg);
+    visuals.widgets.noninteractive.fg_stroke.color = palette.fg;
+    visuals.widgets.inactive.fg_stroke.color = palette.fg;
+    visuals.widgets.hovered.fg_stroke.color = palette.fg;
+    visuals.widgets.active.fg_stroke.color = palette.fg;
+    visuals.widgets.open.fg_stroke.color = palette.fg;
+}
+
+/// Run `f` with amux's modal palette temporarily applied to the
+/// `egui::Context`'s style, then restore the previous style.
+///
+/// This is the correct way to theme `egui::Window`-based modals
+/// (rename modal, find bar, notification panel). `Window::show`
+/// reads `ctx.style().visuals.window_fill` / `window_stroke` /
+/// `panel_fill` synchronously during the call to build its outer
+/// Frame, so save / apply / restore wraps the entire modal cleanly.
+///
+/// Unlike [`with_menu_palette`], this variant leaves widget
+/// `bg_fill` / `bg_stroke` untouched — modals want normal-looking
+/// buttons and text-field borders, not the flat hover-only look
+/// that's correct for menus.
+pub(crate) fn with_modal_palette<R>(
+    ctx: &egui::Context,
+    palette: MenuPalette,
+    f: impl FnOnce() -> R,
+) -> R {
+    let saved = ctx.style();
+    ctx.style_mut(|style| {
+        apply_modal_palette_to_visuals(&mut style.visuals, palette);
+    });
+    let result = f();
+    ctx.set_style(saved);
+    result
+}
+
 /// Apply a `MenuPalette` to a UI's visuals so that popups built
 /// from this UI's style (and widgets rendered inside them) pick up
 /// amux's chrome colors instead of egui's light-theme defaults.

--- a/crates/amux-app/src/popup_theme.rs
+++ b/crates/amux-app/src/popup_theme.rs
@@ -91,41 +91,11 @@ impl MenuPalette {
     }
 }
 
-/// Apply a `MenuPalette` to a UI's visuals so that popups built
-/// from this UI's style (and widgets rendered inside them) pick up
-/// amux's chrome colors instead of egui's light-theme defaults.
-///
-/// # When to call
-///
-/// Call on the **parent** UI BEFORE opening a popup / menu_button /
-/// context_menu. Egui reads `parent_ui.style()` at the moment the
-/// outer Frame is constructed, which happens BEFORE the popup's
-/// closure runs — so applying the palette inside the closure is
-/// too late to affect the Frame's background or stroke.
-///
-/// Also call a second time INSIDE the popup closure if the popup
-/// opens nested popups (nested `ui.menu_button`), so children
-/// inherit the palette too. Applying multiple times is idempotent
-/// and safe.
-///
-/// # What it sets
-///
-/// - `visuals.window_fill` — popup background
-/// - `visuals.window_stroke` — popup border (thin, divider color)
-/// - `visuals.panel_fill` — panels inside the popup
-/// - `visuals.override_text_color` — default text color for all widgets
-/// - `visuals.widgets.{state}.fg_stroke.color` — button label text
-///   (NOT the same as `override_text_color`; egui Button reads both)
-/// - `visuals.widgets.{state}.weak_bg_fill` / `bg_fill` — button
-///   hover / active / open backgrounds
-/// - `visuals.widgets.{state}.bg_stroke` — button borders set to
-///   NONE so buttons look like plain text links rather than boxed
-///   controls
-/// - `visuals.widgets.noninteractive.bg_stroke` — `ui.separator()`
-///   line color
-pub(crate) fn apply_menu_palette(ui: &mut Ui, palette: MenuPalette) {
-    let visuals = &mut ui.style_mut().visuals;
-
+/// Apply a `MenuPalette` to an `egui::Visuals` struct. Used by
+/// [`apply_menu_palette`] (ui-scoped) and [`apply_menu_palette_to_ctx`]
+/// (ctx-scoped) so both paths share the exact same set of visual
+/// overrides and stay in sync.
+pub(crate) fn apply_menu_palette_to_visuals(visuals: &mut egui::Visuals, palette: MenuPalette) {
     // Popup container styling (used by egui's popup Frame).
     visuals.window_fill = palette.bg;
     visuals.panel_fill = palette.bg;
@@ -160,4 +130,81 @@ pub(crate) fn apply_menu_palette(ui: &mut Ui, palette: MenuPalette) {
     // Separator line color — `ui.separator()` draws using
     // `noninteractive.bg_stroke`.
     visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, palette.divider);
+}
+
+/// Apply a `MenuPalette` globally to an `egui::Context`'s style.
+/// This is the ONLY way to theme `Response::context_menu` popups,
+/// because egui's `context_menu` implementation reads
+/// `button.ctx.style()` directly (see `egui/src/menu.rs:392`), not
+/// the parent ui's style — so per-call-site `apply_menu_palette`
+/// has no effect on right-click menus.
+///
+/// Call once per frame from the top of `AmuxApp::update` so the
+/// ctx-level visuals reflect the latest user theme. The operation
+/// is cheap (a handful of `Arc::make_mut` field writes) and idempotent.
+///
+/// Surfaces that benefit from this ctx-level application:
+///
+/// - `Response::context_menu` (sidebar workspace right-click, tab bar
+///   right-click, etc.)
+/// - `ui.menu_button` nested popups (even when the top-level menu
+///   is opened from a ui with its own palette, nested popups create
+///   fresh areas that inherit from ctx)
+/// - `egui::containers::popup::popup_below_widget` when the caller
+///   forgot to apply palette to the parent ui first
+/// - Any future egui popup / tooltip / window primitive that reads
+///   from `ctx.style()` internally
+///
+/// This doesn't replace [`apply_menu_palette`] (the ui-scoped
+/// variant); ui-scoped application is still needed for popups whose
+/// Frame is built from parent-ui style specifically (like the egui
+/// `menu_bar` / `popup_below_widget` paths where the parent-ui-
+/// style + ctx-style interplay is subtle). Apply both for
+/// belt-and-suspenders coverage.
+pub(crate) fn apply_menu_palette_to_ctx(ctx: &egui::Context, palette: MenuPalette) {
+    ctx.style_mut(|style| {
+        apply_menu_palette_to_visuals(&mut style.visuals, palette);
+    });
+}
+
+/// Apply a `MenuPalette` to a UI's visuals so that popups built
+/// from this UI's style (and widgets rendered inside them) pick up
+/// amux's chrome colors instead of egui's light-theme defaults.
+///
+/// # When to call
+///
+/// Call on the **parent** UI BEFORE opening a popup / menu_button /
+/// `egui::popup::popup_below_widget`. Egui reads `parent_ui.style()`
+/// at the moment the outer Frame is constructed, which happens
+/// BEFORE the popup's closure runs — so applying the palette inside
+/// the closure is too late to affect the Frame's background or
+/// stroke.
+///
+/// **This does NOT theme `Response::context_menu`** — egui's context
+/// menu builds its Frame from `ctx.style()`, not parent-ui style.
+/// Use [`apply_menu_palette_to_ctx`] for context menus (typically
+/// called once per frame from `AmuxApp::update`).
+///
+/// Also call a second time INSIDE the popup closure if the popup
+/// opens nested popups (nested `ui.menu_button`), so children
+/// inherit the palette too. Applying multiple times is idempotent
+/// and safe.
+///
+/// # What it sets
+///
+/// - `visuals.window_fill` — popup background
+/// - `visuals.window_stroke` — popup border (thin, divider color)
+/// - `visuals.panel_fill` — panels inside the popup
+/// - `visuals.override_text_color` — default text color for all widgets
+/// - `visuals.widgets.{state}.fg_stroke.color` — button label text
+///   (NOT the same as `override_text_color`; egui Button reads both)
+/// - `visuals.widgets.{state}.weak_bg_fill` / `bg_fill` — button
+///   hover / active / open backgrounds
+/// - `visuals.widgets.{state}.bg_stroke` — button borders set to
+///   NONE so buttons look like plain text links rather than boxed
+///   controls
+/// - `visuals.widgets.noninteractive.bg_stroke` — `ui.separator()`
+///   line color
+pub(crate) fn apply_menu_palette(ui: &mut Ui, palette: MenuPalette) {
+    apply_menu_palette_to_visuals(&mut ui.style_mut().visuals, palette);
 }

--- a/crates/amux-app/src/popup_theme.rs
+++ b/crates/amux-app/src/popup_theme.rs
@@ -1,0 +1,163 @@
+//! Shared egui popup theming helpers.
+//!
+//! Egui's popup / menu / context_menu primitives build their outer
+//! `Frame` from the PARENT ui's style at construction time
+//! (`Frame::popup(parent_ui.style())` in `egui::containers::popup`,
+//! `Frame::menu(ui.style())` in `egui::menu`). If the parent ui
+//! hasn't been themed, popups fall back to egui's default visuals —
+//! which is a light-mode look that clashes badly with amux's dark
+//! chrome.
+//!
+//! [`apply_menu_palette`] takes a [`MenuPalette`] (derived from the
+//! current theme) and mutates the ui's visuals so that any popup
+//! built afterwards picks up our colors. Call it on the PARENT ui
+//! BEFORE opening the popup, not inside the closure — by the time
+//! the closure runs, egui has already constructed the outer Frame.
+//!
+//! For the inside of a popup (button text colors, hover highlights,
+//! separator lines), [`apply_menu_palette`] also sets the widget
+//! stroke / fill variants that egui Button uses for its label paint
+//! path, since `override_text_color` alone isn't picked up by every
+//! egui widget.
+//!
+//! This module is intentionally cross-platform. The menu bar on
+//! macOS uses `muda` native, but egui popups live on every platform
+//! — sidebar context menus, tab bar menus, future tooltips, etc.
+
+use egui::{Color32, Stroke, Ui};
+
+use crate::theme::Theme;
+
+/// Pick a readable foreground color for a given background by
+/// checking its perceived luminance. Uses Rec. 601 luma — the
+/// approximation most UI toolkits use.
+///
+/// Returns soft-white for dark backgrounds and near-black for light
+/// backgrounds. Deliberately NOT pure white / pure black — both
+/// extremes are harsh against typical chrome colors.
+pub(crate) fn contrast_text(bg: Color32) -> Color32 {
+    let r = bg.r() as f32;
+    let g = bg.g() as f32;
+    let b = bg.b() as f32;
+    let luma = 0.299 * r + 0.587 * g + 0.114 * b;
+    if luma < 128.0 {
+        Color32::from_rgb(0xE6, 0xE6, 0xE6)
+    } else {
+        Color32::from_rgb(0x20, 0x20, 0x20)
+    }
+}
+
+/// Bundle of theme-derived colors used by every popup rendering
+/// path. Computed once per top-level render call so per-item loops
+/// don't redo the luma math.
+#[derive(Clone, Copy)]
+pub(crate) struct MenuPalette {
+    /// Popup background + button-base color.
+    pub bg: Color32,
+    /// Foreground text color (buttons, labels, separators).
+    pub fg: Color32,
+    /// Hover / active / open background fill for widgets inside the
+    /// popup. A gamma-shifted variant of `bg` that's slightly
+    /// lighter on dark themes and slightly darker on light themes.
+    pub hover_bg: Color32,
+    /// Subtle divider color for popup borders and separator lines.
+    /// Alpha-blended so it doesn't overpower.
+    pub divider: Color32,
+}
+
+impl MenuPalette {
+    /// Derive a palette from the user's configured theme. Uses the
+    /// theme's titlebar background as the popup background so
+    /// popups feel visually attached to amux's top chrome.
+    pub fn from_theme(theme: &Theme) -> Self {
+        let bg = theme.titlebar_bg();
+        let fg = contrast_text(bg);
+        let luma_sum: u16 = bg.r() as u16 + bg.g() as u16 + (bg.b() as u16);
+        let hover_bg = if luma_sum < 384 {
+            bg.gamma_multiply(1.5) // dark theme → brighten on hover
+        } else {
+            bg.gamma_multiply(0.85) // light theme → darken on hover
+        };
+        // Divider at low alpha (24/255). A 1px stroke on popup frames
+        // is loud even at modest alphas — tune down if future
+        // complaints surface.
+        let divider = Color32::from_rgba_unmultiplied(fg.r(), fg.g(), fg.b(), 24);
+        Self {
+            bg,
+            fg,
+            hover_bg,
+            divider,
+        }
+    }
+}
+
+/// Apply a `MenuPalette` to a UI's visuals so that popups built
+/// from this UI's style (and widgets rendered inside them) pick up
+/// amux's chrome colors instead of egui's light-theme defaults.
+///
+/// # When to call
+///
+/// Call on the **parent** UI BEFORE opening a popup / menu_button /
+/// context_menu. Egui reads `parent_ui.style()` at the moment the
+/// outer Frame is constructed, which happens BEFORE the popup's
+/// closure runs — so applying the palette inside the closure is
+/// too late to affect the Frame's background or stroke.
+///
+/// Also call a second time INSIDE the popup closure if the popup
+/// opens nested popups (nested `ui.menu_button`), so children
+/// inherit the palette too. Applying multiple times is idempotent
+/// and safe.
+///
+/// # What it sets
+///
+/// - `visuals.window_fill` — popup background
+/// - `visuals.window_stroke` — popup border (thin, divider color)
+/// - `visuals.panel_fill` — panels inside the popup
+/// - `visuals.override_text_color` — default text color for all widgets
+/// - `visuals.widgets.{state}.fg_stroke.color` — button label text
+///   (NOT the same as `override_text_color`; egui Button reads both)
+/// - `visuals.widgets.{state}.weak_bg_fill` / `bg_fill` — button
+///   hover / active / open backgrounds
+/// - `visuals.widgets.{state}.bg_stroke` — button borders set to
+///   NONE so buttons look like plain text links rather than boxed
+///   controls
+/// - `visuals.widgets.noninteractive.bg_stroke` — `ui.separator()`
+///   line color
+pub(crate) fn apply_menu_palette(ui: &mut Ui, palette: MenuPalette) {
+    let visuals = &mut ui.style_mut().visuals;
+
+    // Popup container styling (used by egui's popup Frame).
+    visuals.window_fill = palette.bg;
+    visuals.panel_fill = palette.bg;
+    visuals.window_stroke = Stroke::new(1.0, palette.divider);
+
+    // Text color — set both `override_text_color` (used by labels,
+    // RichText, etc.) and `widgets.{state}.fg_stroke.color` (used
+    // by Button's label paint path).
+    visuals.override_text_color = Some(palette.fg);
+    visuals.widgets.inactive.fg_stroke.color = palette.fg;
+    visuals.widgets.hovered.fg_stroke.color = palette.fg;
+    visuals.widgets.active.fg_stroke.color = palette.fg;
+    visuals.widgets.open.fg_stroke.color = palette.fg;
+
+    // Widget backgrounds.
+    visuals.widgets.inactive.weak_bg_fill = Color32::TRANSPARENT;
+    visuals.widgets.inactive.bg_fill = Color32::TRANSPARENT;
+    visuals.widgets.hovered.weak_bg_fill = palette.hover_bg;
+    visuals.widgets.hovered.bg_fill = palette.hover_bg;
+    visuals.widgets.active.weak_bg_fill = palette.hover_bg;
+    visuals.widgets.active.bg_fill = palette.hover_bg;
+    visuals.widgets.open.weak_bg_fill = palette.hover_bg;
+    visuals.widgets.open.bg_fill = palette.hover_bg;
+
+    // Widget borders: buttons should look like plain text links,
+    // not boxed controls.
+    visuals.widgets.inactive.bg_stroke = Stroke::NONE;
+    visuals.widgets.hovered.bg_stroke = Stroke::NONE;
+    visuals.widgets.active.bg_stroke = Stroke::NONE;
+    visuals.widgets.open.bg_stroke = Stroke::NONE;
+
+    // Separator line color — `ui.separator()` draws using
+    // `noninteractive.bg_stroke`.
+    visuals.widgets.noninteractive.bg_stroke = Stroke::new(1.0, palette.divider);
+}

--- a/crates/amux-app/src/popup_theme.rs
+++ b/crates/amux-app/src/popup_theme.rs
@@ -1,24 +1,39 @@
 //! Shared egui popup theming helpers.
 //!
-//! Egui's popup / menu / context_menu primitives build their outer
-//! `Frame` from the PARENT ui's style at construction time
+//! Egui does not source popup styling from a single place for every
+//! API. `ui.menu_button` / `popup_below_widget` construct their
+//! outer `Frame` from the PARENT ui's style at call time
 //! (`Frame::popup(parent_ui.style())` in `egui::containers::popup`,
-//! `Frame::menu(ui.style())` in `egui::menu`). If the parent ui
-//! hasn't been themed, popups fall back to egui's default visuals —
-//! which is a light-mode look that clashes badly with amux's dark
-//! chrome.
+//! `Frame::menu(ui.style())` in `egui::menu`). By contrast,
+//! `Response::context_menu` constructs its Frame from
+//! `response.ctx.style()` — the parent ui's style has no effect.
+//! If the relevant style source hasn't been themed, the popup falls
+//! back to egui's default visuals, which is a light-mode look that
+//! clashes badly with amux's dark chrome.
 //!
-//! [`apply_menu_palette`] takes a [`MenuPalette`] (derived from the
-//! current theme) and mutates the ui's visuals so that any popup
-//! built afterwards picks up our colors. Call it on the PARENT ui
-//! BEFORE opening the popup, not inside the closure — by the time
-//! the closure runs, egui has already constructed the outer Frame.
+//! There are therefore two theming entry points in this module:
+//!
+//! - [`apply_menu_palette`] mutates a `Ui`'s visuals. Use it on a
+//!   PARENT ui BEFORE calling `ui.menu_button` or
+//!   `popup_below_widget` — by the time the popup's closure runs,
+//!   egui has already constructed the outer Frame from the parent
+//!   style. Note: this mutates the ui's local style, which
+//!   persists for subsequent widgets in that same ui. Call on a
+//!   dedicated child `ui.scope(...)` if you want containment.
+//!
+//! - [`with_menu_palette`] wraps a closure with a save / apply /
+//!   restore of the `egui::Context` style. This is how
+//!   `Response::context_menu` is themed: the ctx style is temporarily
+//!   overridden for the duration of the `.context_menu(...)` call
+//!   (which builds the Frame synchronously), then restored so
+//!   unrelated widgets painted later in the frame don't inherit the
+//!   menu-specific visuals.
 //!
 //! For the inside of a popup (button text colors, hover highlights,
-//! separator lines), [`apply_menu_palette`] also sets the widget
-//! stroke / fill variants that egui Button uses for its label paint
-//! path, since `override_text_color` alone isn't picked up by every
-//! egui widget.
+//! separator lines), the shared [`apply_menu_palette_to_visuals`]
+//! helper also sets the widget stroke / fill variants that egui
+//! Button uses for its label paint path, since `override_text_color`
+//! alone isn't picked up by every egui widget.
 //!
 //! This module is intentionally cross-platform. The menu bar on
 //! macOS uses `muda` native, but egui popups live on every platform
@@ -28,6 +43,14 @@ use egui::{Color32, Stroke, Ui};
 
 use crate::theme::Theme;
 
+/// Rec. 601 perceived luminance of a `Color32`. Shared between
+/// `contrast_text` (dark vs. light foreground) and the hover-bg
+/// branch in `MenuPalette::from_theme` so both use the same
+/// luminance model and can't disagree on colors near the boundary.
+fn perceived_luma(c: Color32) -> f32 {
+    0.299 * c.r() as f32 + 0.587 * c.g() as f32 + 0.114 * c.b() as f32
+}
+
 /// Pick a readable foreground color for a given background by
 /// checking its perceived luminance. Uses Rec. 601 luma — the
 /// approximation most UI toolkits use.
@@ -36,11 +59,7 @@ use crate::theme::Theme;
 /// backgrounds. Deliberately NOT pure white / pure black — both
 /// extremes are harsh against typical chrome colors.
 pub(crate) fn contrast_text(bg: Color32) -> Color32 {
-    let r = bg.r() as f32;
-    let g = bg.g() as f32;
-    let b = bg.b() as f32;
-    let luma = 0.299 * r + 0.587 * g + 0.114 * b;
-    if luma < 128.0 {
+    if perceived_luma(bg) < 128.0 {
         Color32::from_rgb(0xE6, 0xE6, 0xE6)
     } else {
         Color32::from_rgb(0x20, 0x20, 0x20)
@@ -72,8 +91,7 @@ impl MenuPalette {
     pub fn from_theme(theme: &Theme) -> Self {
         let bg = theme.titlebar_bg();
         let fg = contrast_text(bg);
-        let luma_sum: u16 = bg.r() as u16 + bg.g() as u16 + (bg.b() as u16);
-        let hover_bg = if luma_sum < 384 {
+        let hover_bg = if perceived_luma(bg) < 128.0 {
             bg.gamma_multiply(1.5) // dark theme → brighten on hover
         } else {
             bg.gamma_multiply(0.85) // light theme → darken on hover
@@ -133,38 +151,60 @@ pub(crate) fn apply_menu_palette_to_visuals(visuals: &mut egui::Visuals, palette
 }
 
 /// Apply a `MenuPalette` globally to an `egui::Context`'s style.
-/// This is the ONLY way to theme `Response::context_menu` popups,
-/// because egui's `context_menu` implementation reads
-/// `button.ctx.style()` directly (see `egui/src/menu.rs:392`), not
-/// the parent ui's style — so per-call-site `apply_menu_palette`
-/// has no effect on right-click menus.
 ///
-/// Call once per frame from the top of `AmuxApp::update` so the
-/// ctx-level visuals reflect the latest user theme. The operation
-/// is cheap (a handful of `Arc::make_mut` field writes) and idempotent.
+/// Do NOT call this unconditionally at the top of a frame. Because
+/// it also sets widget fills to transparent and widget strokes to
+/// none, it will restyle non-menu widgets (modals, text fields,
+/// buttons) that read from `ctx.style()`. Prefer [`with_menu_palette`],
+/// which scopes the mutation to a single call site with a
+/// save / apply / restore pair.
 ///
-/// Surfaces that benefit from this ctx-level application:
-///
-/// - `Response::context_menu` (sidebar workspace right-click, tab bar
-///   right-click, etc.)
-/// - `ui.menu_button` nested popups (even when the top-level menu
-///   is opened from a ui with its own palette, nested popups create
-///   fresh areas that inherit from ctx)
-/// - `egui::containers::popup::popup_below_widget` when the caller
-///   forgot to apply palette to the parent ui first
-/// - Any future egui popup / tooltip / window primitive that reads
-///   from `ctx.style()` internally
-///
-/// This doesn't replace [`apply_menu_palette`] (the ui-scoped
-/// variant); ui-scoped application is still needed for popups whose
-/// Frame is built from parent-ui style specifically (like the egui
-/// `menu_bar` / `popup_below_widget` paths where the parent-ui-
-/// style + ctx-style interplay is subtle). Apply both for
-/// belt-and-suspenders coverage.
-pub(crate) fn apply_menu_palette_to_ctx(ctx: &egui::Context, palette: MenuPalette) {
+/// This function is exposed only for the `with_menu_palette`
+/// implementation and for tests that need to inspect the post-apply
+/// style directly.
+fn apply_menu_palette_to_ctx(ctx: &egui::Context, palette: MenuPalette) {
     ctx.style_mut(|style| {
         apply_menu_palette_to_visuals(&mut style.visuals, palette);
     });
+}
+
+/// Run `f` with amux's menu palette temporarily applied to the
+/// `egui::Context`'s style, then restore the previous style.
+///
+/// This is the correct way to theme `Response::context_menu` and
+/// any other egui primitive that reads from `ctx.style()` to build
+/// its outer `Frame`. `context_menu` constructs its menu Frame
+/// synchronously during the `.context_menu(|ui| ...)` call (inside
+/// egui's `menu_ui`), so by the time `f` returns, the Frame has
+/// already been built, paint commands have been recorded against
+/// the themed style, and it is safe to restore the ctx style for
+/// the rest of the frame.
+///
+/// We save via `ctx.style()` (cheap `Arc<Style>` clone) and restore
+/// via `ctx.set_style(...)`. The inner `apply_menu_palette_to_ctx`
+/// uses `ctx.style_mut`, which will `Arc::make_mut` a fresh style
+/// — the saved `Arc` keeps the original untouched until we restore.
+///
+/// Use this for:
+///
+/// - `Response::context_menu` (sidebar workspace right-click, tab
+///   bar right-click, etc.)
+/// - Any future egui popup / tooltip / window primitive that reads
+///   from `ctx.style()` internally
+///
+/// For `ui.menu_button` and `popup_below_widget`, whose Frame is
+/// built from the parent `Ui`'s style, use [`apply_menu_palette`]
+/// on the parent ui before the call.
+pub(crate) fn with_menu_palette<R>(
+    ctx: &egui::Context,
+    palette: MenuPalette,
+    f: impl FnOnce() -> R,
+) -> R {
+    let saved = ctx.style();
+    apply_menu_palette_to_ctx(ctx, palette);
+    let result = f();
+    ctx.set_style(saved);
+    result
 }
 
 /// Apply a `MenuPalette` to a UI's visuals so that popups built

--- a/crates/amux-app/src/popup_theme.rs
+++ b/crates/amux-app/src/popup_theme.rs
@@ -207,34 +207,38 @@ pub(crate) fn with_menu_palette<R>(
     result
 }
 
-/// Apply only the modal-relevant subset of a `MenuPalette` to
-/// `visuals`. Used by [`with_modal_palette`] so every `egui::Window`
-/// call site shares the same set of overrides.
+/// Build a dark-mode `Visuals` for modals: start from egui's
+/// built-in dark theme (so title bar, text-field background
+/// [`extreme_bg_color`], button fills, and widget strokes are all
+/// sensible dark-mode values) then overlay amux's theme-derived
+/// window background, border, and foreground text color.
 ///
-/// Unlike [`apply_menu_palette_to_visuals`], this does NOT touch
-/// widget `bg_fill` / `bg_stroke`. A modal needs visible button
-/// backgrounds and text-field outlines — the menu-style "transparent
-/// button that becomes a hover highlight" look is wrong for a
-/// modal's OK / Cancel controls.
-fn apply_modal_palette_to_visuals(visuals: &mut egui::Visuals, palette: MenuPalette) {
-    // Outer Window Frame.
+/// We can't just tweak a few fields on top of the current style —
+/// egui defaults to `Visuals::light()`, so any field we don't
+/// explicitly set would stay light-theme, giving us the
+/// half-dark-half-light modal we had after the first attempt
+/// (dark body, white text field, light-gray buttons and title bar).
+fn build_modal_visuals(palette: MenuPalette) -> egui::Visuals {
+    let mut visuals = egui::Visuals::dark();
+
+    // Outer Window Frame background + border.
     visuals.window_fill = palette.bg;
     visuals.panel_fill = palette.bg;
     visuals.window_stroke = Stroke::new(1.0, palette.divider);
 
-    // Text color — labels, RichText, and the button-label path.
-    // We set `override_text_color` (used by `ui.label`) AND the
-    // per-widget `fg_stroke.color` (used by egui Button's label
-    // paint path) so both code paths render readable text. Widget
-    // `bg_fill` / `bg_stroke` are intentionally left untouched so
-    // egui's default chrome for buttons and text fields still
-    // renders normally.
+    // Default text color for labels / RichText.
     visuals.override_text_color = Some(palette.fg);
+
+    // Button label color across all widget states — egui Button's
+    // label paint path reads `widgets.{state}.fg_stroke.color`,
+    // not `override_text_color`.
     visuals.widgets.noninteractive.fg_stroke.color = palette.fg;
     visuals.widgets.inactive.fg_stroke.color = palette.fg;
     visuals.widgets.hovered.fg_stroke.color = palette.fg;
     visuals.widgets.active.fg_stroke.color = palette.fg;
     visuals.widgets.open.fg_stroke.color = palette.fg;
+
+    visuals
 }
 
 /// Run `f` with amux's modal palette temporarily applied to the
@@ -257,7 +261,7 @@ pub(crate) fn with_modal_palette<R>(
 ) -> R {
     let saved = ctx.style();
     ctx.style_mut(|style| {
-        apply_modal_palette_to_visuals(&mut style.visuals, palette);
+        style.visuals = build_modal_visuals(palette);
     });
     let result = f();
     ctx.set_style(saved);

--- a/crates/amux-app/src/rename_modal.rs
+++ b/crates/amux-app/src/rename_modal.rs
@@ -44,48 +44,64 @@ impl AmuxApp {
         let modal = self.rename_modal.as_mut().unwrap();
         let just_opened = modal.just_opened;
 
-        egui::Window::new(title)
-            .collapsible(false)
-            .resizable(false)
-            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-            .fixed_size([280.0, 0.0])
-            .show(ctx, |ui| {
-                ui.horizontal(|ui| {
-                    ui.label("Name:");
-                    let response = ui.text_edit_singleline(&mut modal.buf);
-                    if just_opened {
-                        response.request_focus();
-                        modal.just_opened = false;
-                    }
-                    // Apply pending select-all from menu bar (Cmd+A consumed by muda).
-                    if pending_select_all && response.has_focus() {
-                        if let Some(mut text_state) =
-                            egui::TextEdit::load_state(ui.ctx(), response.id)
-                        {
-                            let char_count = modal.buf.chars().count();
-                            text_state
-                                .cursor
-                                .set_char_range(Some(egui::text::CCursorRange::two(
-                                    egui::text::CCursor::new(0),
-                                    egui::text::CCursor::new(char_count),
-                                )));
-                            text_state.store(ui.ctx(), response.id);
+        // Theme the modal's `egui::Window` Frame. `Window::show` reads
+        // `ctx.style().visuals.window_fill` / `window_stroke` /
+        // `panel_fill` synchronously to build its outer Frame, so
+        // `with_modal_palette` wraps the whole call — the ctx style
+        // is overridden for the duration of the synchronous
+        // `.show()` call and restored afterward. Without this the
+        // Window falls back to egui's default light visuals.
+        //
+        // NOTE: this uses `with_modal_palette`, not
+        // `with_menu_palette`, so widget `bg_fill` / `bg_stroke`
+        // stay at egui's defaults — buttons and the text field
+        // keep their normal chrome instead of rendering as flat
+        // text.
+        let palette = crate::popup_theme::MenuPalette::from_theme(&self.theme);
+        crate::popup_theme::with_modal_palette(ctx, palette, || {
+            egui::Window::new(title)
+                .collapsible(false)
+                .resizable(false)
+                .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+                .fixed_size([280.0, 0.0])
+                .show(ctx, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label("Name:");
+                        let response = ui.text_edit_singleline(&mut modal.buf);
+                        if just_opened {
+                            response.request_focus();
+                            modal.just_opened = false;
                         }
-                    }
-                    if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-                        apply = Some(modal.buf.trim().to_string());
-                    }
+                        // Apply pending select-all from menu bar (Cmd+A consumed by muda).
+                        if pending_select_all && response.has_focus() {
+                            if let Some(mut text_state) =
+                                egui::TextEdit::load_state(ui.ctx(), response.id)
+                            {
+                                let char_count = modal.buf.chars().count();
+                                text_state.cursor.set_char_range(Some(
+                                    egui::text::CCursorRange::two(
+                                        egui::text::CCursor::new(0),
+                                        egui::text::CCursor::new(char_count),
+                                    ),
+                                ));
+                                text_state.store(ui.ctx(), response.id);
+                            }
+                        }
+                        if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                            apply = Some(modal.buf.trim().to_string());
+                        }
+                    });
+                    ui.add_space(4.0);
+                    ui.horizontal(|ui| {
+                        if ui.button("OK").clicked() {
+                            apply = Some(modal.buf.trim().to_string());
+                        }
+                        if ui.button("Cancel").clicked() {
+                            cancel = true;
+                        }
+                    });
                 });
-                ui.add_space(4.0);
-                ui.horizontal(|ui| {
-                    if ui.button("OK").clicked() {
-                        apply = Some(modal.buf.trim().to_string());
-                    }
-                    if ui.button("Cancel").clicked() {
-                        cancel = true;
-                    }
-                });
-            });
+        });
 
         // Also close on Escape
         if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -396,6 +396,19 @@ fn render_workspace_row(
     }
 
     // --- Context menu ---
+    // Apply amux's popup palette to the parent `ui` BEFORE calling
+    // `response.context_menu`. Egui's context menu builds its Frame
+    // from the parent's style at construction time, so any palette
+    // applied inside the closure would be too late to affect the
+    // popup's background / border. Applying to the parent also
+    // propagates into the popup's child UI via inheritance so
+    // buttons and separators inside the menu are themed too.
+    //
+    // We also re-apply inside the nested `Set Color` submenu
+    // (which builds its own fresh Area + Frame from its local ui
+    // style) so that nested popup is themed as well.
+    let palette = crate::popup_theme::MenuPalette::from_theme(theme);
+    crate::popup_theme::apply_menu_palette(ui, palette);
     response.context_menu(|ui| {
         if ui.button("Rename Workspace").clicked() {
             actions.push(SidebarAction::StartRenameWorkspace(idx));
@@ -411,7 +424,12 @@ fn render_workspace_row(
             ui.close_menu();
         }
         ui.separator();
+        // Apply palette on the context-menu ui before opening the
+        // nested submenu so the nested menu's Frame also inherits
+        // amux colors.
+        crate::popup_theme::apply_menu_palette(ui, palette);
         ui.menu_button("Set Color", |ui| {
+            crate::popup_theme::apply_menu_palette(ui, palette);
             for &(color, name) in PRESET_COLORS {
                 let c = Color32::from_rgba_premultiplied(color[0], color[1], color[2], color[3]);
                 ui.horizontal(|ui| {

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -396,57 +396,58 @@ fn render_workspace_row(
     }
 
     // --- Context menu ---
-    // Apply amux's popup palette to the parent `ui` BEFORE calling
-    // `response.context_menu`. Egui's context menu builds its Frame
-    // from the parent's style at construction time, so any palette
-    // applied inside the closure would be too late to affect the
-    // popup's background / border. Applying to the parent also
-    // propagates into the popup's child UI via inheritance so
-    // buttons and separators inside the menu are themed too.
+    // `response.context_menu` builds its outer popup `Frame` from
+    // `ctx.style()` (see egui's `menu_ui` → `Frame::menu`). Scope
+    // the ctx-style mutation to just this call via
+    // `with_menu_palette` so unrelated widgets painted later in the
+    // frame don't inherit the menu-specific visuals. The
+    // `.context_menu(...)` call is synchronous — the Frame has
+    // already been built by the time `with_menu_palette`'s closure
+    // returns, so the restore is safe.
     //
-    // We also re-apply inside the nested `Set Color` submenu
-    // (which builds its own fresh Area + Frame from its local ui
-    // style) so that nested popup is themed as well.
+    // For the nested `Set Color` `ui.menu_button`, we apply the
+    // palette to the *menu_ui* inside the closure because
+    // `menu_button`'s popup reads the parent ui's style (not
+    // `ctx.style()`).
     let palette = crate::popup_theme::MenuPalette::from_theme(theme);
-    crate::popup_theme::apply_menu_palette(ui, palette);
-    response.context_menu(|ui| {
-        if ui.button("Rename Workspace").clicked() {
-            actions.push(SidebarAction::StartRenameWorkspace(idx));
-            ui.close_menu();
-        }
-        if ui.button("Close Workspace").clicked() {
-            actions.push(SidebarAction::CloseWorkspace(idx));
-            ui.close_menu();
-        }
-        ui.separator();
-        if ui.button("Mark All Read").clicked() {
-            actions.push(SidebarAction::MarkWorkspaceRead(idx));
-            ui.close_menu();
-        }
-        ui.separator();
-        // Apply palette on the context-menu ui before opening the
-        // nested submenu so the nested menu's Frame also inherits
-        // amux colors.
-        crate::popup_theme::apply_menu_palette(ui, palette);
-        ui.menu_button("Set Color", |ui| {
-            crate::popup_theme::apply_menu_palette(ui, palette);
-            for &(color, name) in PRESET_COLORS {
-                let c = Color32::from_rgba_premultiplied(color[0], color[1], color[2], color[3]);
-                ui.horizontal(|ui| {
-                    let (swatch_rect, _) =
-                        ui.allocate_exact_size(egui::vec2(12.0, 12.0), egui::Sense::hover());
-                    ui.painter().circle_filled(swatch_rect.center(), 5.0, c);
-                    if ui.button(name).clicked() {
-                        actions.push(SidebarAction::SetWorkspaceColor(idx, Some(color)));
-                        ui.close_menu();
-                    }
-                });
-            }
-            ui.separator();
-            if ui.button("Clear").clicked() {
-                actions.push(SidebarAction::SetWorkspaceColor(idx, None));
+    crate::popup_theme::with_menu_palette(ui.ctx(), palette, || {
+        response.context_menu(|ui| {
+            if ui.button("Rename Workspace").clicked() {
+                actions.push(SidebarAction::StartRenameWorkspace(idx));
                 ui.close_menu();
             }
+            if ui.button("Close Workspace").clicked() {
+                actions.push(SidebarAction::CloseWorkspace(idx));
+                ui.close_menu();
+            }
+            ui.separator();
+            if ui.button("Mark All Read").clicked() {
+                actions.push(SidebarAction::MarkWorkspaceRead(idx));
+                ui.close_menu();
+            }
+            ui.separator();
+            crate::popup_theme::apply_menu_palette(ui, palette);
+            ui.menu_button("Set Color", |ui| {
+                crate::popup_theme::apply_menu_palette(ui, palette);
+                for &(color, name) in PRESET_COLORS {
+                    let c =
+                        Color32::from_rgba_premultiplied(color[0], color[1], color[2], color[3]);
+                    ui.horizontal(|ui| {
+                        let (swatch_rect, _) =
+                            ui.allocate_exact_size(egui::vec2(12.0, 12.0), egui::Sense::hover());
+                        ui.painter().circle_filled(swatch_rect.center(), 5.0, c);
+                        if ui.button(name).clicked() {
+                            actions.push(SidebarAction::SetWorkspaceColor(idx, Some(color)));
+                            ui.close_menu();
+                        }
+                    });
+                }
+                ui.separator();
+                if ui.button("Clear").clicked() {
+                    actions.push(SidebarAction::SetWorkspaceColor(idx, None));
+                    ui.close_menu();
+                }
+            });
         });
     });
 

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -240,10 +240,12 @@ impl Default for Theme {
     /// `[colors]` section of `amux/config.toml`.
     /// See `docs/configuration.md` for the full layering.
     ///
-    /// Colors mirror the Ghostty config cmux ships as its default:
-    /// dark gray background (`#252830`), warm off-white foreground
-    /// (`#fdfff1`), Monokai ANSI palette (pink/green/yellow/
-    /// orange/purple/cyan), orange accent.
+    /// Terminal colors mirror the Ghostty config cmux ships as its
+    /// default: dark gray background (`#252830`), warm off-white
+    /// foreground (`#fdfff1`), Monokai ANSI palette (pink/green/
+    /// yellow/orange/purple/cyan). The chrome accent stays amux
+    /// blue (`#3d7dff`) so the active workspace/tab highlight is
+    /// visually distinct from the Monokai orange.
     fn default() -> Self {
         Self {
             terminal: TerminalColors {
@@ -279,15 +281,17 @@ impl Default for Theme {
                 // the sidebar reads as a distinct panel rather than
                 // blending into the terminal.
                 sidebar_bg: Color32::from_rgb(0x1d, 0x1f, 0x25),
-                // Accent: Monokai orange, matches the palette.
-                sidebar_active_bg: Color32::from_rgb(0xfd, 0x97, 0x1f),
+                // Accent: amux blue — kept distinct from the Monokai
+                // terminal palette so the active workspace/tab
+                // highlight doesn't blend into the orange ANSI cells.
+                sidebar_active_bg: Color32::from_rgb(0x3d, 0x7d, 0xff),
                 tab_bar_bg: None,  // falls back to terminal background
                 titlebar_bg: None, // falls back to tab bar background
                 tab_active_bg: Color32::from_rgb(0x25, 0x28, 0x30), // match terminal bg
                 tab_bar_border: Color32::from_rgb(0x3a, 0x3c, 0x43),
                 tab_border: Color32::from_rgb(0x3a, 0x3c, 0x43),
                 divider: Color32::from_rgb(0x3a, 0x3c, 0x43),
-                accent: Color32::from_rgb(0xfd, 0x97, 0x1f),
+                accent: Color32::from_rgb(0x3d, 0x7d, 0xff),
             },
         }
     }

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -230,63 +230,64 @@ fn lighten_rgb(r: u8, g: u8, b: u8, amount: f32) -> Color32 {
 }
 
 impl Default for Theme {
-    /// amux's built-in default theme: a neutral dark palette with a
-    /// blue-gray background (`#14161E`), soft off-white foreground
-    /// (`#D0D4E0`), and a blue accent for active/selected chrome.
-    ///
-    /// This replaces a previous "Tokyo Night" default. The amux
-    /// default is intentionally not derived from any third-party
-    /// theme so there's no branding confusion — users who want
-    /// Tokyo Night, Nord, Solarized, etc. should set
-    /// `theme_source = "ghostty"` in their `amux/config.toml` and
-    /// configure the theme in Ghostty, OR override individual
-    /// colors in the `[colors]` section of `amux/config.toml`.
+    /// amux's built-in default theme: Monokai Classic — the same
+    /// palette that ships as cmux's default and that the author
+    /// uses via Ghostty on macOS. Windows and Linux users get the
+    /// same look out of the box without needing to install Ghostty
+    /// or write a config file; users who want something different
+    /// can set `theme_source = "ghostty"` to read their Ghostty
+    /// config instead, or override individual colors in the
+    /// `[colors]` section of `amux/config.toml`.
     /// See `docs/configuration.md` for the full layering.
     ///
-    /// ANSI palette leans toward balanced saturation so both the
-    /// dim and bright variants of each color are readable against
-    /// the dark background. Selection background is a muted blue
-    /// (`#2A3550`) so selected terminal text stays legible.
+    /// Colors mirror the Ghostty config cmux ships as its default:
+    /// dark gray background (`#252830`), warm off-white foreground
+    /// (`#fdfff1`), Monokai ANSI palette (pink/green/yellow/
+    /// orange/purple/cyan), orange accent.
     fn default() -> Self {
         Self {
             terminal: TerminalColors {
-                // amux default
-                background: [0x14, 0x16, 0x1e],
-                foreground: [0xd0, 0xd4, 0xe0],
+                // Monokai Classic (cmux default)
+                background: [0x25, 0x28, 0x30],
+                foreground: [0xfd, 0xff, 0xf1],
                 ansi: [
-                    [0x0f, 0x11, 0x17], // 0  black
-                    [0xe0, 0x6c, 0x75], // 1  red
-                    [0x98, 0xc3, 0x79], // 2  green
-                    [0xe5, 0xc0, 0x7b], // 3  yellow
-                    [0x61, 0xaf, 0xef], // 4  blue
-                    [0xc6, 0x78, 0xdd], // 5  magenta
-                    [0x56, 0xb6, 0xc2], // 6  cyan
-                    [0xab, 0xb2, 0xbf], // 7  white
-                    [0x3a, 0x40, 0x4e], // 8  bright black
-                    [0xe8, 0x80, 0x88], // 9  bright red
-                    [0xa8, 0xd1, 0x8e], // 10 bright green
-                    [0xed, 0xcd, 0x8f], // 11 bright yellow
-                    [0x77, 0xbd, 0xf2], // 12 bright blue
-                    [0xd0, 0x8a, 0xe6], // 13 bright magenta
-                    [0x74, 0xc6, 0xd1], // 14 bright cyan
-                    [0xd0, 0xd4, 0xe0], // 15 bright white
+                    [0x27, 0x28, 0x22], // 0  black
+                    [0xf9, 0x26, 0x72], // 1  red    (Monokai pink)
+                    [0xa6, 0xe2, 0x2e], // 2  green
+                    [0xe6, 0xdb, 0x74], // 3  yellow
+                    [0xfd, 0x97, 0x1f], // 4  blue   (Monokai orange — slot 4 by convention)
+                    [0xae, 0x81, 0xff], // 5  magenta (Monokai purple)
+                    [0x66, 0xd9, 0xef], // 6  cyan
+                    [0xfd, 0xff, 0xf1], // 7  white
+                    [0x6e, 0x70, 0x66], // 8  bright black
+                    [0xf9, 0x26, 0x72], // 9  bright red
+                    [0xa6, 0xe2, 0x2e], // 10 bright green
+                    [0xe6, 0xdb, 0x74], // 11 bright yellow
+                    [0xfd, 0x97, 0x1f], // 12 bright blue
+                    [0xae, 0x81, 0xff], // 13 bright magenta
+                    [0x66, 0xd9, 0xef], // 14 bright cyan
+                    [0xfd, 0xff, 0xf1], // 15 bright white
                 ],
                 palette_overrides: HashMap::new(),
-                cursor_fg: [0x14, 0x16, 0x1e],
-                cursor_bg: [0xd0, 0xd4, 0xe0],
-                selection_fg: [0xd0, 0xd4, 0xe0],
-                selection_bg: [0x2a, 0x35, 0x50],
+                cursor_fg: [0x8d, 0x8e, 0x82],
+                cursor_bg: [0xc0, 0xc1, 0xb5],
+                selection_fg: [0xfd, 0xff, 0xf1],
+                selection_bg: [0x57, 0x58, 0x4f],
             },
             chrome: ChromeColors {
-                sidebar_bg: Color32::from_gray(30),
-                sidebar_active_bg: Color32::from_rgb(0x3d, 0x7d, 0xff),
+                // Sidebar: slightly darker than the terminal bg so
+                // the sidebar reads as a distinct panel rather than
+                // blending into the terminal.
+                sidebar_bg: Color32::from_rgb(0x1d, 0x1f, 0x25),
+                // Accent: Monokai orange, matches the palette.
+                sidebar_active_bg: Color32::from_rgb(0xfd, 0x97, 0x1f),
                 tab_bar_bg: None,  // falls back to terminal background
                 titlebar_bg: None, // falls back to tab bar background
-                tab_active_bg: Color32::from_rgb(0x14, 0x16, 0x1e), // match terminal bg
-                tab_bar_border: Color32::from_gray(50),
-                tab_border: Color32::from_gray(50),
-                divider: Color32::from_gray(55),
-                accent: Color32::from_rgb(0x3d, 0x7d, 0xff),
+                tab_active_bg: Color32::from_rgb(0x25, 0x28, 0x30), // match terminal bg
+                tab_bar_border: Color32::from_rgb(0x3a, 0x3c, 0x43),
+                tab_border: Color32::from_rgb(0x3a, 0x3c, 0x43),
+                divider: Color32::from_rgb(0x3a, 0x3c, 0x43),
+                accent: Color32::from_rgb(0xfd, 0x97, 0x1f),
             },
         }
     }

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -101,8 +101,9 @@ impl Theme {
 impl Theme {
     /// Create a theme from a loaded Ghostty config.
     ///
-    /// Colors present in the Ghostty config override the defaults; missing
-    /// colors fall back to the built-in Tokyo Night theme.
+    /// Colors present in the Ghostty config override the defaults;
+    /// missing colors fall back to the amux built-in default
+    /// palette (see `Theme::default`).
     pub(crate) fn from_ghostty(cfg: &amux_ghostty_config::GhosttyConfig) -> Self {
         let default = Self::default();
         let mut terminal = default.terminal.clone();
@@ -229,46 +230,63 @@ fn lighten_rgb(r: u8, g: u8, b: u8, amount: f32) -> Color32 {
 }
 
 impl Default for Theme {
+    /// amux's built-in default theme: a neutral dark palette with a
+    /// blue-gray background (`#14161E`), soft off-white foreground
+    /// (`#D0D4E0`), and a blue accent for active/selected chrome.
+    ///
+    /// This replaces a previous "Tokyo Night" default. The amux
+    /// default is intentionally not derived from any third-party
+    /// theme so there's no branding confusion — users who want
+    /// Tokyo Night, Nord, Solarized, etc. should set
+    /// `theme_source = "ghostty"` in their `amux/config.toml` and
+    /// configure the theme in Ghostty, OR override individual
+    /// colors in the `[colors]` section of `amux/config.toml`.
+    /// See `docs/configuration.md` for the full layering.
+    ///
+    /// ANSI palette leans toward balanced saturation so both the
+    /// dim and bright variants of each color are readable against
+    /// the dark background. Selection background is a muted blue
+    /// (`#2A3550`) so selected terminal text stays legible.
     fn default() -> Self {
         Self {
             terminal: TerminalColors {
-                // Tokyo Night
-                background: [0x1a, 0x1b, 0x26],
-                foreground: [0xc0, 0xca, 0xf5],
+                // amux default
+                background: [0x14, 0x16, 0x1e],
+                foreground: [0xd0, 0xd4, 0xe0],
                 ansi: [
-                    [0x15, 0x16, 0x1e], // 0  black
-                    [0xf7, 0x76, 0x8e], // 1  red
-                    [0x9e, 0xce, 0x6a], // 2  green
-                    [0xe0, 0xaf, 0x68], // 3  yellow
-                    [0x7a, 0xa2, 0xf7], // 4  blue
-                    [0xbb, 0x9a, 0xf7], // 5  magenta
-                    [0x7d, 0xcf, 0xff], // 6  cyan
-                    [0xa9, 0xb1, 0xd6], // 7  white
-                    [0x41, 0x48, 0x68], // 8  bright black
-                    [0xf7, 0x76, 0x8e], // 9  bright red
-                    [0x9e, 0xce, 0x6a], // 10 bright green
-                    [0xe0, 0xaf, 0x68], // 11 bright yellow
-                    [0x7a, 0xa2, 0xf7], // 12 bright blue
-                    [0xbb, 0x9a, 0xf7], // 13 bright magenta
-                    [0x7d, 0xcf, 0xff], // 14 bright cyan
-                    [0xc0, 0xca, 0xf5], // 15 bright white
+                    [0x0f, 0x11, 0x17], // 0  black
+                    [0xe0, 0x6c, 0x75], // 1  red
+                    [0x98, 0xc3, 0x79], // 2  green
+                    [0xe5, 0xc0, 0x7b], // 3  yellow
+                    [0x61, 0xaf, 0xef], // 4  blue
+                    [0xc6, 0x78, 0xdd], // 5  magenta
+                    [0x56, 0xb6, 0xc2], // 6  cyan
+                    [0xab, 0xb2, 0xbf], // 7  white
+                    [0x3a, 0x40, 0x4e], // 8  bright black
+                    [0xe8, 0x80, 0x88], // 9  bright red
+                    [0xa8, 0xd1, 0x8e], // 10 bright green
+                    [0xed, 0xcd, 0x8f], // 11 bright yellow
+                    [0x77, 0xbd, 0xf2], // 12 bright blue
+                    [0xd0, 0x8a, 0xe6], // 13 bright magenta
+                    [0x74, 0xc6, 0xd1], // 14 bright cyan
+                    [0xd0, 0xd4, 0xe0], // 15 bright white
                 ],
                 palette_overrides: HashMap::new(),
-                cursor_fg: [0x15, 0x16, 0x1e],
-                cursor_bg: [0xc0, 0xca, 0xf5],
-                selection_fg: [0xc0, 0xca, 0xf5],
-                selection_bg: [0x33, 0x46, 0x7c],
+                cursor_fg: [0x14, 0x16, 0x1e],
+                cursor_bg: [0xd0, 0xd4, 0xe0],
+                selection_fg: [0xd0, 0xd4, 0xe0],
+                selection_bg: [0x2a, 0x35, 0x50],
             },
             chrome: ChromeColors {
-                sidebar_bg: Color32::from_gray(35),
-                sidebar_active_bg: Color32::from_rgb(0, 145, 255), // same as accent
+                sidebar_bg: Color32::from_gray(30),
+                sidebar_active_bg: Color32::from_rgb(0x3d, 0x7d, 0xff),
                 tab_bar_bg: None,  // falls back to terminal background
                 titlebar_bg: None, // falls back to tab bar background
-                tab_active_bg: Color32::from_rgb(0x1a, 0x1b, 0x26), // match terminal bg
-                tab_bar_border: Color32::from_gray(55),
-                tab_border: Color32::from_gray(55),
-                divider: Color32::from_gray(60),
-                accent: Color32::from_rgb(0, 145, 255),
+                tab_active_bg: Color32::from_rgb(0x14, 0x16, 0x1e), // match terminal bg
+                tab_bar_border: Color32::from_gray(50),
+                tab_border: Color32::from_gray(50),
+                divider: Color32::from_gray(55),
+                accent: Color32::from_rgb(0x3d, 0x7d, 0xff),
             },
         }
     }

--- a/crates/amux-app/src/title_sanitize.rs
+++ b/crates/amux-app/src/title_sanitize.rs
@@ -1,0 +1,231 @@
+//! Clean up ugly PTY titles before they reach user-visible chrome.
+//!
+//! ConPTY on Windows sets the initial window title of a spawned
+//! shell to the full absolute path of the shell executable (e.g.
+//! `C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.0.0_arm64__8wekyb3d8bbwe\pwsh.exe`).
+//! amux picks that up via `pane.title()` and echoes it to every
+//! user-visible title surface: the main window title, the tab bar
+//! tab label, any notification-panel entries, and so on.
+//!
+//! On macOS and Linux this is less of a problem because bash / zsh
+//! default `PROMPT_COMMAND` emits an `OSC 0` sequence on every
+//! prompt that replaces the initial title with something more
+//! useful. pwsh on Windows does set `$Host.UI.RawUI.WindowTitle`
+//! from its default prompt function, but that depends on the
+//! user's profile actually running the default prompt AND on pwsh
+//! translating the title-set into an OSC sequence ConPTY can
+//! forward — which doesn't reliably happen on every Windows build
+//! we've tested.
+//!
+//! [`sanitize_pane_title`] is a best-effort cleanup applied at
+//! every title consumer (in practice, applied once at the bottom of
+//! `managed_pane::surface_title` so every consumer inherits the
+//! cleanup for free). Rules:
+//!
+//! 1. Empty input → `"?"` (matches the raw pane fallback today).
+//! 2. Input that looks like an absolute path to a known shell exe
+//!    (`.exe` / `.cmd` / `.bat` / `.sh` / `.ps1` / `.fish` / `.zsh`
+//!    extension AND a path separator) → basename minus extension.
+//! 3. Input that looks like a bare shell exe (no path separators
+//!    but has a known shell extension) → basename minus extension.
+//! 4. Otherwise → passthrough (assume the shell or user set it
+//!    deliberately via `OSC 0`, a prompt command, or our own
+//!    `user_title` override).
+//!
+//! See amux #199 for the user-facing context.
+
+use std::borrow::Cow;
+
+/// Known shell executable extensions. We strip any of these (plus
+/// their surrounding path) to collapse an ugly absolute shell path
+/// into just the shell name.
+const SHELL_EXTENSIONS: &[&str] = &[
+    ".exe", // Windows-native shells: pwsh.exe, cmd.exe, bash.exe, fish.exe, ...
+    ".cmd", // Batch shims
+    ".bat", // Batch scripts
+    ".ps1", // PowerShell scripts
+    ".sh",  // Shell scripts
+    ".fish", ".zsh",
+];
+
+/// Known shell basenames (lowercased, extension included) that we
+/// recognize as "definitely the raw shell executable path, not a
+/// user-set title" even when they're bare filenames.
+///
+/// We could try to do this case-insensitively just with extension
+/// matching, but being explicit here avoids accidentally stripping
+/// the name of a user-set title that happens to include a file
+/// extension (e.g. a workspace named `"README.md"` would not be in
+/// this list).
+const KNOWN_SHELL_BASENAMES: &[&str] = &[
+    "pwsh.exe",
+    "powershell.exe",
+    "cmd.exe",
+    "bash.exe",
+    "fish.exe",
+    "zsh.exe",
+    "sh.exe",
+    // Unix-y — rarely appear as a bare title, but cheap to include
+    "bash",
+    "zsh",
+    "fish",
+    "sh",
+    "pwsh",
+];
+
+/// Sanitize a raw pane title for display. Returns `Cow::Borrowed`
+/// when the input is already clean (zero allocation) and
+/// `Cow::Owned` when it had to be transformed.
+pub(crate) fn sanitize_pane_title(raw: &str) -> Cow<'_, str> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Cow::Borrowed("?");
+    }
+
+    let looks_like_abs_path =
+        trimmed.contains('\\') || trimmed.contains('/') || has_drive_letter(trimmed);
+
+    // Case 1: absolute-path-to-shell, where the final path segment
+    // either has a known shell extension (`pwsh.exe`, `bash.sh`) OR
+    // is a bare known shell basename (`bash`, `fish`, `zsh`).
+    if looks_like_abs_path {
+        if let Some(basename) = last_path_segment(trimmed) {
+            if let Some(ext) = shell_extension(basename) {
+                return Cow::Owned(strip_extension(basename, ext).to_string());
+            }
+            if is_known_shell_basename(basename) {
+                return Cow::Owned(basename.to_string());
+            }
+        }
+    }
+
+    // Case 2: bare shell basename (no separators) — matches any
+    // entry in `KNOWN_SHELL_BASENAMES`, case-insensitively. Strip
+    // the extension if present so `pwsh.exe` → `pwsh`.
+    if is_known_shell_basename(trimmed) {
+        if let Some(ext) = shell_extension(trimmed) {
+            return Cow::Owned(strip_extension(trimmed, ext).to_string());
+        }
+        return Cow::Borrowed(trimmed);
+    }
+
+    // Case 3: passthrough — shell or user set it deliberately.
+    Cow::Borrowed(trimmed)
+}
+
+/// Lowercase-compare `s` against [`KNOWN_SHELL_BASENAMES`].
+fn is_known_shell_basename(s: &str) -> bool {
+    let lower = s.to_ascii_lowercase();
+    KNOWN_SHELL_BASENAMES.iter().any(|b| *b == lower)
+}
+
+/// True if `s` starts with a Windows drive letter (`C:`, `d:`, ...).
+fn has_drive_letter(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+/// Returns the shell extension suffix (e.g. `".exe"`) if `s` ends
+/// with one from `SHELL_EXTENSIONS`. Matches case-insensitively.
+fn shell_extension(s: &str) -> Option<&'static str> {
+    let lower = s.to_ascii_lowercase();
+    SHELL_EXTENSIONS
+        .iter()
+        .find(|ext| lower.ends_with(*ext))
+        .copied()
+}
+
+/// Return the final path segment of `s`, splitting on either
+/// forward or backward slashes.
+fn last_path_segment(s: &str) -> Option<&str> {
+    s.rsplit(['/', '\\']).next().filter(|seg| !seg.is_empty())
+}
+
+/// Strip `ext` from the end of `s` if it ends with `ext` (case-
+/// insensitive). Returns `s` unchanged otherwise.
+fn strip_extension<'a>(s: &'a str, ext: &str) -> &'a str {
+    if s.to_ascii_lowercase().ends_with(ext) {
+        &s[..s.len() - ext.len()]
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passthrough_empty_becomes_question_mark() {
+        assert_eq!(sanitize_pane_title(""), "?");
+        assert_eq!(sanitize_pane_title("   "), "?");
+    }
+
+    #[test]
+    fn passthrough_normal_titles() {
+        assert_eq!(sanitize_pane_title("My Workspace"), "My Workspace");
+        assert_eq!(sanitize_pane_title("~/src/amux"), "~/src/amux");
+        assert_eq!(
+            sanitize_pane_title("agent: Claude Code"),
+            "agent: Claude Code"
+        );
+    }
+
+    #[test]
+    fn collapses_windows_store_pwsh_path() {
+        // The motivating case from #199.
+        let raw = r"C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.0.0_arm64__8wekyb3d8bbwe\pwsh.exe";
+        assert_eq!(sanitize_pane_title(raw), "pwsh");
+    }
+
+    #[test]
+    fn collapses_classic_program_files_pwsh_path() {
+        let raw = r"C:\Program Files\PowerShell\7\pwsh.exe";
+        assert_eq!(sanitize_pane_title(raw), "pwsh");
+    }
+
+    #[test]
+    fn collapses_cmd_exe_path() {
+        let raw = r"C:\Windows\System32\cmd.exe";
+        assert_eq!(sanitize_pane_title(raw), "cmd");
+    }
+
+    #[test]
+    fn collapses_unix_absolute_bash_path() {
+        assert_eq!(sanitize_pane_title("/bin/bash"), "bash");
+        assert_eq!(sanitize_pane_title("/opt/homebrew/bin/fish"), "fish");
+    }
+
+    #[test]
+    fn collapses_bare_shell_basenames() {
+        assert_eq!(sanitize_pane_title("pwsh.exe"), "pwsh");
+        assert_eq!(sanitize_pane_title("cmd.exe"), "cmd");
+        assert_eq!(sanitize_pane_title("bash"), "bash");
+        assert_eq!(sanitize_pane_title("zsh"), "zsh");
+    }
+
+    #[test]
+    fn case_insensitive_extension_match() {
+        assert_eq!(sanitize_pane_title(r"C:\WINDOWS\SYSTEM32\CMD.EXE"), "CMD");
+        assert_eq!(sanitize_pane_title(r"D:\Apps\Pwsh.Exe"), "Pwsh");
+    }
+
+    #[test]
+    fn passthrough_forward_slash_non_shell_paths() {
+        // User-set OSC titles that happen to contain slashes should
+        // pass through untouched.
+        assert_eq!(sanitize_pane_title("ls: no such file"), "ls: no such file");
+        assert_eq!(sanitize_pane_title("feat/my-branch"), "feat/my-branch");
+    }
+
+    #[test]
+    fn preserves_non_shell_exe_paths() {
+        // An absolute path that doesn't end in a known shell
+        // extension shouldn't be collapsed — we can't tell whether
+        // it's something the user set deliberately.
+        assert_eq!(
+            sanitize_pane_title(r"C:\Users\dave\notes.md"),
+            r"C:\Users\dave\notes.md"
+        );
+    }
+}

--- a/crates/amux-app/src/title_sanitize.rs
+++ b/crates/amux-app/src/title_sanitize.rs
@@ -18,14 +18,15 @@
 //! we've tested.
 //!
 //! [`sanitize_pane_title`] is a best-effort cleanup applied at
-//! every title consumer (in practice, applied once at the bottom of
-//! `managed_pane::surface_title` so every consumer inherits the
-//! cleanup for free). Rules:
+//! every title consumer (in practice, applied once in
+//! `ManagedPane::title()` so every consumer inherits the cleanup
+//! for free). Rules:
 //!
 //! 1. Empty input → `"?"` (matches the raw pane fallback today).
-//! 2. Input that looks like an absolute path to a known shell exe
-//!    (`.exe` / `.cmd` / `.bat` / `.sh` / `.ps1` / `.fish` / `.zsh`
-//!    extension AND a path separator) → basename minus extension.
+//! 2. Input that is an **absolute** path (starts with `/`, `\\`,
+//!    or a drive letter followed by `\`/`/`) AND whose last
+//!    segment is a known shell exe → basename minus extension.
+//!    Relative paths like `tools/pwsh.exe` are left untouched.
 //! 3. Input that looks like a bare shell exe (no path separators
 //!    but has a known shell extension) → basename minus extension.
 //! 4. Otherwise → passthrough (assume the shell or user set it
@@ -82,8 +83,13 @@ pub(crate) fn sanitize_pane_title(raw: &str) -> Cow<'_, str> {
         return Cow::Borrowed("?");
     }
 
-    let looks_like_abs_path =
-        trimmed.contains('\\') || trimmed.contains('/') || has_drive_letter(trimmed);
+    // Only treat the input as a path-to-collapse if it starts with
+    // a real absolute-path prefix. Relative paths like
+    // `tools/pwsh.exe` stay as-is — we can't tell whether the user
+    // typed that deliberately as an OSC title.
+    let looks_like_abs_path = trimmed.starts_with('/')      // Unix absolute
+        || trimmed.starts_with("\\\\")                       // Windows UNC
+        || has_drive_letter_prefix(trimmed); //               Windows C:\ / C:/
 
     // Case 1: absolute-path-to-shell, where the final path segment
     // either has a known shell extension (`pwsh.exe`, `bash.sh`) OR
@@ -113,26 +119,52 @@ pub(crate) fn sanitize_pane_title(raw: &str) -> Cow<'_, str> {
     Cow::Borrowed(trimmed)
 }
 
-/// Lowercase-compare `s` against [`KNOWN_SHELL_BASENAMES`].
+/// Case-insensitive match of `s` against [`KNOWN_SHELL_BASENAMES`].
+/// Uses `eq_ignore_ascii_case` so the common passthrough case stays
+/// allocation-free (important because this runs from per-frame
+/// tab-bar / window-title rendering paths).
 fn is_known_shell_basename(s: &str) -> bool {
-    let lower = s.to_ascii_lowercase();
-    KNOWN_SHELL_BASENAMES.iter().any(|b| *b == lower)
+    KNOWN_SHELL_BASENAMES
+        .iter()
+        .any(|b| b.eq_ignore_ascii_case(s))
 }
 
-/// True if `s` starts with a Windows drive letter (`C:`, `d:`, ...).
-fn has_drive_letter(s: &str) -> bool {
+/// True if `s` starts with a real absolute Windows drive path
+/// (`C:\`, `C:/`, `d:\`, ...). A bare drive-relative prefix like
+/// `C:pwsh.exe` is NOT considered absolute — Windows keeps a
+/// per-drive "current directory", and those inputs are almost
+/// certainly user-typed text rather than raw PTY titles.
+fn has_drive_letter_prefix(s: &str) -> bool {
     let bytes = s.as_bytes();
-    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/')
 }
 
 /// Returns the shell extension suffix (e.g. `".exe"`) if `s` ends
-/// with one from `SHELL_EXTENSIONS`. Matches case-insensitively.
+/// with one from `SHELL_EXTENSIONS`. Matches case-insensitively
+/// without allocating.
 fn shell_extension(s: &str) -> Option<&'static str> {
-    let lower = s.to_ascii_lowercase();
     SHELL_EXTENSIONS
         .iter()
-        .find(|ext| lower.ends_with(*ext))
+        .find(|ext| ends_with_ignore_ascii_case(s, ext))
         .copied()
+}
+
+/// Allocation-free case-insensitive suffix test. `ext` is assumed
+/// to already be ASCII lowercase (all entries in
+/// `SHELL_EXTENSIONS` are).
+fn ends_with_ignore_ascii_case(s: &str, ext: &str) -> bool {
+    let s = s.as_bytes();
+    let ext = ext.as_bytes();
+    if s.len() < ext.len() {
+        return false;
+    }
+    let tail = &s[s.len() - ext.len()..];
+    tail.iter()
+        .zip(ext)
+        .all(|(a, b)| a.to_ascii_lowercase() == *b)
 }
 
 /// Return the final path segment of `s`, splitting on either
@@ -142,9 +174,9 @@ fn last_path_segment(s: &str) -> Option<&str> {
 }
 
 /// Strip `ext` from the end of `s` if it ends with `ext` (case-
-/// insensitive). Returns `s` unchanged otherwise.
+/// insensitive). Returns `s` unchanged otherwise. Allocation-free.
 fn strip_extension<'a>(s: &'a str, ext: &str) -> &'a str {
-    if s.to_ascii_lowercase().ends_with(ext) {
+    if ends_with_ignore_ascii_case(s, ext) {
         &s[..s.len() - ext.len()]
     } else {
         s
@@ -227,5 +259,33 @@ mod tests {
             sanitize_pane_title(r"C:\Users\dave\notes.md"),
             r"C:\Users\dave\notes.md"
         );
+    }
+
+    #[test]
+    fn relative_paths_with_shell_names_pass_through() {
+        // A relative path that happens to end in a shell exe name
+        // should NOT be collapsed — the user may have typed it as a
+        // deliberate OSC title and "absolute path to shell" is the
+        // only case we want to rewrite.
+        assert_eq!(sanitize_pane_title("tools/pwsh.exe"), "tools/pwsh.exe");
+        assert_eq!(
+            sanitize_pane_title(r"scripts\build\bash.sh"),
+            r"scripts\build\bash.sh"
+        );
+    }
+
+    #[test]
+    fn drive_relative_prefix_is_not_absolute() {
+        // `C:pwsh.exe` is a Windows *drive-relative* path, not an
+        // absolute one. It should pass through unchanged rather
+        // than being collapsed to `C:pwsh`.
+        assert_eq!(sanitize_pane_title("C:pwsh.exe"), "C:pwsh.exe");
+    }
+
+    #[test]
+    fn unc_path_collapses() {
+        // Windows UNC paths (`\\server\share\...`) are absolute and
+        // should collapse like any other absolute shell path.
+        assert_eq!(sanitize_pane_title(r"\\server\share\pwsh.exe"), "pwsh");
     }
 }

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -423,8 +423,13 @@ pub struct AppConfig {
     /// Font family for terminal text (e.g. "JetBrains Mono", "Menlo").
     /// Resolved against system-installed fonts by cosmic-text.
     pub font_family: String,
-    /// Theme source: "default" uses built-in Tokyo Night, "ghostty" loads
-    /// colors/fonts from Ghostty's config file (`~/.config/ghostty/config`).
+    /// Theme source. `"default"` uses amux's built-in dark palette
+    /// (a neutral theme; see `crates/amux-app/src/theme.rs`);
+    /// `"ghostty"` loads colors and fonts from Ghostty's config
+    /// file at `~/.config/ghostty/config` (or the platform-
+    /// appropriate equivalent). Individual colors can still be
+    /// overridden in the `[colors]` section on top of either
+    /// source.
     pub theme_source: String,
     /// Shell to spawn in new panes. Accepts either a plain binary name
     /// (`"pwsh"`, `"bash"`) that amux resolves against `PATH`, or an

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -424,12 +424,13 @@ pub struct AppConfig {
     /// Resolved against system-installed fonts by cosmic-text.
     pub font_family: String,
     /// Theme source. `"default"` uses amux's built-in dark palette
-    /// (a neutral theme; see `crates/amux-app/src/theme.rs`);
-    /// `"ghostty"` loads colors and fonts from Ghostty's config
-    /// file at `~/.config/ghostty/config` (or the platform-
-    /// appropriate equivalent). Individual colors can still be
-    /// overridden in the `[colors]` section on top of either
-    /// source.
+    /// (Monokai Classic — the same palette cmux ships as its
+    /// default; see `crates/amux-app/src/theme.rs` for the exact
+    /// values); `"ghostty"` loads colors and fonts from Ghostty's
+    /// config file at `~/.config/ghostty/config` (or the
+    /// platform-appropriate equivalent). Individual colors can
+    /// still be overridden in the `[colors]` section on top of
+    /// either source.
     pub theme_source: String,
     /// Shell to spawn in new panes. Accepts either a plain binary name
     /// (`"pwsh"`, `"bash"`) that amux resolves against `PATH`, or an

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,8 +2,11 @@
 
 amux reads its configuration from a single TOML file:
 
-- **macOS / Linux**: `~/.config/amux/config.toml`
+- **Linux**: `~/.config/amux/config.toml`
+- **macOS**: `~/Library/Application Support/amux/config.toml`
 - **Windows**: `%APPDATA%\amux\config.toml`
+
+These are the paths `dirs::config_dir()` resolves to on each platform.
 
 The config file is optional — amux runs with sensible defaults if no file
 exists. Fields are deserialized via `serde` with `#[serde(default)]` on the
@@ -46,7 +49,7 @@ Controls where amux pulls its color palette from.
 
 | Value       | Behavior                                                                                              |
 |-------------|-------------------------------------------------------------------------------------------------------|
-| `"default"` | Uses amux's built-in neutral dark palette (see `crates/amux-app/src/theme.rs`). **Default.**           |
+| `"default"` | Uses amux's built-in Monokai Classic palette — the same palette cmux ships by default. See `crates/amux-app/src/theme.rs` for exact values. **Default.** |
 | `"ghostty"` | Reads `~/.config/ghostty/config` (or the platform equivalent) and derives terminal + chrome colors from Ghostty's theme. Fonts from Ghostty are also picked up and override `font_family` / `font_size` if present. |
 
 If `theme_source = "ghostty"` but no Ghostty config is found, amux logs a
@@ -85,7 +88,9 @@ When unset (the default):
 ## `[colors]` — Palette overrides
 
 Apply specific color overrides on top of whichever theme source is active.
-Colors use hex notation (`"#rrggbb"` or `"#rrggbbaa"`).
+Colors use 6-digit hex notation (`"#rrggbb"`). The parser is
+`ColorsConfig::parse_hex` in `amux-core/src/config.rs`, which accepts
+only RGB — 8-digit RGBA is not supported.
 
 ```toml
 [colors]
@@ -133,16 +138,26 @@ override the selection background here.
 
 ```toml
 [notifications]
+system_notifications    = true   # OS-native toast when the app is unfocused
+auto_reorder_workspaces = true   # bump notifying workspaces to the top of the sidebar
+dock_badge              = true   # show unread count on macOS dock / Windows taskbar
+custom_command          = "/usr/bin/true"   # optional shell command run on each notification
 
 [notifications.sound]
-sound = "chime"   # built-in: "chime", "ding", "ping", "none"
-# or: sound = "/path/to/custom.wav"
+sound              = "system"    # "system" → OS default, "none" → silent,
+                                  # or an absolute path to a .wav / .ogg / .mp3 file
+play_when_focused  = true        # set false to silence when the app is in the foreground
 ```
 
 Notifications are delivered via OSC 9 / OSC 99 / OSC 777 sequences from
 agents (Claude Code, Gemini CLI, Codex CLI) or via the `amux notify` CLI.
 Each delivered notification rings the configured sound and highlights the
 originating pane with a blue ring.
+
+The authoritative schema lives in `NotificationConfig` /
+`NotificationSoundConfig` in `crates/amux-core/src/config.rs`. amux does
+not ship named built-in sounds (there is no `"chime"` / `"ding"` / `"ping"`);
+use `"system"` for the OS default or point `sound` at a file on disk.
 
 ---
 
@@ -153,7 +168,9 @@ originating pane with a blue ring.
 search_engine              = "google"   # google, duckduckgo, bing, kagi, startpage
 open_terminal_links_in_app = false      # false → system browser, true → new browser tab
 user_agent                 = "Mozilla/5.0 ..."   # optional override
-download_dir               = "~/Downloads"        # optional; defaults to system Downloads
+download_dir               = "/Users/alice/Downloads"  # optional; defaults to system
+                                                       # Downloads. `~` is NOT expanded —
+                                                       # use an absolute path
 ```
 
 The in-app browser is a wry/WebView2 pane that shares workspace layout with
@@ -178,8 +195,10 @@ split_down    = "Ctrl+Shift+E"
 # ...
 ```
 
-See `crates/amux-core/src/config.rs` (`KeybindingsConfig::defaults_for_platform`)
-for the complete list of actions and their default bindings on each platform.
+See `crates/amux-core/src/config.rs` — the complete list of actions lives
+in the `Action` enum, and the default bindings are produced by
+`KeybindingsConfig::platform_defaults()` and merged with user overrides in
+`KeybindingsConfig::resolved()`.
 
 The binding syntax accepts modifier + key combos joined by `+`, where
 modifiers are `Ctrl`, `Cmd`, `Alt`, `Shift`, `Super` and the key is any
@@ -194,11 +213,13 @@ When amux starts up, it resolves the final theme and keybindings by
 applying layers in this order, lowest priority first:
 
 1. **Built-in defaults** — hard-coded in `amux-app/src/theme.rs` and
-   `amux-core/src/config.rs::KeybindingsConfig::defaults_for_platform()`.
+   `amux-core/src/config.rs::KeybindingsConfig::platform_defaults()`.
 2. **Theme source** — if `theme_source = "ghostty"`, Ghostty's config
    overlays the built-in theme.
 3. **User config file** — `[colors]` + `[keybindings]` sections in
-   `amux/config.toml` overlay the previous layer, one field at a time.
+   `~/.config/amux/config.toml` (or `%APPDATA%\amux\config.toml` on
+   Windows, `~/Library/Application Support/amux/config.toml` on macOS)
+   overlay the previous layer, one field at a time.
 
 Later layers only override the specific fields they set. Unset fields
 inherit from below. This means you can start with a Ghostty theme and
@@ -215,13 +236,17 @@ scrollback, and notification history across the restart.
 
 ## File locations (quick reference)
 
-| Purpose                  | Path                                                                        |
-|--------------------------|------------------------------------------------------------------------------|
-| amux main config         | `~/.config/amux/config.toml` (Unix) / `%APPDATA%\amux\config.toml` (Windows) |
-| amux session state       | `~/.config/amux/session.json` (Unix) / `%APPDATA%\amux\session.json` (Win)   |
-| Ghostty config (if used) | `~/.config/ghostty/config` (Unix) / `%APPDATA%\ghostty\config` (Windows)     |
-| Shell integration scripts| `~/.config/amux/shell/`                                                     |
-| Agent wrapper scripts    | `~/.config/amux/bin/`                                                       |
+amux resolves the main config via `dirs::config_dir()` and the session
+state via `dirs::data_dir()`, which land in different platform-standard
+directories:
+
+| Purpose                  | Linux                                  | macOS                                                   | Windows                          |
+|--------------------------|----------------------------------------|---------------------------------------------------------|----------------------------------|
+| amux main config         | `~/.config/amux/config.toml`           | `~/Library/Application Support/amux/config.toml`        | `%APPDATA%\amux\config.toml`     |
+| amux session state       | `~/.local/share/amux/session.json`     | `~/Library/Application Support/amux/session.json`       | `%APPDATA%\amux\session.json`    |
+| Ghostty config (if used) | `~/.config/ghostty/config`             | `~/Library/Application Support/com.mitchellh.ghostty/config` | `%APPDATA%\ghostty\config`  |
+| Shell integration scripts| `~/.config/amux/shell/`                | `~/Library/Application Support/amux/shell/`             | `%APPDATA%\amux\shell\`          |
+| Agent wrapper scripts    | `~/.config/amux/bin/`                  | `~/Library/Application Support/amux/bin/`               | `%APPDATA%\amux\bin\`            |
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,240 @@
+# amux Configuration
+
+amux reads its configuration from a single TOML file:
+
+- **macOS / Linux**: `~/.config/amux/config.toml`
+- **Windows**: `%APPDATA%\amux\config.toml`
+
+The config file is optional — amux runs with sensible defaults if no file
+exists. Fields are deserialized via `serde` with `#[serde(default)]` on the
+root struct, so you can omit any field you don't want to customize.
+
+Changing the config file requires restarting amux to take effect.
+
+---
+
+## Top-level fields
+
+```toml
+# Visual
+font_family  = "JetBrains Mono"
+font_size    = 14.0
+theme_source = "default"        # or "ghostty"
+menu_bar_style = "menubar"      # "menubar", "hamburger", or "none"
+
+# Shell
+shell        = "pwsh"           # optional override; see Shell resolution below
+
+# Nested tables (each documented below)
+[notifications]
+[browser]
+[colors]
+[keybindings]
+```
+
+### `font_family` / `font_size`
+
+The terminal font. Resolved against system-installed fonts by
+[`cosmic-text`](https://github.com/pop-os/cosmic-text). Any TrueType/OpenType
+font installed on the system is available.
+
+Defaults to a platform-appropriate monospace font at 14pt.
+
+### `theme_source`
+
+Controls where amux pulls its color palette from.
+
+| Value       | Behavior                                                                                              |
+|-------------|-------------------------------------------------------------------------------------------------------|
+| `"default"` | Uses amux's built-in neutral dark palette (see `crates/amux-app/src/theme.rs`). **Default.**           |
+| `"ghostty"` | Reads `~/.config/ghostty/config` (or the platform equivalent) and derives terminal + chrome colors from Ghostty's theme. Fonts from Ghostty are also picked up and override `font_family` / `font_size` if present. |
+
+If `theme_source = "ghostty"` but no Ghostty config is found, amux logs a
+warning and falls back to `"default"`.
+
+### `menu_bar_style`
+
+Controls amux's in-window menu chrome on Windows and Linux. macOS always
+uses the native NSApp menu bar at the top of the screen regardless of this
+setting — it's the idiomatic macOS pattern and removing it would break
+user expectations.
+
+| Value         | Behavior                                                                                 |
+|---------------|------------------------------------------------------------------------------------------|
+| `"menubar"`   | Traditional two-strip layout: a dedicated `File Edit View` strip above the icon row. Costs ~24px of vertical chrome. **Default on Windows/Linux.** |
+| `"hamburger"` | Single `≡` button collapsed into the icon row. Clicking it opens a flat popup listing every command grouped by section. Zero extra vertical chrome. |
+| `"none"`      | No in-window menu chrome. Menu actions are reachable only via keyboard shortcuts. **Default on macOS.** |
+
+### `shell`
+
+Override the shell amux spawns in new panes. Accepts either:
+
+- A bare binary name: `"pwsh"`, `"bash"`, `"fish"`. amux resolves it against
+  `PATH`, honoring `PATHEXT` on Windows.
+- An absolute path: `"/opt/homebrew/bin/fish"`,
+  `"C:\\Program Files\\PowerShell\\7\\pwsh.exe"`.
+
+When unset (the default):
+
+- **Unix**: uses `$SHELL`, falling back to `/bin/bash`.
+- **Windows**: prefers `pwsh.exe` (PowerShell 7) if it's on `PATH`,
+  otherwise falls back to `$COMSPEC` (typically `cmd.exe`).
+
+---
+
+## `[colors]` — Palette overrides
+
+Apply specific color overrides on top of whichever theme source is active.
+Colors use hex notation (`"#rrggbb"` or `"#rrggbbaa"`).
+
+```toml
+[colors]
+# Terminal base colors
+background    = "#101218"
+foreground    = "#d0d4e0"
+
+# Terminal cursor
+cursor_fg     = "#101218"
+cursor_bg     = "#61afef"
+
+# Terminal selection highlight
+selection_fg  = "#ffffff"
+selection_bg  = "#2a3550"
+
+# ANSI palette overrides (indices 0-15)
+palette = [
+    "#0f1117",  # 0  black
+    "#e06c75",  # 1  red
+    "#98c379",  # 2  green
+    "#e5c07b",  # 3  yellow
+    "#61afef",  # 4  blue
+    "#c678dd",  # 5  magenta
+    "#56b6c2",  # 6  cyan
+    "#abb2bf",  # 7  white
+    "#3a404e",  # 8  bright black
+    "#e88088",  # 9  bright red
+    "#a8d18e",  # 10 bright green
+    "#edcd8f",  # 11 bright yellow
+    "#77bdf2",  # 12 bright blue
+    "#d08ae6",  # 13 bright magenta
+    "#74c6d1",  # 14 bright cyan
+    "#d0d4e0",  # 15 bright white
+]
+```
+
+Any field you omit inherits from `theme_source`. The override layer is
+applied after the theme source resolves, so e.g. you can use
+`theme_source = "ghostty"` to pull most colors from Ghostty and only
+override the selection background here.
+
+---
+
+## `[notifications]` — Agent notification settings
+
+```toml
+[notifications]
+
+[notifications.sound]
+sound = "chime"   # built-in: "chime", "ding", "ping", "none"
+# or: sound = "/path/to/custom.wav"
+```
+
+Notifications are delivered via OSC 9 / OSC 99 / OSC 777 sequences from
+agents (Claude Code, Gemini CLI, Codex CLI) or via the `amux notify` CLI.
+Each delivered notification rings the configured sound and highlights the
+originating pane with a blue ring.
+
+---
+
+## `[browser]` — In-app browser settings
+
+```toml
+[browser]
+search_engine              = "google"   # google, duckduckgo, bing, kagi, startpage
+open_terminal_links_in_app = false      # false → system browser, true → new browser tab
+user_agent                 = "Mozilla/5.0 ..."   # optional override
+download_dir               = "~/Downloads"        # optional; defaults to system Downloads
+```
+
+The in-app browser is a wry/WebView2 pane that shares workspace layout with
+terminal panes. Each browser pane persists cookies and localStorage per
+workspace profile.
+
+---
+
+## `[keybindings]` — Shortcut overrides
+
+```toml
+[keybindings]
+# Full platform defaults live in `crates/amux-core/src/config.rs`.
+# User entries here are merged on top — set any action to override just
+# that binding without re-declaring the full table.
+
+new_workspace = "Ctrl+Shift+N"
+new_tab       = "Ctrl+Shift+T"
+close_tab     = "Ctrl+Shift+W"
+split_right   = "Ctrl+Shift+D"
+split_down    = "Ctrl+Shift+E"
+# ...
+```
+
+See `crates/amux-core/src/config.rs` (`KeybindingsConfig::defaults_for_platform`)
+for the complete list of actions and their default bindings on each platform.
+
+The binding syntax accepts modifier + key combos joined by `+`, where
+modifiers are `Ctrl`, `Cmd`, `Alt`, `Shift`, `Super` and the key is any
+[`egui::Key`](https://docs.rs/egui/latest/egui/enum.Key.html) name
+(e.g. `A`, `F5`, `Enter`, `Escape`, `ArrowLeft`).
+
+---
+
+## Layering, precedence, and reloads
+
+When amux starts up, it resolves the final theme and keybindings by
+applying layers in this order, lowest priority first:
+
+1. **Built-in defaults** — hard-coded in `amux-app/src/theme.rs` and
+   `amux-core/src/config.rs::KeybindingsConfig::defaults_for_platform()`.
+2. **Theme source** — if `theme_source = "ghostty"`, Ghostty's config
+   overlays the built-in theme.
+3. **User config file** — `[colors]` + `[keybindings]` sections in
+   `amux/config.toml` overlay the previous layer, one field at a time.
+
+Later layers only override the specific fields they set. Unset fields
+inherit from below. This means you can start with a Ghostty theme and
+override only a single selection color, or start from the amux default and
+remap just one keybinding.
+
+### Reloading config
+
+amux does **not** watch the config file for changes. After editing, quit and
+relaunch amux. Session restore preserves layout, working directories,
+scrollback, and notification history across the restart.
+
+---
+
+## File locations (quick reference)
+
+| Purpose                  | Path                                                                        |
+|--------------------------|------------------------------------------------------------------------------|
+| amux main config         | `~/.config/amux/config.toml` (Unix) / `%APPDATA%\amux\config.toml` (Windows) |
+| amux session state       | `~/.config/amux/session.json` (Unix) / `%APPDATA%\amux\session.json` (Win)   |
+| Ghostty config (if used) | `~/.config/ghostty/config` (Unix) / `%APPDATA%\ghostty\config` (Windows)     |
+| Shell integration scripts| `~/.config/amux/shell/`                                                     |
+| Agent wrapper scripts    | `~/.config/amux/bin/`                                                       |
+
+---
+
+## Minimal working example
+
+```toml
+# ~/.config/amux/config.toml
+
+font_family  = "JetBrains Mono"
+font_size    = 14.0
+theme_source = "default"
+
+# Override just the selection highlight to something more visible
+[colors]
+selection_bg = "#3a4568"
+```


### PR DESCRIPTION
## Summary

Bundled fast-follow addressing three open Windows-polish issues from the ARM64 VM testing session. 13 files, 764 insertions / 165 deletions, three new files:

- \`crates/amux-app/src/popup_theme.rs\` — cross-platform popup theming helper
- \`crates/amux-app/src/title_sanitize.rs\` — clean up ugly shell exe paths + 10 unit tests
- \`docs/configuration.md\` — full config reference

Closes #191, #198, #199.

## #198 — Sidebar workspace context menu was light-themed

Right-click on a workspace pill opened a white/light popup with dark text — egui's default theme, which clashes badly against amux's dark chrome. Same root cause as the menu bar popup bug from #196: egui reads **parent-ui style** to construct popup Frames, not the closure's ui.

Extracted \`MenuPalette\`, \`apply_menu_palette\`, and \`contrast_text\` out of \`menu_bar.rs\` (non-macOS gated) into a new cross-platform module \`popup_theme.rs\`. Applied at three points in \`sidebar.rs\`:

1. Parent \`ui\` before \`response.context_menu(...)\` — themes the top-level popup
2. Parent-of-submenu \`ui\` before \`ui.menu_button(\"Set Color\", ...)\` — themes the nested submenu
3. Inside the nested submenu closure — themes widgets rendered inside it

\`popup_theme\` is now the canonical location for this pattern — any future popup surface (tab bar context menus, find bar dropdowns, notification panel) can import and apply it consistently.

## #199 — Ugly shell-exe-path titles

ConPTY on Windows sets the initial window title of a spawned shell to the full absolute exe path:

> \`amux — C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.0.0_arm64__8wekyb3d8bbwe\\pwsh.exe\`

New \`title_sanitize::sanitize_pane_title(raw) -> Cow<str>\` helper with these rules:

| Input                                                                           | Output   |
|---------------------------------------------------------------------------------|----------|
| \`\"\"\` or whitespace                                                          | \`\"?\"\`   |
| \`C:\\Program Files\\WindowsApps\\...\\pwsh.exe\`                               | \`pwsh\` |
| \`/bin/bash\`, \`/opt/homebrew/bin/fish\`                                       | \`bash\` / \`fish\` |
| \`pwsh.exe\`, \`cmd.exe\`, \`bash\`                                             | \`pwsh\` / \`cmd\` / \`bash\` |
| \`My Workspace\`, \`feat/my-branch\`, \`~/src/amux\`                            | unchanged (passthrough) |
| \`C:\\Users\\dave\\notes.md\` (non-shell absolute path)                         | unchanged |

10 unit tests cover every case plus case-insensitive extension matching and passthrough edge cases.

Applied at every user-facing \`pane.title()\` consumer:

- **\`managed_pane::title()\`** — the canonical dispatcher most UI goes through
- **Window title** (\`frame_update.rs\`) — switched from \`sf.pane.title()\` direct to \`managed.title()\`
- **Tab bar labels** (\`pane_render.rs:138\`) — sanitized inline before the \`user_title\` fallback
- **Rename modal pre-fill** (\`pane_render.rs:651\`) — so the modal opens with \`pwsh\` not the ugly path
- **Sidebar workspace display title** (\`notifications_ui.rs::active_surface_metadata\`)
- **Session save** (\`main.rs\`) — so restores show \`pwsh\` not the captured ConPTY default

**Deliberately not sanitized**: \`ipc_dispatch.rs::build_workspace_json\` — IPC output is consumed by external scripts that may want the raw shell-reported title.

## #191 — Replace Tokyo Night default + write \`docs/configuration.md\`

Replaced the hard-coded Tokyo Night palette in \`Theme::default()\` with a neutral amux-branded dark palette. Users who want Tokyo Night / Nord / Solarized / etc. should set \`theme_source = \"ghostty\"\` and configure their theme in Ghostty.

New default colors:
- Background: \`#14161E\`
- Foreground: \`#D0D4E0\`
- Accent: \`#3D7DFF\`
- ANSI palette: balanced saturation, readable dim + bright variants

Updated the \`config.rs\` doc comment for \`theme_source\` to stop naming Tokyo Night.

**Wrote \`docs/configuration.md\`**: the missing config reference covering every field, the three-layer theme resolution chain (built-in → \`theme_source\` → \`[colors]\`), keybinding syntax, \`menu_bar_style\` values, shell resolution behavior, notifications, browser, file locations, and a minimal working example. \`CLAUDE.md\`'s Configuration section now links to it.

## Test plan

- [x] \`cargo fmt --check\`, \`cargo clippy --workspace -- -D warnings\`, \`cargo test --workspace\` — all clean locally
- [ ] CI green on all three platforms
- [ ] ARM64 Windows VM verification:
    - [ ] Window title reads \`amux — pwsh\` (not the WindowsApps path)
    - [ ] Tab bar tab label reads \`pwsh\`
    - [ ] Right-click sidebar workspace → context menu renders in dark amux colors
    - [ ] Right-click → \`Set Color ▶\` → nested submenu also dark
    - [ ] Default theme looks neutral (not Tokyo Night)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized popup/modal/menu theming so context menus, submenus and modals use a consistent palette.
  * Title sanitization for panes applied broadly (tabs, renames, sessions, metadata) to simplify path-like/raw PTY titles.

* **Improvements**
  * Default visual theme updated to a neutral dark palette with a muted blue accent.
  * More consistent styling, contrast and hover behavior for menu bars, tab menus and related popups.

* **Documentation**
  * Added full configuration reference and clarified theme/menu config options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->