### PR TITLE
Add Azure Trusted Signing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,8 +275,15 @@ jobs:
 
       # Sign EXEs BEFORE creating the zip so the archive contains
       # signed binaries. Sign MSIX separately after MakeAppx.
+      # The Azure identity SDK checks AZURE_* env vars via
+      # DefaultAzureCredential, so we set them in addition to
+      # passing them as action inputs.
       - name: Sign EXEs — Azure Trusted Signing
         if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         uses: azure/trusted-signing-action@v1.2.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -293,6 +300,10 @@ jobs:
 
       - name: Sign MSIX — Azure Trusted Signing
         if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         uses: azure/trusted-signing-action@v1.2.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,15 +201,6 @@ jobs:
           # Surface the artifact path for the upload step.
           echo "ARCHIVE_PATH=${staging}.tar.gz" >> "$GITHUB_ENV"
 
-      - name: Archive (zip) — Windows
-        if: matrix.archive_ext == 'zip'
-        shell: pwsh
-        run: |
-          $staging = "amux-${{ matrix.target }}"
-          Compress-Archive -Path $staging -DestinationPath "$staging.zip" -Force
-          # Surface the artifact path for the upload step.
-          Add-Content -Path $env:GITHUB_ENV -Value "ARCHIVE_PATH=$staging.zip"
-
       - name: Build MSIX package — Windows
         if: runner.os == 'Windows'
         shell: pwsh
@@ -256,10 +247,8 @@ jobs:
           Write-Host "MSIX version: $msixVersion"
 
           # 3. Generate resources.pri (required by MakeAppx for icon assets).
-          #    Find MakePri.exe from Windows SDK.
-          # Find the newest Windows SDK version by sorting on the parent
-          # version directory name (e.g. "10.0.22621.0"), not the "x64"
-          # leaf which is the same for every SDK installation.
+          #    Find the newest Windows SDK by sorting on the parent version
+          #    directory name (e.g. "10.0.22621.0"), not the "x64" leaf.
           $sdkBin = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\10.*\x64" -Directory |
                     Sort-Object { [version]$_.Parent.Name } -Descending | Select-Object -First 1
           if (-not $sdkBin) {
@@ -284,16 +273,32 @@ jobs:
           # Surface for upload
           Add-Content -Path $env:GITHUB_ENV -Value "MSIX_PATH=$msixPath"
 
-      - name: Sign MSIX — Azure Trusted Signing
-        if: runner.os == 'Windows' && env.HAS_SIGNING_SECRETS == 'true'
-        env:
-          HAS_SIGNING_SECRETS: ${{ secrets.AZURE_TENANT_ID != '' }}
+      # Sign EXEs BEFORE creating the zip so the archive contains
+      # signed binaries. Sign MSIX separately after MakeAppx.
+      - name: Sign EXEs — Azure Trusted Signing
+        if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
         uses: azure/trusted-signing-action@v0.5.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: https://eus.codesigning.azure.net
+          endpoint: ${{ vars.SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net' }}
+          trusted-signing-account-name: ${{ secrets.SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.CERT_PROFILE }}
+          files-folder: amux-${{ matrix.target }}
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign MSIX — Azure Trusted Signing
+        if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
+        uses: azure/trusted-signing-action@v0.5.0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ vars.SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net' }}
           trusted-signing-account-name: ${{ secrets.SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ secrets.CERT_PROFILE }}
           files-folder: ${{ github.workspace }}
@@ -302,23 +307,14 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
-      - name: Sign EXEs — Azure Trusted Signing
-        if: runner.os == 'Windows' && env.HAS_SIGNING_SECRETS == 'true'
-        env:
-          HAS_SIGNING_SECRETS: ${{ secrets.AZURE_TENANT_ID != '' }}
-        uses: azure/trusted-signing-action@v0.5.0
-        with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: https://eus.codesigning.azure.net
-          trusted-signing-account-name: ${{ secrets.SIGNING_ACCOUNT }}
-          certificate-profile-name: ${{ secrets.CERT_PROFILE }}
-          files-folder: amux-${{ matrix.target }}
-          files-folder-filter: exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
+      # Create the Windows zip AFTER signing so it contains signed EXEs.
+      - name: Archive (zip) — Windows
+        if: matrix.archive_ext == 'zip'
+        shell: pwsh
+        run: |
+          $staging = "amux-${{ matrix.target }}"
+          Compress-Archive -Path $staging -DestinationPath "$staging.zip" -Force
+          Add-Content -Path $env:GITHUB_ENV -Value "ARCHIVE_PATH=$staging.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,7 @@ jobs:
       # signed binaries. Sign MSIX separately after MakeAppx.
       - name: Sign EXEs — Azure Trusted Signing
         if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
-        uses: azure/trusted-signing-action@v0.5.0
+        uses: azure/trusted-signing-action@v1.2.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -293,7 +293,7 @@ jobs:
 
       - name: Sign MSIX — Azure Trusted Signing
         if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
-        uses: azure/trusted-signing-action@v0.5.0
+        uses: azure/trusted-signing-action@v1.2.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,29 +276,27 @@ jobs:
       # Debug: verify Azure credentials work from this runner.
       - name: Verify Azure credentials
         if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
+        continue-on-error: true
         shell: pwsh
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          SIGNING_ACCOUNT: ${{ secrets.SIGNING_ACCOUNT }}
+          CERT_PROFILE: ${{ secrets.CERT_PROFILE }}
         run: |
           Write-Host "TENANT_ID length: $($env:AZURE_TENANT_ID.Length)"
           Write-Host "CLIENT_ID length: $($env:AZURE_CLIENT_ID.Length)"
           Write-Host "SECRET length: $($env:AZURE_CLIENT_SECRET.Length)"
-          Write-Host "TENANT_ID starts: $($env:AZURE_TENANT_ID.Substring(0,8))..."
-          Write-Host "CLIENT_ID starts: $($env:AZURE_CLIENT_ID.Substring(0,8))..."
-          Write-Host "SIGNING_ACCOUNT: ${{ secrets.SIGNING_ACCOUNT }}"
-          Write-Host "CERT_PROFILE: ${{ secrets.CERT_PROFILE }}"
-          # Test actual auth
-          az login --service-principal `
-            --username $env:AZURE_CLIENT_ID `
-            --password $env:AZURE_CLIENT_SECRET `
-            --tenant $env:AZURE_TENANT_ID
-          az account show
-          # Test signing API access
-          az rest --method GET `
-            --url "https://eus.codesigning.azure.net/codesigningaccounts/${{ secrets.SIGNING_ACCOUNT }}/certificateprofiles/${{ secrets.CERT_PROFILE }}?api-version=2024-09-30-preview" `
-            --resource "https://codesigning.azure.net" 2>&1 || Write-Host "REST call returned non-zero (may be expected for API version mismatch)"
+          Write-Host "SIGNING_ACCOUNT length: $($env:SIGNING_ACCOUNT.Length) value: [$($env:SIGNING_ACCOUNT)]"
+          Write-Host "CERT_PROFILE length: $($env:CERT_PROFILE.Length) value: [$($env:CERT_PROFILE)]"
+          Write-Host "Auth test..."
+          az login --service-principal --username $env:AZURE_CLIENT_ID --password $env:AZURE_CLIENT_SECRET --tenant $env:AZURE_TENANT_ID | Out-Null
+          Write-Host "Auth: OK"
+          # List role assignments for this SP
+          $spOid = az ad sp show --id $env:AZURE_CLIENT_ID --query id -o tsv
+          Write-Host "SP Object ID: $spOid"
+          az role assignment list --assignee $spOid --all --query "[].{role:roleDefinitionName, scope:scope}" -o table
 
       # Sign EXEs BEFORE creating the zip so the archive contains
       # signed binaries. Sign MSIX separately after MakeAppx.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,6 +322,8 @@ jobs:
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
+          trace: true
+          exclude-azure-cli-credential: true
 
       - name: Sign MSIX — Azure Trusted Signing
         if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,11 +298,17 @@ jobs:
           Write-Host "SP Object ID: $spOid"
           az role assignment list --assignee $spOid --all --query "[].{role:roleDefinitionName, scope:scope}" -o table
 
+      # Establish an Azure CLI session so the Trusted Signing dlib
+      # can pick up the credential via AzureCliCredential in the
+      # DefaultAzureCredential chain.
+      - name: Azure Login
+        if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
+        uses: azure/login@v2
+        with:
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}","subscriptionId":"1b6edf01-7bb1-4fb7-8447-3fcc2eead97d"}'
+
       # Sign EXEs BEFORE creating the zip so the archive contains
       # signed binaries. Sign MSIX separately after MakeAppx.
-      # The Azure identity SDK checks AZURE_* env vars via
-      # DefaultAzureCredential, so we set them in addition to
-      # passing them as action inputs.
       - name: Sign EXEs — Azure Trusted Signing
         if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
         env:
@@ -323,7 +329,6 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
           trace: true
-          exclude-azure-cli-credential: true
 
       - name: Sign MSIX — Azure Trusted Signing
         if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,9 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "MSIX_PATH=$msixPath"
 
       - name: Sign MSIX — Azure Trusted Signing
-        if: runner.os == 'Windows' && secrets.AZURE_TENANT_ID != ''
+        if: runner.os == 'Windows' && env.HAS_SIGNING_SECRETS == 'true'
+        env:
+          HAS_SIGNING_SECRETS: ${{ secrets.AZURE_TENANT_ID != '' }}
         uses: azure/trusted-signing-action@v0.5.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -301,7 +303,9 @@ jobs:
           timestamp-digest: SHA256
 
       - name: Sign EXEs — Azure Trusted Signing
-        if: runner.os == 'Windows' && secrets.AZURE_TENANT_ID != ''
+        if: runner.os == 'Windows' && env.HAS_SIGNING_SECRETS == 'true'
+        env:
+          HAS_SIGNING_SECRETS: ${{ secrets.AZURE_TENANT_ID != '' }}
         uses: azure/trusted-signing-action@v0.5.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,6 +273,33 @@ jobs:
           # Surface for upload
           Add-Content -Path $env:GITHUB_ENV -Value "MSIX_PATH=$msixPath"
 
+      # Debug: verify Azure credentials work from this runner.
+      - name: Verify Azure credentials
+        if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
+        shell: pwsh
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        run: |
+          Write-Host "TENANT_ID length: $($env:AZURE_TENANT_ID.Length)"
+          Write-Host "CLIENT_ID length: $($env:AZURE_CLIENT_ID.Length)"
+          Write-Host "SECRET length: $($env:AZURE_CLIENT_SECRET.Length)"
+          Write-Host "TENANT_ID starts: $($env:AZURE_TENANT_ID.Substring(0,8))..."
+          Write-Host "CLIENT_ID starts: $($env:AZURE_CLIENT_ID.Substring(0,8))..."
+          Write-Host "SIGNING_ACCOUNT: ${{ secrets.SIGNING_ACCOUNT }}"
+          Write-Host "CERT_PROFILE: ${{ secrets.CERT_PROFILE }}"
+          # Test actual auth
+          az login --service-principal `
+            --username $env:AZURE_CLIENT_ID `
+            --password $env:AZURE_CLIENT_SECRET `
+            --tenant $env:AZURE_TENANT_ID
+          az account show
+          # Test signing API access
+          az rest --method GET `
+            --url "https://eus.codesigning.azure.net/codesigningaccounts/${{ secrets.SIGNING_ACCOUNT }}/certificateprofiles/${{ secrets.CERT_PROFILE }}?api-version=2024-09-30-preview" `
+            --resource "https://codesigning.azure.net" 2>&1 || Write-Host "REST call returned non-zero (may be expected for API version mismatch)"
+
       # Sign EXEs BEFORE creating the zip so the archive contains
       # signed binaries. Sign MSIX separately after MakeAppx.
       # The Azure identity SDK checks AZURE_* env vars via

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,61 +285,36 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "MSIX_PATH=$msixPath"
 
       - name: Sign MSIX — Azure Trusted Signing
-        if: runner.os == 'Windows' && env.AZURE_TENANT_ID != ''
-        shell: pwsh
-        env:
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-
-          # Install the Trusted Signing tools
-          dotnet tool install --global AzureSignTool --version 6.*
-
-          # Sign the MSIX package
-          AzureSignTool sign `
-            --azure-key-vault-url "https://${{ secrets.SIGNING_ACCOUNT }}.codesigning.azure.net" `
-            --azure-key-vault-tenant-id "$env:AZURE_TENANT_ID" `
-            --azure-key-vault-client-id "$env:AZURE_CLIENT_ID" `
-            --azure-key-vault-client-secret "$env:AZURE_CLIENT_SECRET" `
-            --azure-key-vault-certificate "${{ secrets.CERT_PROFILE }}" `
-            --timestamp-rfc3161 "http://timestamp.acs.microsoft.com" `
-            --timestamp-digest sha256 `
-            --file-digest sha256 `
-            --verbose `
-            "${{ env.MSIX_PATH }}"
-
-          Write-Host "MSIX signed successfully" -ForegroundColor Green
+        if: runner.os == 'Windows' && secrets.AZURE_TENANT_ID != ''
+        uses: azure/trusted-signing-action@v0.5.0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://eus.codesigning.azure.net
+          trusted-signing-account-name: ${{ secrets.SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.CERT_PROFILE }}
+          files-folder: ${{ github.workspace }}
+          files-folder-filter: msix
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
 
       - name: Sign EXEs — Azure Trusted Signing
-        if: runner.os == 'Windows' && env.AZURE_TENANT_ID != ''
-        shell: pwsh
-        env:
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $staging = "amux-${{ matrix.target }}"
-
-          # Sign the standalone EXEs in the zip archive staging dir
-          # so the non-MSIX download is also signed.
-          $exes = Get-ChildItem "$staging\*.exe"
-          foreach ($exe in $exes) {
-              AzureSignTool sign `
-                --azure-key-vault-url "https://${{ secrets.SIGNING_ACCOUNT }}.codesigning.azure.net" `
-                --azure-key-vault-tenant-id "$env:AZURE_TENANT_ID" `
-                --azure-key-vault-client-id "$env:AZURE_CLIENT_ID" `
-                --azure-key-vault-client-secret "$env:AZURE_CLIENT_SECRET" `
-                --azure-key-vault-certificate "${{ secrets.CERT_PROFILE }}" `
-                --timestamp-rfc3161 "http://timestamp.acs.microsoft.com" `
-                --timestamp-digest sha256 `
-                --file-digest sha256 `
-                "$($exe.FullName)"
-              Write-Host "Signed: $($exe.Name)"
-          }
-          Write-Host "All EXEs signed" -ForegroundColor Green
+        if: runner.os == 'Windows' && secrets.AZURE_TENANT_ID != ''
+        uses: azure/trusted-signing-action@v0.5.0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://eus.codesigning.azure.net
+          trusted-signing-account-name: ${{ secrets.SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.CERT_PROFILE }}
+          files-folder: amux-${{ matrix.target }}
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,13 +276,70 @@ jobs:
           & $makePri new /pr . /cf priconfig.xml /of resources.pri /o
           Pop-Location
 
-          # 4. Build the .msix package (unsigned — signing is a separate step)
+          # 4. Build the .msix package
           $msixPath = "amux-${{ matrix.target }}.msix"
           & $makeAppx pack /d $msixDir /p $msixPath /o
           Write-Host "Built: $msixPath"
 
           # Surface for upload
           Add-Content -Path $env:GITHUB_ENV -Value "MSIX_PATH=$msixPath"
+
+      - name: Sign MSIX — Azure Trusted Signing
+        if: runner.os == 'Windows' && env.AZURE_TENANT_ID != ''
+        shell: pwsh
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # Install the Trusted Signing tools
+          dotnet tool install --global AzureSignTool --version 6.*
+
+          # Sign the MSIX package
+          AzureSignTool sign `
+            --azure-key-vault-url "https://${{ secrets.SIGNING_ACCOUNT }}.codesigning.azure.net" `
+            --azure-key-vault-tenant-id "$env:AZURE_TENANT_ID" `
+            --azure-key-vault-client-id "$env:AZURE_CLIENT_ID" `
+            --azure-key-vault-client-secret "$env:AZURE_CLIENT_SECRET" `
+            --azure-key-vault-certificate "${{ secrets.CERT_PROFILE }}" `
+            --timestamp-rfc3161 "http://timestamp.acs.microsoft.com" `
+            --timestamp-digest sha256 `
+            --file-digest sha256 `
+            --verbose `
+            "${{ env.MSIX_PATH }}"
+
+          Write-Host "MSIX signed successfully" -ForegroundColor Green
+
+      - name: Sign EXEs — Azure Trusted Signing
+        if: runner.os == 'Windows' && env.AZURE_TENANT_ID != ''
+        shell: pwsh
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $staging = "amux-${{ matrix.target }}"
+
+          # Sign the standalone EXEs in the zip archive staging dir
+          # so the non-MSIX download is also signed.
+          $exes = Get-ChildItem "$staging\*.exe"
+          foreach ($exe in $exes) {
+              AzureSignTool sign `
+                --azure-key-vault-url "https://${{ secrets.SIGNING_ACCOUNT }}.codesigning.azure.net" `
+                --azure-key-vault-tenant-id "$env:AZURE_TENANT_ID" `
+                --azure-key-vault-client-id "$env:AZURE_CLIENT_ID" `
+                --azure-key-vault-client-secret "$env:AZURE_CLIENT_SECRET" `
+                --azure-key-vault-certificate "${{ secrets.CERT_PROFILE }}" `
+                --timestamp-rfc3161 "http://timestamp.acs.microsoft.com" `
+                --timestamp-digest sha256 `
+                --file-digest sha256 `
+                "$($exe.FullName)"
+              Write-Host "Signed: $($exe.Name)"
+          }
+          Write-Host "All EXEs signed" -ForegroundColor Green
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,48 +273,10 @@ jobs:
           # Surface for upload
           Add-Content -Path $env:GITHUB_ENV -Value "MSIX_PATH=$msixPath"
 
-      # Debug: verify Azure credentials work from this runner.
-      - name: Verify Azure credentials
-        if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
-        continue-on-error: true
-        shell: pwsh
-        env:
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          SIGNING_ACCOUNT: ${{ secrets.SIGNING_ACCOUNT }}
-          CERT_PROFILE: ${{ secrets.CERT_PROFILE }}
-        run: |
-          Write-Host "TENANT_ID length: $($env:AZURE_TENANT_ID.Length)"
-          Write-Host "CLIENT_ID length: $($env:AZURE_CLIENT_ID.Length)"
-          Write-Host "SECRET length: $($env:AZURE_CLIENT_SECRET.Length)"
-          Write-Host "SIGNING_ACCOUNT length: $($env:SIGNING_ACCOUNT.Length) value: [$($env:SIGNING_ACCOUNT)]"
-          Write-Host "CERT_PROFILE length: $($env:CERT_PROFILE.Length) value: [$($env:CERT_PROFILE)]"
-          Write-Host "Auth test..."
-          az login --service-principal --username $env:AZURE_CLIENT_ID --password $env:AZURE_CLIENT_SECRET --tenant $env:AZURE_TENANT_ID | Out-Null
-          Write-Host "Auth: OK"
-          # List role assignments for this SP
-          $spOid = az ad sp show --id $env:AZURE_CLIENT_ID --query id -o tsv
-          Write-Host "SP Object ID: $spOid"
-          az role assignment list --assignee $spOid --all --query "[].{role:roleDefinitionName, scope:scope}" -o table
-
-      # Establish an Azure CLI session so the Trusted Signing dlib
-      # can pick up the credential via AzureCliCredential in the
-      # DefaultAzureCredential chain.
-      - name: Azure Login
-        if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
-        uses: azure/login@v2
-        with:
-          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}","subscriptionId":"1b6edf01-7bb1-4fb7-8447-3fcc2eead97d"}'
-
       # Sign EXEs BEFORE creating the zip so the archive contains
       # signed binaries. Sign MSIX separately after MakeAppx.
       - name: Sign EXEs — Azure Trusted Signing
         if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
-        env:
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         uses: azure/trusted-signing-action@v1.2.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -328,14 +290,9 @@ jobs:
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
-          trace: true
 
       - name: Sign MSIX — Azure Trusted Signing
         if: runner.os == 'Windows' && vars.SIGNING_ENABLED == 'true'
-        env:
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         uses: azure/trusted-signing-action@v1.2.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.gstack/

--- a/packaging/msix/AppxManifest.xml
+++ b/packaging/msix/AppxManifest.xml
@@ -22,7 +22,7 @@
   <Identity
     Name="DaveOwen.amux"
     Version="0.1.0.0"
-    Publisher="CN=amux-dev, O=Dev, L=Local, S=Dev, C=US"
+    Publisher="CN=David Owen, O=David Owen, L=Atlanta, S=Georgia, C=US"
     ProcessorArchitecture="x64" />
 
   <Properties>

--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -21,15 +21,15 @@ packaging/msix/
 ## CI Integration
 
 The release workflow (`.github/workflows/release.yml`) automatically builds
-an unsigned `.msix` package on every Windows release build:
+the `.msix` package on every Windows release build:
 
 1. Stages binaries + `AppxManifest.xml` + `Assets/` into a staging directory
 2. Updates the manifest version from the git tag (`v1.2.3` → `1.2.3.0`)
 3. Generates `resources.pri` via `MakePri.exe` (Windows SDK)
 4. Builds the `.msix` via `MakeAppx.exe`
-5. Uploads the `.msix` as a release artifact
-
-**The package is currently unsigned.** See "Code Signing" below.
+5. Signs the `.msix` + standalone `.exe` files via Azure Trusted Signing
+   (skipped if secrets aren't configured — produces an unsigned package)
+6. Uploads the `.msix` as a release artifact
 
 ## Prerequisites (Manual Builds)
 
@@ -132,9 +132,59 @@ Add-AppxPackage -AppInstallerFile amux.appinstaller
 Get-AppxPackage *amux* | Remove-AppxPackage
 ```
 
+## Azure Trusted Signing Setup
+
+The release workflow signs automatically when these GitHub Actions secrets
+are configured. Without them, signing is skipped and the `.msix` is unsigned.
+
+### 1. Create Azure resources
+
+1. Create an Azure account at https://portal.azure.com
+2. Create a **Trusted Signing** resource (search "Trusted Signing" in the portal)
+3. Complete identity verification (personal or organization)
+4. Create a **certificate profile** in the Trusted Signing resource
+
+### 2. Create a service principal
+
+```bash
+# Create an app registration for GitHub Actions
+az ad app create --display-name "amux-signing"
+
+# Note the appId (CLIENT_ID) and tenant (TENANT_ID) from output
+# Create a secret:
+az ad app credential reset --id <appId>
+# Note the password (CLIENT_SECRET)
+```
+
+Grant the service principal the "Trusted Signing Certificate Profile Signer"
+role on your Trusted Signing account in the Azure portal.
+
+### 3. Add GitHub secrets
+
+Go to **Settings → Secrets and variables → Actions** in the amux repo:
+
+| Secret | Value |
+|--------|-------|
+| `AZURE_TENANT_ID` | Your Azure AD tenant ID |
+| `AZURE_CLIENT_ID` | Service principal app ID |
+| `AZURE_CLIENT_SECRET` | Service principal password |
+| `SIGNING_ACCOUNT` | Trusted Signing account name (just the name, not the full URL) |
+| `CERT_PROFILE` | Certificate profile name |
+
+### 4. Update the manifest publisher
+
+Update the `Publisher` field in `AppxManifest.xml` and `amux.appinstaller`
+to match the subject of the Trusted Signing certificate exactly. Azure
+Trusted Signing certificates typically use a subject like
+`CN=<your org name>, O=<your org name>`.
+
+### 5. Verify
+
+Push a tag (`git tag v0.1.0 && git push --tags`) or trigger a manual
+workflow dispatch. The signing steps will run after MakeAppx and sign
+both the `.msix` and the standalone `.exe` files.
+
 ## Remaining Work
 
-- [ ] Set up Azure Trusted Signing and wire secrets into CI
-- [ ] Add signing step to the release workflow after MakeAppx
 - [ ] Test sideloading and auto-update flow end-to-end
 - [ ] Optional: submit to Microsoft Store ($19 one-time fee)

--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -147,29 +147,41 @@ are configured. Without them, signing is skipped and the `.msix` is unsigned.
 ### 2. Create a service principal
 
 ```bash
-# Create an app registration for GitHub Actions
-az ad app create --display-name "amux-signing"
+# Create an app registration + service principal in one step.
+# Save the appId (CLIENT_ID) and password (CLIENT_SECRET) from the output.
+az ad sp create-for-rbac --name "amux-github-signing"
 
-# Note the appId (CLIENT_ID) and tenant (TENANT_ID) from output
-# Create a secret:
-az ad app credential reset --id <appId>
-# Note the password (CLIENT_SECRET)
+# Get the service principal's object ID for role assignment:
+az ad sp show --id <appId> --query id -o tsv
+
+# Grant it permission to sign with your certificate:
+az role assignment create \
+  --assignee-object-id <objectId> \
+  --assignee-principal-type ServicePrincipal \
+  --role "Artifact Signing Certificate Profile Signer" \
+  --scope "/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.CodeSigning/codeSigningAccounts/<ACCOUNT>"
 ```
 
-Grant the service principal the "Trusted Signing Certificate Profile Signer"
-role on your Trusted Signing account in the Azure portal.
+### 3. Add GitHub secrets and variables
 
-### 3. Add GitHub secrets
+Go to **Settings → Secrets and variables → Actions** in the amux repo.
 
-Go to **Settings → Secrets and variables → Actions** in the amux repo:
+**Secrets:**
 
 | Secret | Value |
 |--------|-------|
-| `AZURE_TENANT_ID` | Your Azure AD tenant ID |
+| `AZURE_TENANT_ID` | Your Azure AD tenant ID (`az account show --query tenantId`) |
 | `AZURE_CLIENT_ID` | Service principal app ID |
 | `AZURE_CLIENT_SECRET` | Service principal password |
 | `SIGNING_ACCOUNT` | Trusted Signing account name (just the name, not the full URL) |
 | `CERT_PROFILE` | Certificate profile name |
+
+**Variables** (Settings → Secrets and variables → Actions → Variables tab):
+
+| Variable | Value |
+|----------|-------|
+| `SIGNING_ENABLED` | `true` (enables the signing steps) |
+| `SIGNING_ENDPOINT` | *(optional)* Override the Trusted Signing endpoint if your account is not in East US. Default: `https://eus.codesigning.azure.net` |
 
 ### 4. Update the manifest publisher
 

--- a/packaging/msix/amux.appinstaller
+++ b/packaging/msix/amux.appinstaller
@@ -18,7 +18,7 @@
   <MainPackage
     Name="DaveOwen.amux"
     Version="0.1.0.0"
-    Publisher="CN=amux-dev, O=Dev, L=Local, S=Dev, C=US"
+    Publisher="CN=David Owen, O=David Owen, L=Atlanta, S=Georgia, C=US"
     ProcessorArchitecture="x64"
     Uri="https://github.com/daveowenatl/amux/releases/latest/download/amux.msix" />
 


### PR DESCRIPTION
## Summary

Adds code signing via Azure Trusted Signing to the Windows release build:

- **MSIX package** signed after `MakeAppx`
- **Standalone EXEs** (`amux-app.exe`, `amux.exe`, `amux-agent-wrapper.exe`) in the zip archive also signed
- Uses `AzureSignTool` (dotnet tool) with RFC 3161 timestamping
- Conditional on `AZURE_TENANT_ID` secret — skipped when secrets aren't configured

README updated with full setup guide: Azure account, service principal, GitHub secrets, manifest publisher update.

Refs #141

## To activate

1. Create Azure Trusted Signing account + certificate profile
2. Create service principal with signing role
3. Add 5 GitHub secrets: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `SIGNING_ACCOUNT`, `CERT_PROFILE`
4. Update `Publisher` in `AppxManifest.xml` to match the cert subject
5. Push a tag or trigger workflow dispatch

## Test plan

- [ ] Without secrets: signing steps skip cleanly, unsigned MSIX produced (existing behavior)
- [ ] With secrets: MSIX and EXEs are signed, `signtool verify` passes
- [ ] Signed MSIX installs without sideloading or self-signed cert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now signs MSIX packages and standalone EXE installers when signing is enabled; Windows archives are recreated after signing so archives include signed EXEs.
  * MSIX/appinstaller publisher identity updated to a named publisher.

* **Documentation**
  * Release docs expanded with Azure Trusted Signing setup, required secrets/variables, publisher alignment guidance, and verification/upload instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->