### PR TITLE
Set windows_subsystem = windows on amux-app

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -1,3 +1,10 @@
+// On Windows, declare this as a GUI application so it doesn't
+// allocate a console window on launch. Without this, launching
+// from the Start menu / MSIX / Explorer creates a visible console
+// host that flashes briefly (or stays open). Debug/development
+// builds launched from a terminal still inherit the parent console.
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+
 mod find_bar;
 mod fonts;
 mod frame_update;


### PR DESCRIPTION
## Summary

amux-app.exe was a console application (default Rust subsystem). When launched from Start menu / MSIX / Explorer, Windows allocates a console host that flashes and the app fails to stay running under MSIX.

Fix: `#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]` marks the PE as a GUI app. No console allocated on launch; still inherits parent console when run from a terminal.

## Test plan

- [ ] MSIX install → launch from Start menu → amux opens without console flash
- [ ] `cargo run -p amux-app` from terminal → still works, tracing output visible
- [ ] Double-click amux-app.exe from Explorer → opens without console window

🤖 Generated with [Claude Code](https://claude.com/claude-code)