### PR TITLE
Fix scrollback restore on Windows

### DIFF
--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -641,19 +641,24 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         let start = total.saturating_sub(max_lines);
         let mut selected: Vec<&str> = lines[start..].iter().map(|s| s.as_str()).collect();
 
-        // Drop trailing blank lines AND trailing prompt rows.
-        // Prompt rows are identified via libghostty-vt's per-row semantic_prompt
-        // metadata, populated by OSC 133 marks that our shell integration emits.
-        // This prevents prompt lines from accumulating across save/restore cycles.
+        // Drop trailing blank rows. Then drop at most one trailing prompt
+        // row (the unused prompt that's visible when save fires). We can't
+        // aggressively drop all trailing prompt rows because on Windows the
+        // pwsh integration can't emit OSC 133;B/C (no preexec hook), so
+        // ghostty tags command output rows as Prompt/Continuation too —
+        // an unconditional drop would eat the content we're trying to save.
         let prompt_row_indices = self.prompt_row_indices();
         while let Some(last_idx) = selected.len().checked_sub(1) {
-            let row_idx = start + last_idx;
-            let is_blank = selected[last_idx].trim().is_empty();
-            let is_prompt = prompt_row_indices.contains(&row_idx);
-            if is_blank || is_prompt {
+            if selected[last_idx].trim().is_empty() {
                 selected.pop();
             } else {
                 break;
+            }
+        }
+        if let Some(last_idx) = selected.len().checked_sub(1) {
+            let row_idx = start + last_idx;
+            if prompt_row_indices.contains(&row_idx) {
+                selected.pop();
             }
         }
 

--- a/resources/shell-integration/amux-pwsh-integration.ps1
+++ b/resources/shell-integration/amux-pwsh-integration.ps1
@@ -43,11 +43,20 @@ if ($env:AMUX_RESTORE_SCROLLBACK_FILE) {
     Remove-Item Env:AMUX_RESTORE_SCROLLBACK_FILE -ErrorAction SilentlyContinue
     if (Test-Path -LiteralPath $scrollbackFile) {
         try {
-            # Use Get-Content -Raw + [Console]::Write to emit the saved
-            # scrollback verbatim, with no added encoding or formatting —
-            # analogous to the `/bin/cat` call in the bash/zsh integration.
-            $content = Get-Content -Raw -LiteralPath $scrollbackFile -ErrorAction Stop
-            [Console]::Write($content)
+            # Write the saved scrollback as raw bytes to stdout,
+            # bypassing .NET's text encoding layer entirely.
+            # [Console]::Write(string) encodes through
+            # [Console]::OutputEncoding, which can mangle the ANSI
+            # escape sequences (0x1B bytes) in the saved text
+            # depending on the console's code page. Writing raw
+            # bytes via [Console]::OpenStandardOutput() is the
+            # direct Windows equivalent of `/bin/cat` in the
+            # bash/zsh integration — the bytes flow straight to
+            # ConPTY without any encoding conversion.
+            $bytes = [System.IO.File]::ReadAllBytes($scrollbackFile)
+            $stdout = [Console]::OpenStandardOutput()
+            $stdout.Write($bytes, 0, $bytes.Length)
+            $stdout.Flush()
         } catch {
             # Restore is best-effort; a failure must not block the shell.
         }


### PR DESCRIPTION
## Summary

Two independent bugs prevented Windows scrollback restore from working:

### 1. `[Console]::Write()` mangled ANSI bytes

`[Console]::Write(string)` in the pwsh integration encodes through `[Console]::OutputEncoding`, which can mangle ANSI escape bytes (0x1B) depending on the console's code page. Switch to raw-byte write via `[Console]::OpenStandardOutput()` — the direct Windows equivalent of the `/bin/cat` call in bash/zsh.

### 2. Prompt-row filter dropped all content

`read_scrollback_text` was dropping every trailing row tagged Prompt/Continuation to strip the unused prompt at save time. bash and zsh emit OSC 133;B and 133;C from a preexec hook, so ghostty-vt only tags the actual prompt line as Prompt. pwsh has no native preexec, so the amux integration only emits OSC 133;A and 133;D. Without B/C, libghostty-vt tags *every* row between A and D as Prompt/Continuation — including the command and its output. The trailing-drop loop then ate all content and the session saved an empty scrollback string.

Fix by dropping at most **one** trailing prompt row — enough to strip the unused prompt visible at save time, but not enough to eat command output when the prompt tagging runs on.

Fixes #207

## Test plan

- [x] Generate visible scrollback (echo, ls, git status), close with X, relaunch — all rows restore
- [x] Verify ANSI colors are preserved in restored scrollback
- [ ] Verify macOS/Linux scrollback restore is unaffected (same code path, different preexec behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PowerShell scrollback restore so terminal formatting and ANSI sequences are preserved during replay.
  * Adjusted terminal pane scrollback trimming to avoid inadvertently discarding prompt-adjacent content, preserving more of the final rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->