### PR TITLE
Fix browser pane white flash on open (#202)

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -422,9 +422,14 @@ impl AmuxApp {
 
         let ua = self.app_config.browser.user_agent.clone();
         let dl_dir = self.app_config.browser.download_dir.clone();
+        // Match the webview's initial background to the current terminal
+        // background so any paint before content loads blends with chrome
+        // on both dark and light themes.
+        let [bg_r, bg_g, bg_b] = self.theme.terminal.background;
         let options = amux_browser::BrowserOptions {
             user_agent: ua.as_deref(),
             download_dir: dl_dir.as_deref(),
+            background_color: Some((bg_r, bg_g, bg_b, 255)),
         };
 
         // New browser panes — added as tabs in their originating pane

--- a/crates/amux-browser/src/pane.rs
+++ b/crates/amux-browser/src/pane.rs
@@ -66,6 +66,9 @@ pub struct BrowserPane {
     #[allow(dead_code)]
     web_context: Option<WebContext>,
     download_dir: PathBuf,
+    /// Created hidden; flipped to `false` on the first `set_bounds` call
+    /// so the webview only becomes visible once positioned correctly.
+    hidden_until_positioned: std::cell::Cell<bool>,
 }
 
 /// Logical rectangle for positioning the webview within its parent window.
@@ -220,7 +223,8 @@ impl BrowserPane {
         let mut builder = WebViewBuilder::new_with_web_context(&mut web_context)
             .with_bounds(bounds.to_wry_rect())
             .with_url(url)
-            .with_visible(true)
+            .with_visible(false)
+            .with_background_color((30, 30, 30, 255))
             .with_clipboard(true)
             .with_hotkeys_zoom(true)
             .with_accept_first_mouse(true)
@@ -440,6 +444,7 @@ impl BrowserPane {
             profile: profile_name,
             web_context: Some(web_context),
             download_dir,
+            hidden_until_positioned: std::cell::Cell::new(true),
         })
     }
 
@@ -458,8 +463,14 @@ impl BrowserPane {
     }
 
     /// Update the webview's position and size within the parent window.
+    /// On the first call the webview is also made visible — it starts hidden
+    /// so the placeholder bounds (0,0 / 800×600) are never shown.
     pub fn set_bounds(&self, bounds: BrowserRect) {
         let _ = self.webview.set_bounds(bounds.to_wry_rect());
+        if self.hidden_until_positioned.get() {
+            self.hidden_until_positioned.set(false);
+            let _ = self.webview.set_visible(true);
+        }
     }
 
     /// Navigate to a URL.
@@ -533,7 +544,12 @@ impl BrowserPane {
     }
 
     /// Show or hide the webview.
+    /// While `hidden_until_positioned` is set, show requests are suppressed
+    /// so the webview stays invisible until `set_bounds` places it correctly.
     pub fn set_visible(&self, visible: bool) {
+        if visible && self.hidden_until_positioned.get() {
+            return;
+        }
         let _ = self.webview.set_visible(visible);
     }
 

--- a/crates/amux-browser/src/pane.rs
+++ b/crates/amux-browser/src/pane.rs
@@ -66,9 +66,14 @@ pub struct BrowserPane {
     #[allow(dead_code)]
     web_context: Option<WebContext>,
     download_dir: PathBuf,
-    /// Created hidden; flipped to `false` on the first `set_bounds` call
-    /// so the webview only becomes visible once positioned correctly.
+    /// Created hidden; flipped to `false` on the first successful `set_bounds`
+    /// call so the webview only becomes visible once positioned correctly.
     hidden_until_positioned: std::cell::Cell<bool>,
+    /// Visibility the app *wants* the webview to have. `set_visible` records
+    /// requests here while `hidden_until_positioned` is set, so the first
+    /// `set_bounds` can apply the right state (e.g. stay hidden if an overlay
+    /// was already open when the pane was created). Defaults to `true`.
+    desired_visible: std::cell::Cell<bool>,
 }
 
 /// Logical rectangle for positioning the webview within its parent window.
@@ -173,7 +178,17 @@ pub fn delete_profile(name: &str) -> std::io::Result<()> {
 pub struct BrowserOptions<'a> {
     pub user_agent: Option<&'a str>,
     pub download_dir: Option<&'a str>,
+    /// Initial webview background color (R, G, B, A). Shown if the webview
+    /// paints before its content loads. Callers should pass the terminal
+    /// background so the webview blends with the surrounding chrome on both
+    /// dark and light themes. Defaults to `DEFAULT_BROWSER_BG` when `None`.
+    pub background_color: Option<(u8, u8, u8, u8)>,
 }
+
+/// Fallback webview background — neutral dark grey. Used only when the caller
+/// doesn't supply a theme-aware color via `BrowserOptions::background_color`.
+/// Will be visibly wrong on light themes, so callers should prefer setting it.
+pub const DEFAULT_BROWSER_BG: (u8, u8, u8, u8) = (30, 30, 30, 255);
 
 impl BrowserPane {
     /// Create a new browser pane as a child view of the given window.
@@ -224,7 +239,11 @@ impl BrowserPane {
             .with_bounds(bounds.to_wry_rect())
             .with_url(url)
             .with_visible(false)
-            .with_background_color((30, 30, 30, 255))
+            .with_background_color(
+                options
+                    .and_then(|o| o.background_color)
+                    .unwrap_or(DEFAULT_BROWSER_BG),
+            )
             .with_clipboard(true)
             .with_hotkeys_zoom(true)
             .with_accept_first_mouse(true)
@@ -445,6 +464,7 @@ impl BrowserPane {
             web_context: Some(web_context),
             download_dir,
             hidden_until_positioned: std::cell::Cell::new(true),
+            desired_visible: std::cell::Cell::new(true),
         })
     }
 
@@ -463,13 +483,19 @@ impl BrowserPane {
     }
 
     /// Update the webview's position and size within the parent window.
-    /// On the first call the webview is also made visible — it starts hidden
-    /// so the placeholder bounds (0,0 / 800×600) are never shown.
+    /// The webview starts hidden so the placeholder bounds (0,0 / 800×600)
+    /// are never shown; on the first *successful* call we clear the deferred
+    /// flag and apply whatever visibility the app has requested so far
+    /// (defaulting to visible). If `set_bounds` itself fails, the webview
+    /// stays hidden so it can't be revealed at stale bounds.
     pub fn set_bounds(&self, bounds: BrowserRect) {
-        let _ = self.webview.set_bounds(bounds.to_wry_rect());
+        if let Err(e) = self.webview.set_bounds(bounds.to_wry_rect()) {
+            tracing::warn!("failed to set webview bounds: {e}");
+            return;
+        }
         if self.hidden_until_positioned.get() {
             self.hidden_until_positioned.set(false);
-            let _ = self.webview.set_visible(true);
+            let _ = self.webview.set_visible(self.desired_visible.get());
         }
     }
 
@@ -544,10 +570,16 @@ impl BrowserPane {
     }
 
     /// Show or hide the webview.
-    /// While `hidden_until_positioned` is set, show requests are suppressed
-    /// so the webview stays invisible until `set_bounds` places it correctly.
+    /// While `hidden_until_positioned` is set, requests are recorded in
+    /// `desired_visible` instead of being applied, so the webview stays
+    /// invisible until `set_bounds` places it correctly — at which point the
+    /// most recently requested visibility is applied. This means a caller
+    /// that asked to hide the webview (e.g. because an overlay is open)
+    /// during the deferred window will still get the intended state once
+    /// positioning lands, without a one-frame flash over the overlay.
     pub fn set_visible(&self, visible: bool) {
-        if visible && self.hidden_until_positioned.get() {
+        if self.hidden_until_positioned.get() {
+            self.desired_visible.set(visible);
             return;
         }
         let _ = self.webview.set_visible(visible);


### PR DESCRIPTION
## Summary
- Browser webview was created with placeholder bounds (0,0 / 800×600) and `with_visible(true)`, so a white rectangle rendered in the wrong spot for one or more frames before `render_browser_pane()` applied real geometry.
- Create the webview hidden with a dark background, and reveal it on the first `set_bounds()` call — at which point the real pane geometry has been computed.
- Suppress `set_visible(true)` from the per-frame visibility manager until the first positioning lands, so the webview can't sneak onscreen with stale bounds.

Fixes #202.

## Test plan
- [ ] Open amux with the default dark theme
- [ ] Create a new browser pane — verify no white rectangle flashes before the webview settles into the pane bounds
- [ ] Split/resize the pane containing the browser — verify the webview still follows geometry changes
- [ ] Toggle the notification panel / rename modal / find bar over a browser pane — verify the webview still hides and restores correctly
- [ ] Switch between a terminal tab and a browser tab in the same pane — verify the browser shows/hides at the correct position with no flash
- [ ] Restore a session with a saved browser tab — verify no flash on restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Browser panes now inherit background colors from your theme configuration
  * Enhanced browser pane rendering by deferring visibility until the pane is fully positioned

<!-- end of auto-generated comment: release notes by coderabbit.ai -->