### PR TITLE
Add MSIX build step to Windows release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,11 +210,80 @@ jobs:
           # Surface the artifact path for the upload step.
           Add-Content -Path $env:GITHUB_ENV -Value "ARCHIVE_PATH=$staging.zip"
 
+      - name: Build MSIX package — Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $staging = "amux-${{ matrix.target }}"
+          $msixDir = "msix-staging"
+
+          # 1. Stage binaries + manifest + assets into a flat directory
+          New-Item -ItemType Directory -Force -Path $msixDir | Out-Null
+          Copy-Item "$staging/amux-app.exe" "$msixDir/"
+          Copy-Item "$staging/amux.exe" "$msixDir/"
+          # ghostty-vt.dll is required at runtime (import library)
+          if (Test-Path "$staging/ghostty-vt.dll") {
+              Copy-Item "$staging/ghostty-vt.dll" "$msixDir/"
+          }
+          # Optional agent wrapper
+          if (Test-Path "$staging/amux-agent-wrapper.exe") {
+              Copy-Item "$staging/amux-agent-wrapper.exe" "$msixDir/"
+          }
+          Copy-Item "packaging/msix/AppxManifest.xml" "$msixDir/"
+          Copy-Item -Recurse "packaging/msix/Assets" "$msixDir/Assets"
+
+          # 2. Update the version in AppxManifest.xml from the git tag.
+          #    MSIX requires a four-part version (Major.Minor.Patch.Revision).
+          $tag = "${{ github.ref_name }}" -replace '^v', ''
+          $parts = $tag -split '\.'
+          while ($parts.Count -lt 4) { $parts += '0' }
+          $msixVersion = ($parts[0..3]) -join '.'
+          $manifest = Get-Content "$msixDir/AppxManifest.xml" -Raw
+          $manifest = $manifest -replace 'Version="[^"]*"', "Version=`"$msixVersion`""
+          Set-Content "$msixDir/AppxManifest.xml" $manifest
+          Write-Host "MSIX version: $msixVersion"
+
+          # 3. Generate resources.pri (required by MakeAppx for icon assets).
+          #    Find MakePri.exe from Windows SDK.
+          $sdkBin = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\10.*\x64" -Directory |
+                    Sort-Object Name -Descending | Select-Object -First 1
+          if (-not $sdkBin) {
+              Write-Error "Windows SDK not found"
+              exit 1
+          }
+          $makePri = Join-Path $sdkBin.FullName "MakePri.exe"
+          $makeAppx = Join-Path $sdkBin.FullName "MakeAppx.exe"
+          Write-Host "Using SDK: $($sdkBin.FullName)"
+
+          # MakePri needs a priconfig.xml — generate one
+          Push-Location $msixDir
+          & $makePri createconfig /cf priconfig.xml /dq en-US /o
+          & $makePri new /pr . /cf priconfig.xml /of resources.pri /o
+          Pop-Location
+
+          # 4. Build the .msix package (unsigned — signing is a separate step)
+          $msixPath = "amux-${{ matrix.target }}.msix"
+          & $makeAppx pack /d $msixDir /p $msixPath /o
+          Write-Host "Built: $msixPath"
+
+          # Surface for upload
+          Add-Content -Path $env:GITHUB_ENV -Value "MSIX_PATH=$msixPath"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: amux-${{ matrix.target }}
           path: ${{ env.ARCHIVE_PATH }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload MSIX artifact
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: amux-${{ matrix.target }}-msix
+          path: ${{ env.MSIX_PATH }}
           if-no-files-found: error
           retention-days: 7
 
@@ -243,7 +312,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets
-          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' \) \
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.msix' \) \
             -exec cp {} release-assets/ \;
           ls -la release-assets
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path $msixDir | Out-Null
           Copy-Item "$staging/amux-app.exe" "$msixDir/"
           Copy-Item "$staging/amux.exe" "$msixDir/"
-          # ghostty-vt.dll is required at runtime (import library)
+          # ghostty-vt.dll is the runtime shared library dependency
           if (Test-Path "$staging/ghostty-vt.dll") {
               Copy-Item "$staging/ghostty-vt.dll" "$msixDir/"
           }
@@ -235,19 +235,33 @@ jobs:
 
           # 2. Update the version in AppxManifest.xml from the git tag.
           #    MSIX requires a four-part version (Major.Minor.Patch.Revision).
-          $tag = "${{ github.ref_name }}" -replace '^v', ''
+          #    On workflow_dispatch (manual runs without a tag), use 0.0.0.0
+          #    so the build still succeeds for testing.
+          $refName = "${{ github.ref_name }}"
+          if ($refName -match '^\d+\.' -or $refName -match '^v\d+\.') {
+              $tag = $refName -replace '^v', ''
+          } else {
+              $tag = '0.0.0'
+              Write-Host "Not a version tag ($refName), using fallback version"
+          }
           $parts = $tag -split '\.'
           while ($parts.Count -lt 4) { $parts += '0' }
           $msixVersion = ($parts[0..3]) -join '.'
+          # Target only the <Identity Version="..."> attribute — the
+          # manifest also contains MinVersion and MaxVersionTested
+          # attributes that must NOT be rewritten.
           $manifest = Get-Content "$msixDir/AppxManifest.xml" -Raw
-          $manifest = $manifest -replace 'Version="[^"]*"', "Version=`"$msixVersion`""
+          $manifest = $manifest -replace '(<Identity[^>]*)\bVersion="[^"]*"', "`$1Version=`"$msixVersion`""
           Set-Content "$msixDir/AppxManifest.xml" $manifest
           Write-Host "MSIX version: $msixVersion"
 
           # 3. Generate resources.pri (required by MakeAppx for icon assets).
           #    Find MakePri.exe from Windows SDK.
+          # Find the newest Windows SDK version by sorting on the parent
+          # version directory name (e.g. "10.0.22621.0"), not the "x64"
+          # leaf which is the same for every SDK installation.
           $sdkBin = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\10.*\x64" -Directory |
-                    Sort-Object Name -Descending | Select-Object -First 1
+                    Sort-Object { [version]$_.Parent.Name } -Descending | Select-Object -First 1
           if (-not $sdkBin) {
               Write-Error "Windows SDK not found"
               exit 1


### PR DESCRIPTION
## Summary

Adds MSIX packaging to the Windows release build. After staging binaries, the workflow now:

1. Copies binaries + `AppxManifest.xml` + `Assets/` into a staging directory
2. Updates the manifest version from the git tag (`v1.2.3` → `1.2.3.0`)
3. Runs `MakePri.exe` to generate `resources.pri` for icon assets
4. Runs `MakeAppx.exe` to produce the `.msix` package
5. Uploads the `.msix` as a separate artifact

The release job now collects `.msix` alongside `.tar.gz` / `.zip` for GitHub Release attachment.

**The `.msix` is unsigned** — code signing (#2 in the MSIX checklist) will be wired up separately when Azure Trusted Signing is configured. Unsigned packages can still be sideloaded with a self-signed cert for testing.

Refs #141

## Test plan

- [ ] Trigger a manual `workflow_dispatch` run on this branch to verify the MSIX build step succeeds
- [ ] Download the `.msix` artifact and verify it can be installed with a self-signed cert
- [ ] Verify the tag-based version substitution produces valid four-part versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows releases now include MSIX package format, offering streamlined installation and improved system integration on Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->