### PR TITLE
Fix AMUX_BIN not set on Windows — breaks git/CWD reporting

### DIFF
--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -789,9 +789,13 @@ pub(crate) fn spawn_surface(
 
     // Point AMUX_BIN to the CLI binary so shell integration scripts can invoke it
     // without relying on PATH (macOS path_helper in /etc/zprofile rebuilds PATH).
+    // On Windows the binary is `amux.exe` — Rust's `Path::exists()` does NOT
+    // append PATHEXT the way cmd.exe / PowerShell `Get-Command` do, so we
+    // must use the platform-correct filename.
     if let Ok(exe) = std::env::current_exe() {
         if let Some(exe_dir) = exe.parent() {
-            let cli_bin = exe_dir.join("amux");
+            let cli_name = if cfg!(windows) { "amux.exe" } else { "amux" };
+            let cli_bin = exe_dir.join(cli_name);
             if cli_bin.exists() {
                 cmd.env("AMUX_BIN", cli_bin.to_string_lossy().as_ref());
             }

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -792,14 +792,13 @@ pub(crate) fn spawn_surface(
     // On Windows the binary is `amux.exe` — Rust's `Path::exists()` does NOT
     // append PATHEXT the way cmd.exe / PowerShell `Get-Command` do, so we
     // must use the platform-correct filename.
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(exe_dir) = exe.parent() {
-            let cli_name = if cfg!(windows) { "amux.exe" } else { "amux" };
-            let cli_bin = exe_dir.join(cli_name);
-            if cli_bin.exists() {
-                cmd.env("AMUX_BIN", cli_bin.to_string_lossy().as_ref());
-            }
-        }
+    //
+    // When building with a `--target` flag (e.g. x86_64 on ARM64 Windows),
+    // Cargo places the app binary under `target/<triple>/debug/` but the CLI
+    // binary may only be in `target/debug/`. Fall back to a PATH search so
+    // cross-compiled dev builds still resolve the CLI.
+    if let Some(cli_bin) = resolve_cli_binary() {
+        cmd.env("AMUX_BIN", cli_bin.to_string_lossy().as_ref());
     }
 
     // Prepend amux bin dir (containing claude wrapper) to PATH so hooks are
@@ -897,6 +896,43 @@ pub(crate) fn spawn_surface(
         user_title: None,
         exited: None,
     })
+}
+
+/// Locate the `amux` CLI binary.
+///
+/// Search order:
+/// 1. Next to `current_exe()` — covers release installs and same-target dev builds.
+/// 2. Sibling profile dirs under the same `target/` root — covers cross-compiled
+///    dev builds where `cargo build --target <triple>` places the app binary in
+///    `target/<triple>/<profile>/` while the CLI is in `target/<profile>/`.
+/// 3. PATH search — last resort.
+fn resolve_cli_binary() -> Option<std::path::PathBuf> {
+    let cli_name = if cfg!(windows) { "amux.exe" } else { "amux" };
+
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(exe_dir) = exe.parent() {
+            // Primary: same directory.
+            let candidate = exe_dir.join(cli_name);
+            if candidate.exists() {
+                return Some(candidate);
+            }
+
+            // Cross-target fallback: exe is at target/<triple>/<profile>/,
+            // CLI may be at target/<profile>/ (two levels up, then into the
+            // same profile dir name — typically "debug" or "release").
+            if let Some(profile_dir) = exe_dir.file_name() {
+                if let Some(target_root) = exe_dir.parent().and_then(|p| p.parent()) {
+                    let candidate = target_root.join(profile_dir).join(cli_name);
+                    if candidate.exists() {
+                        return Some(candidate);
+                    }
+                }
+            }
+        }
+    }
+
+    // Last resort: search PATH.
+    shell::find_on_path(cli_name).map(std::path::PathBuf::from)
 }
 
 #[cfg(test)]

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -913,7 +913,7 @@ fn resolve_cli_binary() -> Option<std::path::PathBuf> {
         if let Some(exe_dir) = exe.parent() {
             // Primary: same directory.
             let candidate = exe_dir.join(cli_name);
-            if candidate.exists() {
+            if candidate.is_file() {
                 return Some(candidate);
             }
 
@@ -923,7 +923,7 @@ fn resolve_cli_binary() -> Option<std::path::PathBuf> {
             if let Some(profile_dir) = exe_dir.file_name() {
                 if let Some(target_root) = exe_dir.parent().and_then(|p| p.parent()) {
                     let candidate = target_root.join(profile_dir).join(cli_name);
-                    if candidate.exists() {
+                    if candidate.is_file() {
                         return Some(candidate);
                     }
                 }

--- a/crates/amux-core/src/shell.rs
+++ b/crates/amux-core/src/shell.rs
@@ -58,7 +58,7 @@ pub fn resolve_shell(config_override: Option<&str>) -> String {
 /// PATH-hijacking risk (e.g. a `.` entry pointing the shell resolver at
 /// whatever binary happens to be in the current working directory).
 /// Returns the first match as an absolute path string, or `None`.
-fn find_on_path(name: &str) -> Option<String> {
+pub fn find_on_path(name: &str) -> Option<String> {
     let path_var = std::env::var_os("PATH")?;
     #[cfg(windows)]
     let extensions: Vec<String> = {


### PR DESCRIPTION
## Summary

- On Windows, `exe_dir.join("amux").exists()` returns false because Rust's `Path::exists()` doesn't append `.exe` like cmd/PowerShell do
- `AMUX_BIN` env var was never set in the child shell's environment
- The PowerShell integration script's fallback (`Get-Command amux`) also fails because the CLI binary isn't on PATH
- With `$script:AmuxBin` null, every `Invoke-AmuxQuiet` call returns early → `set-cwd`, `set-git`, `set-pr` are never sent to amux
- **Result: no git branch, no dirty indicator, no CWD, no PR badge in the sidebar on Windows**

Fix: use `"amux.exe"` on Windows via `cfg!(windows)`.

Fixes #201

## Test plan

- [ ] Build on Windows, open amux, navigate to a git repo
- [ ] Verify sidebar shows git branch and dirty indicator
- [ ] Verify CWD updates in sidebar when changing directories
- [ ] Verify macOS/Linux still work (binary name is `amux` without extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved startup to more reliably locate the CLI binary across platforms, including Windows.
  * Added automatic fallback to search the system PATH when the CLI isn’t found in build directories.
  * Better handling for cross-compiled and development build layouts so the app can find the matching CLI in more scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->