### PR TITLE
Windows: taskbar flash on notifications + get_cwd_from_pid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "rodio",
  "serde",
  "serde_json",
+ "sysinfo",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -3006,6 +3007,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4730,6 +4740,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows 0.54.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 open = "5"
+sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 
 # Error handling
 anyhow = "1"

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -55,4 +55,6 @@ windows-sys = { version = "0.60", features = [
     "Win32_Foundation",
     "Win32_Graphics_Dwm",
     "Win32_System_LibraryLoader",
+    "Win32_UI_WindowsAndMessaging",
 ] }
+sysinfo = { workspace = true }

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -36,7 +36,9 @@ impl eframe::App for AmuxApp {
             use raw_window_handle::{HasWindowHandle, RawWindowHandle};
             if let Ok(handle) = _frame.window_handle() {
                 if let RawWindowHandle::Win32(win32) = handle.as_raw() {
-                    crate::windows_chrome::apply_dark_mode_to_window(win32.hwnd.get());
+                    let hwnd = win32.hwnd.get();
+                    crate::windows_chrome::apply_dark_mode_to_window(hwnd);
+                    self.cached_hwnd = Some(hwnd);
                     self.window_chrome_applied = true;
                 }
             }
@@ -188,6 +190,12 @@ impl eframe::App for AmuxApp {
         if self.app_config.notifications.dock_badge {
             let count = self.notifications.total_unread();
             if count != self.last_badge_count {
+                #[cfg(target_os = "windows")]
+                if count > self.last_badge_count {
+                    if let Some(hwnd) = self.cached_hwnd {
+                        system_notify::flash_taskbar_window(hwnd);
+                    }
+                }
                 self.last_badge_count = count;
                 system_notify::set_badge_count(count);
             }

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -191,7 +191,7 @@ impl eframe::App for AmuxApp {
             let count = self.notifications.total_unread();
             if count != self.last_badge_count {
                 #[cfg(target_os = "windows")]
-                if count > self.last_badge_count {
+                if !self.app_focused && count > self.last_badge_count {
                     if let Some(hwnd) = self.cached_hwnd {
                         system_notify::flash_taskbar_window(hwnd);
                     }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -85,7 +85,29 @@ fn get_cwd_from_pid(pid: u32) -> Option<String> {
         return None;
     }
 
-    // Windows / other: no fallback yet
+    // Windows: read CWD from the process's PEB via sysinfo.
+    #[cfg(target_os = "windows")]
+    {
+        use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+
+        let mut sys = System::new();
+        let sysinfo_pid = Pid::from_u32(pid);
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[sysinfo_pid]),
+            true,
+            ProcessRefreshKind::nothing().with_cwd(UpdateKind::Always),
+        );
+        if let Some(process) = sys.process(sysinfo_pid) {
+            if let Some(cwd) = process.cwd() {
+                let s = cwd.to_string_lossy().to_string();
+                if !s.is_empty() {
+                    return Some(s);
+                }
+            }
+        }
+        return None;
+    }
+
     #[allow(unreachable_code)]
     None
 }
@@ -186,6 +208,10 @@ struct AmuxApp {
     /// once successful so we only do it once.
     #[cfg(target_os = "windows")]
     window_chrome_applied: bool,
+    /// Cached HWND for `FlashWindowEx` taskbar notifications. Populated
+    /// alongside `window_chrome_applied` on the first frame.
+    #[cfg(target_os = "windows")]
+    cached_hwnd: Option<isize>,
     #[cfg(feature = "gpu-renderer")]
     gpu_renderer: Option<GpuRenderer>,
     /// Pending browser pane creation requests (originating_pane_id, URL).

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -466,6 +466,8 @@ pub(crate) fn run() -> anyhow::Result<()> {
                 menu,
                 #[cfg(target_os = "windows")]
                 window_chrome_applied: false,
+                #[cfg(target_os = "windows")]
+                cached_hwnd: None,
                 #[cfg(feature = "gpu-renderer")]
                 gpu_renderer,
                 pending_browser_panes: Vec::new(),

--- a/crates/amux-app/src/system_notify.rs
+++ b/crates/amux-app/src/system_notify.rs
@@ -328,23 +328,40 @@ pub fn set_badge_count(count: usize) {
 }
 
 /// Flash the Windows taskbar button to signal new unread notifications.
-/// Uses `FLASHW_TRAY | FLASHW_TIMERNOFG` so the button flashes briefly
-/// then stays highlighted until the user brings amux to the foreground.
+/// Stops any in-progress flash first so repeated calls always produce a
+/// visible flash, then starts a new `FLASHW_TRAY | FLASHW_TIMERNOFG`
+/// cycle that flashes briefly and stays highlighted until the user
+/// brings amux to the foreground.
 #[cfg(target_os = "windows")]
 pub fn flash_taskbar_window(hwnd_raw: isize) {
     use windows_sys::Win32::Foundation::HWND;
     use windows_sys::Win32::UI::WindowsAndMessaging::{
-        FlashWindowEx, FLASHWINFO, FLASHW_TIMERNOFG, FLASHW_TRAY,
+        FlashWindowEx, FLASHWINFO, FLASHW_STOP, FLASHW_TIMERNOFG, FLASHW_TRAY,
     };
 
-    let info = FLASHWINFO {
-        cbSize: std::mem::size_of::<FLASHWINFO>() as u32,
-        hwnd: hwnd_raw as HWND,
-        dwFlags: FLASHW_TRAY | FLASHW_TIMERNOFG,
-        uCount: 3,
-        dwTimeout: 0, // default cursor blink rate
+    let hwnd = hwnd_raw as HWND;
+    let size = std::mem::size_of::<FLASHWINFO>() as u32;
+
+    // Stop any previous flash so the new one is always visible.
+    let stop = FLASHWINFO {
+        cbSize: size,
+        hwnd,
+        dwFlags: FLASHW_STOP,
+        uCount: 0,
+        dwTimeout: 0,
     };
     unsafe {
-        FlashWindowEx(&info);
+        FlashWindowEx(&stop);
+    }
+
+    let flash = FLASHWINFO {
+        cbSize: size,
+        hwnd,
+        dwFlags: FLASHW_TRAY | FLASHW_TIMERNOFG,
+        uCount: 3,
+        dwTimeout: 0,
+    };
+    unsafe {
+        FlashWindowEx(&flash);
     }
 }

--- a/crates/amux-app/src/system_notify.rs
+++ b/crates/amux-app/src/system_notify.rs
@@ -358,7 +358,7 @@ pub fn flash_taskbar_window(hwnd_raw: isize) {
         cbSize: size,
         hwnd,
         dwFlags: FLASHW_TRAY | FLASHW_TIMERNOFG,
-        uCount: 3,
+        uCount: 0, // ignored by FLASHW_TIMERNOFG — flashes until foreground
         dwTimeout: 0,
     };
     unsafe {

--- a/crates/amux-app/src/system_notify.rs
+++ b/crates/amux-app/src/system_notify.rs
@@ -314,14 +314,37 @@ pub fn set_badge_count(count: usize) {
 
     #[cfg(target_os = "windows")]
     {
-        // Windows taskbar badge is not yet supported — requires HWND access
-        // which eframe doesn't expose directly. FlashWindowEx or
-        // ITaskbarList3::SetOverlayIcon can be added once we have a handle.
+        // Windows uses FlashWindowEx for taskbar attention (called separately
+        // from frame_update.rs when count increases). Nothing to do here for
+        // the count itself — Windows has no dock-badge equivalent without
+        // ITaskbarList3::SetOverlayIcon (deferred).
         let _ = count;
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
         let _ = count;
+    }
+}
+
+/// Flash the Windows taskbar button to signal new unread notifications.
+/// Uses `FLASHW_TRAY | FLASHW_TIMERNOFG` so the button flashes briefly
+/// then stays highlighted until the user brings amux to the foreground.
+#[cfg(target_os = "windows")]
+pub fn flash_taskbar_window(hwnd_raw: isize) {
+    use windows_sys::Win32::Foundation::HWND;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        FlashWindowEx, FLASHWINFO, FLASHW_TIMERNOFG, FLASHW_TRAY,
+    };
+
+    let info = FLASHWINFO {
+        cbSize: std::mem::size_of::<FLASHWINFO>() as u32,
+        hwnd: hwnd_raw as HWND,
+        dwFlags: FLASHW_TRAY | FLASHW_TIMERNOFG,
+        uCount: 3,
+        dwTimeout: 0, // default cursor blink rate
+    };
+    unsafe {
+        FlashWindowEx(&info);
     }
 }


### PR DESCRIPTION
## Summary

- **F6 — Taskbar flash**: `FlashWindowEx` flashes the taskbar button when unread notifications increase while amux is backgrounded. Stays highlighted until the user switches back. Uses the HWND already obtained for dark-mode chrome. `ITaskbarList3::SetOverlayIcon` (persistent badge with count) deferred as a follow-up.
- **F7 — `get_cwd_from_pid` on Windows**: Uses the `sysinfo` crate to read the process CWD from the PEB. Only refreshes the single target PID. Called during session save as a last-resort fallback after `metadata.cwd` and OSC 7 `working_dir()`.

Fixes #179

## Test plan

- [ ] Build on Windows, open amux, switch to another window, trigger a notification (bell or agent hook) — taskbar button should flash and stay highlighted
- [ ] Switch back to amux — highlight should clear
- [ ] Open amux, `cd` to a known directory, close amux, reopen — pane should restore to that directory
- [ ] Verify macOS/Linux still build (`sysinfo` is Windows-only dep, `FlashWindowEx` is `#[cfg(windows)]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows: Taskbar window now flashes when unread message count increases for better visibility.
  * Windows: Improved fallback for detecting a process's current working directory.

* **Chores**
  * Added a shared system-monitoring dependency to the workspace.
  * Windows target: enabled an additional Windows UI feature for improved integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->