### PR TITLE
Windows: force omnibar focus on click

### DIFF
--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -55,6 +55,7 @@ windows-sys = { version = "0.60", features = [
     "Win32_Foundation",
     "Win32_Graphics_Dwm",
     "Win32_System_LibraryLoader",
+    "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",
 ] }
 sysinfo = { workspace = true }

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -1086,8 +1086,21 @@ impl AmuxApp {
             .get(&pane_id)
             .and_then(|e| e.as_browser())
             .is_some_and(|b| b.take_got_focus());
+        let clicked = response.clicked();
         if webview_got_focus && response.has_focus() {
             response.surrender_focus();
+        }
+        // On Windows, clicking the omnibar TextEdit fires `clicked()` but
+        // does not grant egui focus — WebView2's child HWND keeps Win32
+        // keyboard focus after the click so egui skips its auto-focus step.
+        // Force egui focus and then SetFocus() the parent HWND so the
+        // keyboard events reach egui's TextEdit.
+        if clicked && !response.has_focus() {
+            response.request_focus();
+            #[cfg(target_os = "windows")]
+            if let Some(hwnd) = self.cached_hwnd {
+                crate::windows_chrome::set_focus(hwnd);
+            }
         }
         state.focused = response.has_focus();
         state.text = text;

--- a/crates/amux-app/src/windows_chrome.rs
+++ b/crates/amux-app/src/windows_chrome.rs
@@ -196,3 +196,18 @@ pub fn apply_dark_mode_to_window(hwnd_raw: isize) {
         }
     }
 }
+
+/// Call Win32 `SetFocus()` on the given window handle.
+///
+/// Used to steal keyboard focus back from a WebView2 child HWND when the
+/// user clicks an egui widget (e.g. the browser omnibar). wry's
+/// `webview.focus_parent()` doesn't reliably do this on Windows because
+/// WebView2's internal focus arbitration lets the child HWND keep Win32
+/// keyboard focus even after wry calls its own release logic.
+pub fn set_focus(hwnd_raw: isize) {
+    use windows_sys::Win32::UI::Input::KeyboardAndMouse::SetFocus;
+    let hwnd: HWND = hwnd_raw as HWND;
+    unsafe {
+        SetFocus(hwnd);
+    }
+}


### PR DESCRIPTION
## Summary

On Windows, clicking the browser pane's omnibar (URL bar) did not accept keyboard input. The user could select text but not type, and no cursor appeared.

## Root cause

egui's TextEdit detected the click (\`response.clicked()\` returned true) but did not auto-grant focus. WebView2 is embedded as a child HWND that keeps Win32 keyboard focus even after a click on an egui widget *outside* its bounds, so egui's focus auto-grant step silently skipped.

## Fix

When \`clicked() && !has_focus()\` is detected on the omnibar TextEdit, explicitly:
1. Call \`response.request_focus()\` to put egui in the right logical state
2. On Windows, call Win32 \`SetFocus()\` on the main window HWND so keyboard messages route to egui instead of WebView2

Also adds a \`set_focus()\` helper in \`windows_chrome.rs\` and enables the \`Win32_UI_Input_KeyboardAndMouse\` windows-sys feature.

Fixes #208

## Test plan

- [x] Open a browser pane on Windows, click the omnibar, type a URL, press Enter — navigates correctly
- [x] Confirmed cursor appears on click
- [ ] Verify macOS/Linux are unaffected (Windows-only SetFocus is \`#[cfg]\` gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved keyboard input issues on Windows for the omnibar. When clicking the text input field, keyboard events are now properly directed to ensure reliable text entry and improved responsiveness on Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->