### PR TITLE
Fix Edit > Copy no-op for egui text fields

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -213,6 +213,14 @@ impl eframe::App for AmuxApp {
         // Drain native menu bar actions
         self.handle_menu_actions();
 
+        // If a menu-bar Copy was requested for a focused text field, inject
+        // Event::Copy into egui's input so TextEdit processes it during the
+        // render pass and sets PlatformOutput::copied_text (which eframe
+        // writes to the system clipboard). Must happen BEFORE the render pass.
+        if std::mem::take(&mut self.pending_text_field_copy) {
+            ctx.input_mut(|i| i.events.push(egui::Event::Copy));
+        }
+
         // Handle keyboard/paste input -> focused pane's active surface only
         // (blocked during copy mode — all keys go through handle_copy_mode_key)
         let mut sent_input = false;

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -235,6 +235,10 @@ struct AmuxApp {
     /// field. Applied during the omnibar render pass so that egui can update
     /// the TextEdit cursor selection state.
     pending_text_field_select_all: bool,
+    /// Whether a menu-bar Copy action is pending for the focused text field.
+    /// Injected as `egui::Event::Copy` before the render pass so egui's
+    /// TextEdit processes it and sets `PlatformOutput::copied_text`.
+    pending_text_field_copy: bool,
 }
 
 /// Editing state for a browser pane's omnibar.

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -478,6 +478,7 @@ pub(crate) fn run() -> anyhow::Result<()> {
                 favicon_pending: std::collections::HashSet::new(),
                 pending_text_field_paste: None,
                 pending_text_field_select_all: false,
+                pending_text_field_copy: false,
             }))
         }),
     )

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -249,14 +249,15 @@ impl AmuxApp {
                     }
                 }
                 menu_bar::MenuAction::Copy => {
-                    if !self.has_focused_text_field() {
+                    if self.has_focused_text_field() {
+                        // The native menu bar consumes Cmd+C before egui sees
+                        // it, so egui's TextEdit never gets the key event and
+                        // never copies. Set a flag so we can inject
+                        // Event::Copy into egui's input before the render pass.
+                        self.pending_text_field_copy = true;
+                    } else {
                         self.copy_selection();
                     }
-                    // When an egui text field is focused, egui handles copy
-                    // internally through its own event processing. The native
-                    // menu bar Cmd+C is consumed before egui sees it, but egui's
-                    // TextEdit widget copies the selected text on its own — no
-                    // action needed here.
                 }
                 menu_bar::MenuAction::Paste => {
                     if self.has_focused_text_field() {


### PR DESCRIPTION
## Summary

- Native menu bar consumes Cmd+C before egui sees it → TextEdit never copies
- Add `pending_text_field_copy` flag (same pattern as Paste/SelectAll)
- Inject `egui::Event::Copy` into `ctx.input` before the render pass
- egui's TextEdit processes the event and sets `PlatformOutput::copied_text`
- eframe writes it to the system clipboard

Fixes #148

## Test plan

- [ ] Open rename modal, type text, select part of it, Edit > Copy → verify clipboard has selected text
- [ ] Same in find bar
- [ ] Same in browser omnibar
- [ ] Verify Edit > Copy still works for terminal selection (non-text-field path)
- [ ] Verify Paste and SelectAll still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)