### PR TITLE
Set MSIX publisher to match dev signing cert

### DIFF
--- a/packaging/msix/AppxManifest.xml
+++ b/packaging/msix/AppxManifest.xml
@@ -22,7 +22,7 @@
   <Identity
     Name="DaveOwen.amux"
     Version="0.1.0.0"
-    Publisher="CN=PLACEHOLDER, O=PLACEHOLDER, L=PLACEHOLDER, S=PLACEHOLDER, C=US"
+    Publisher="CN=amux-dev, O=Dev, L=Local, S=Dev, C=US"
     ProcessorArchitecture="x64" />
 
   <Properties>

--- a/packaging/msix/amux.appinstaller
+++ b/packaging/msix/amux.appinstaller
@@ -18,7 +18,7 @@
   <MainPackage
     Name="DaveOwen.amux"
     Version="0.1.0.0"
-    Publisher="CN=PLACEHOLDER, O=PLACEHOLDER, L=PLACEHOLDER, S=PLACEHOLDER, C=US"
+    Publisher="CN=amux-dev, O=Dev, L=Local, S=Dev, C=US"
     ProcessorArchitecture="x64"
     Uri="https://github.com/daveowenatl/amux/releases/latest/download/amux.msix" />
 


### PR DESCRIPTION
SignTool fails with `0x8007000b` (ERROR_BAD_FORMAT) when the manifest publisher doesn't match the cert subject. Updates the PLACEHOLDER to `CN=amux-dev, O=Dev, L=Local, S=Dev, C=US` to match the self-signed dev cert.

Will be updated to production cert subject when Azure Trusted Signing is set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application publisher configuration for Windows MSIX packaging and distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->