### PR TITLE
Config file hot-reload

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -201,6 +201,9 @@ impl eframe::App for AmuxApp {
             }
         }
 
+        // Hot-reload config file if it changed on disk.
+        self.check_config_reload();
+
         // Process IPC commands
         self.process_ipc_commands();
 

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -186,6 +186,12 @@ impl eframe::App for AmuxApp {
         // Drain notification events from all surfaces
         self.drain_notifications();
 
+        // Hot-reload config file if it changed on disk. Runs before
+        // the badge update so toggling dock_badge takes effect on
+        // the same frame (otherwise a true→false flip leaves a stale
+        // badge until the next notification event).
+        self.check_config_reload();
+
         // Update dock/taskbar badge with total unread count (only when changed)
         if self.app_config.notifications.dock_badge {
             let count = self.notifications.total_unread();
@@ -200,9 +206,6 @@ impl eframe::App for AmuxApp {
                 system_notify::set_badge_count(count);
             }
         }
-
-        // Hot-reload config file if it changed on disk.
-        self.check_config_reload();
 
         // Process IPC commands
         self.process_ipc_commands();

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -235,6 +235,12 @@ struct AmuxApp {
     /// field. Applied during the omnibar render pass so that egui can update
     /// the TextEdit cursor selection state.
     pending_text_field_select_all: bool,
+    /// Path to the config file that was loaded at startup (for hot-reload polling).
+    config_file_path: Option<std::path::PathBuf>,
+    /// Last known modification time of the config file.
+    config_last_modified: Option<std::time::SystemTime>,
+    /// When we last checked the config file's mtime (throttle to ~2s).
+    config_last_checked: Instant,
 }
 
 /// Editing state for a browser pane's omnibar.

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -286,7 +286,7 @@ pub(crate) fn run() -> anyhow::Result<()> {
     cleanup_stale_codex_home_dirs();
     cleanup_legacy_claude_hooks_in_settings();
 
-    let mut app_config = config::load_app_config();
+    let (mut app_config, config_file_path) = config::load_app_config();
     let mut font_size = app_config.font_size;
 
     // Initialize sound player with configured sound setting
@@ -478,6 +478,11 @@ pub(crate) fn run() -> anyhow::Result<()> {
                 favicon_pending: std::collections::HashSet::new(),
                 pending_text_field_paste: None,
                 pending_text_field_select_all: false,
+                config_last_modified: config_file_path
+                    .as_ref()
+                    .and_then(|p| std::fs::metadata(p).ok()?.modified().ok()),
+                config_file_path,
+                config_last_checked: Instant::now(),
             }))
         }),
     )

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -513,4 +513,95 @@ impl AmuxApp {
             }
         }
     }
+
+    /// Poll the config file for changes and apply hot-reloadable fields.
+    /// Called every frame but only actually checks the file every ~2 seconds.
+    pub(crate) fn check_config_reload(&mut self) {
+        const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+        let Some(ref path) = self.config_file_path else {
+            return;
+        };
+
+        if self.config_last_checked.elapsed() < POLL_INTERVAL {
+            return;
+        }
+        self.config_last_checked = Instant::now();
+
+        let current_mtime = match std::fs::metadata(path).and_then(|m| m.modified()) {
+            Ok(t) => t,
+            Err(_) => return, // File deleted or unreadable — skip
+        };
+
+        if self.config_last_modified == Some(current_mtime) {
+            return; // No change
+        }
+
+        // File changed — reload
+        tracing::info!("Config file changed, reloading: {}", path.display());
+        let contents = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("Failed to read config on reload: {e}");
+                return;
+            }
+        };
+        let new_config = match toml::from_str::<config::AppConfig>(&contents) {
+            Ok(mut c) => {
+                c.font_size = config::validate_font_size(c.font_size);
+                c.font_family = c.font_family.trim().to_owned();
+                if c.font_family.is_empty() {
+                    c.font_family = config::DEFAULT_FONT_FAMILY.to_owned();
+                }
+                c
+            }
+            Err(e) => {
+                tracing::warn!("Failed to parse config on reload: {e}");
+                return;
+            }
+        };
+
+        self.config_last_modified = Some(current_mtime);
+
+        // Apply hot-reloadable fields:
+
+        // Font size
+        if (new_config.font_size - self.app_config.font_size).abs() > f32::EPSILON {
+            self.font_size = new_config.font_size;
+            #[cfg(feature = "gpu-renderer")]
+            if let Some(gpu) = &mut self.gpu_renderer {
+                gpu.set_font_size(self.font_size);
+            }
+            tracing::info!("Hot-reloaded font_size: {}", self.font_size);
+        }
+
+        // Theme / colors — rebuild from scratch
+        let mut new_theme = match new_config.theme_source.as_str() {
+            "ghostty" => {
+                if let Some(ghostty_cfg) = amux_ghostty_config::GhosttyConfig::load() {
+                    crate::theme::Theme::from_ghostty(&ghostty_cfg)
+                } else {
+                    crate::theme::Theme::default()
+                }
+            }
+            _ => crate::theme::Theme::default(),
+        };
+        new_theme.apply_color_config(&new_config.colors);
+        // Update the terminal palette so new/existing panes pick up colors
+        let mut term_config = (*self.config).clone();
+        new_theme.apply_to_palette(&mut term_config.color_palette);
+        self.config = Arc::new(term_config);
+        self.theme = new_theme;
+        tracing::info!("Hot-reloaded theme/colors");
+
+        // Store the full new config but preserve non-hot-reloadable fields
+        // (keybindings, shell, menu_bar_style require a restart).
+        let keybindings_saved = self.app_config.keybindings.clone();
+        let shell_saved = self.app_config.shell.clone();
+        let menu_bar_style_saved = self.app_config.menu_bar_style;
+        self.app_config = new_config;
+        self.app_config.keybindings = keybindings_saved;
+        self.app_config.shell = shell_saved;
+        self.app_config.menu_bar_style = menu_bar_style_saved;
+    }
 }

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -539,6 +539,10 @@ impl AmuxApp {
 
         // File changed — reload
         tracing::info!("Config file changed, reloading: {}", path.display());
+        // Update mtime FIRST — even if read/parse fails, we don't
+        // want to retry the same broken file every 2 seconds.
+        self.config_last_modified = Some(current_mtime);
+
         let contents = match std::fs::read_to_string(path) {
             Ok(c) => c,
             Err(e) => {
@@ -560,8 +564,6 @@ impl AmuxApp {
                 return;
             }
         };
-
-        self.config_last_modified = Some(current_mtime);
 
         // Apply hot-reloadable fields:
 
@@ -590,18 +592,33 @@ impl AmuxApp {
         // Update the terminal palette so new/existing panes pick up colors
         let mut term_config = (*self.config).clone();
         new_theme.apply_to_palette(&mut term_config.color_palette);
+        let new_palette = term_config.color_palette.clone();
         self.config = Arc::new(term_config);
         self.theme = new_theme;
+
+        // Propagate the new palette to every existing terminal pane.
+        // Without this, already-running panes keep their old palette
+        // (set_palette is only called at spawn time in startup.rs).
+        for entry in self.panes.values_mut() {
+            if let PaneEntry::Terminal(managed) = entry {
+                for surface in managed.surfaces_mut() {
+                    surface.pane.set_palette(new_palette.clone());
+                }
+            }
+        }
         tracing::info!("Hot-reloaded theme/colors");
 
         // Store the full new config but preserve non-hot-reloadable fields
-        // (keybindings, shell, menu_bar_style require a restart).
+        // (keybindings, shell, menu_bar_style, font_family require a restart
+        // or a FontSystem rebuild — see issue #216).
         let keybindings_saved = self.app_config.keybindings.clone();
         let shell_saved = self.app_config.shell.clone();
         let menu_bar_style_saved = self.app_config.menu_bar_style;
+        let font_family_saved = self.app_config.font_family.clone();
         self.app_config = new_config;
         self.app_config.keybindings = keybindings_saved;
         self.app_config.shell = shell_saved;
         self.app_config.menu_bar_style = menu_bar_style_saved;
+        self.app_config.font_family = font_family_saved;
     }
 }

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -9,7 +9,7 @@ pub const DEFAULT_FONT_SIZE: f32 = 14.0;
 
 /// Custom color palette configuration.
 /// Colors are specified as hex strings: "#rrggbb" or "rrggbb".
-#[derive(Debug, Default, serde::Deserialize)]
+#[derive(Debug, Clone, Default, serde::Deserialize)]
 #[serde(default)]
 pub struct ColorsConfig {
     pub foreground: Option<String>,
@@ -142,7 +142,7 @@ impl<'de> serde::Deserialize<'de> for KeyCombo {
 
 /// User-customizable keybindings. Each field is an optional override;
 /// if None, the platform default is used.
-#[derive(Debug, Default, serde::Deserialize)]
+#[derive(Debug, Clone, Default, serde::Deserialize)]
 #[serde(default)]
 pub struct KeybindingsConfig {
     pub copy: Option<KeyCombo>,
@@ -420,7 +420,7 @@ impl Default for MenuBarStyle {
     }
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 #[serde(default)]
 pub struct AppConfig {
     pub font_size: f32,
@@ -471,7 +471,7 @@ impl Default for AppConfig {
     }
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 #[serde(default)]
 pub struct BrowserConfig {
     /// Search engine: "google", "duckduckgo", "bing", "kagi", "startpage"
@@ -535,7 +535,7 @@ pub fn is_url_like(input: &str) -> bool {
     trimmed.contains('.')
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 #[serde(default)]
 pub struct NotificationConfig {
     /// Deliver OS-native toast notifications when the app is unfocused.
@@ -562,7 +562,7 @@ impl Default for NotificationConfig {
     }
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 #[serde(default)]
 pub struct NotificationSoundConfig {
     /// "system", "none", or path to a .wav/.ogg/.mp3 file.
@@ -630,7 +630,7 @@ fn write_default_config() -> Option<std::path::PathBuf> {
     }
 }
 
-pub fn load_app_config() -> AppConfig {
+pub fn load_app_config() -> (AppConfig, Option<std::path::PathBuf>) {
     // 1. ~/.amux/config.toml (cross-platform, preferred)
     let amux_home_path = amux_home_dir().map(|d| d.join("config.toml"));
 
@@ -654,7 +654,7 @@ pub fn load_app_config() -> AppConfig {
                     if config.font_family.is_empty() {
                         config.font_family = DEFAULT_FONT_FAMILY.to_owned();
                     }
-                    return config;
+                    return (config, Some(path.clone()));
                 }
                 Err(e) => {
                     tracing::warn!("Failed to parse {}: {}", path.display(), e);
@@ -676,7 +676,7 @@ pub fn load_app_config() -> AppConfig {
             Ok(mut config) => {
                 tracing::info!("Using newly written default config at {}", path.display());
                 config.font_size = validate_font_size(config.font_size);
-                return config;
+                return (config, Some(path));
             }
             Err(e) => {
                 tracing::warn!("Default config failed to parse (bug): {e}");
@@ -684,7 +684,7 @@ pub fn load_app_config() -> AppConfig {
         }
     }
 
-    AppConfig::default()
+    (AppConfig::default(), None)
 }
 
 pub fn validate_font_size(size: f32) -> f32 {

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -723,7 +723,9 @@ mod tests {
         let default = MenuBarStyle::default();
         #[cfg(target_os = "macos")]
         assert_eq!(default, MenuBarStyle::None);
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "windows")]
+        assert_eq!(default, MenuBarStyle::Hamburger);
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         assert_eq!(default, MenuBarStyle::Menubar);
     }
 

--- a/crates/amux-term/src/any_backend.rs
+++ b/crates/amux-term/src/any_backend.rs
@@ -30,6 +30,17 @@ macro_rules! delegate {
     };
 }
 
+impl AnyBackend {
+    /// Update the color palette on the underlying terminal backend.
+    /// Used by config hot-reload to propagate theme changes to
+    /// already-running panes.
+    pub fn set_palette(&mut self, palette: Palette) {
+        match self {
+            AnyBackend::Ghostty(inner) => inner.set_palette(palette),
+        }
+    }
+}
+
 impl TerminalBackend for AnyBackend {
     fn advance(&mut self) -> AdvanceResult {
         delegate!(self, advance)

--- a/crates/amux-term/src/config.rs
+++ b/crates/amux-term/src/config.rs
@@ -1,7 +1,7 @@
 use crate::backend::{Color, Palette};
 
 /// Terminal configuration for amux panes.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AmuxTermConfig {
     pub scrollback_lines: usize,
     pub color_palette: Palette,


### PR DESCRIPTION
## Summary

Poll the config file for changes every 2 seconds. When it changes on disk, reload and apply hot-reloadable fields without restarting.

**Hot-reloadable:** font_size, theme_source + [colors], [notifications], [browser]

**Not hot-reloadable:** keybindings, shell, menu_bar_style, font_family (see follow-up issue)

**No new dependencies** — uses `fs::metadata().modified()` polling in the existing update loop.

Fixes #156

## Changes

| File | What |
|------|------|
| `amux-core/src/config.rs` | `load_app_config()` returns `(AppConfig, Option<PathBuf>)`, added `Clone` derives |
| `amux-term/src/config.rs` | Added `Clone` to `AmuxTermConfig` for palette updates |
| `amux-app/src/main.rs` | New fields: `config_file_path`, `config_last_modified`, `config_last_checked` |
| `amux-app/src/startup.rs` | Initialize reload state from loaded config path |
| `amux-app/src/workspace_ops.rs` | `check_config_reload()` method — polls mtime, reloads, applies |
| `amux-app/src/frame_update.rs` | Call `check_config_reload()` in update loop |

## Test plan

- [ ] Edit `~/.amux/config.toml` font_size, save → amux picks up new size within 2 seconds
- [ ] Change `[colors] background` → terminal background updates live
- [ ] Change `theme_source = "ghostty"` ↔ `"default"` → theme switches live
- [ ] Change `[notifications] dock_badge = false` → badge stops updating
- [ ] Change `menu_bar_style` → no effect until restart (expected)
- [ ] Delete the config file → amux continues running with last-loaded config
- [ ] Introduce a TOML syntax error → amux logs a warning and keeps running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration hot-reload: detect and apply config file changes automatically without restarting the app.

* **Improvements**
  * Font size, theme, color palette, and dock badge notification settings now update in real-time across all terminal panes.
  * Note: Keybindings, shell, menu bar style, and font family still require app restart to take effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->