### PR TITLE
MSIX dev versioning: in-place upgrades via run_number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,14 +229,16 @@ jobs:
 
           # 2. Update the version in AppxManifest.xml from the git tag.
           #    MSIX requires a four-part version (Major.Minor.Patch.Revision).
-          #    On workflow_dispatch (manual runs without a tag), use 0.0.0.0
-          #    so the build still succeeds for testing.
+          #    Tagged releases: v1.2.3 → 1.2.3.0
+          #    Dev builds (workflow_dispatch): 0.0.0.<run_number> — always
+          #    incrementing so each build upgrades in-place over the previous
+          #    one, and below any real semver release.
           $refName = "${{ github.ref_name }}"
           if ($refName -match '^\d+\.' -or $refName -match '^v\d+\.') {
               $tag = $refName -replace '^v', ''
           } else {
-              $tag = '0.0.0'
-              Write-Host "Not a version tag ($refName), using fallback version"
+              $tag = "0.0.0.${{ github.run_number }}"
+              Write-Host "Not a version tag ($refName), using dev version: $tag"
           }
           $parts = $tag -split '\.'
           while ($parts.Count -lt 4) { $parts += '0' }

--- a/packaging/msix/install-dev.ps1
+++ b/packaging/msix/install-dev.ps1
@@ -97,7 +97,7 @@ if ($LASTEXITCODE -ne 0) {
 Write-Host "  Signed successfully" -ForegroundColor Green
 
 # --- Install or upgrade ---
-$existing = Get-AppxPackage *amux* -ErrorAction SilentlyContinue
+$existing = Get-AppxPackage DaveOwen.amux -ErrorAction SilentlyContinue
 if ($existing) {
     Write-Host "Upgrading amux $($existing.Version) → new build..." -ForegroundColor Yellow
     Add-AppxPackage -Path $MsixPath -Update
@@ -108,7 +108,7 @@ if ($existing) {
 Write-Host "  Done!" -ForegroundColor Green
 
 # --- Verify ---
-$pkg = Get-AppxPackage *amux*
+$pkg = Get-AppxPackage DaveOwen.amux
 if ($pkg) {
     Write-Host "`namux installed:" -ForegroundColor Cyan
     Write-Host "  Version:  $($pkg.Version)"

--- a/packaging/msix/install-dev.ps1
+++ b/packaging/msix/install-dev.ps1
@@ -96,18 +96,16 @@ if ($LASTEXITCODE -ne 0) {
 }
 Write-Host "  Signed successfully" -ForegroundColor Green
 
-# --- Uninstall existing ---
+# --- Install or upgrade ---
 $existing = Get-AppxPackage *amux* -ErrorAction SilentlyContinue
 if ($existing) {
-    Write-Host "Removing existing amux package..." -ForegroundColor Yellow
-    $existing | Remove-AppxPackage
-    Write-Host "  Removed" -ForegroundColor Green
+    Write-Host "Upgrading amux $($existing.Version) → new build..." -ForegroundColor Yellow
+    Add-AppxPackage -Path $MsixPath -Update
+} else {
+    Write-Host "Installing..." -ForegroundColor Yellow
+    Add-AppxPackage -Path $MsixPath
 }
-
-# --- Install ---
-Write-Host "Installing..." -ForegroundColor Yellow
-Add-AppxPackage -Path $MsixPath
-Write-Host "  Installed!" -ForegroundColor Green
+Write-Host "  Done!" -ForegroundColor Green
 
 # --- Verify ---
 $pkg = Get-AppxPackage *amux*


### PR DESCRIPTION
## Summary

- Dev builds use `0.0.0.<run_number>` instead of `0.0.0.0` — each build has a unique, incrementing version
- Windows allows in-place upgrade without manual uninstall
- Tagged releases use the tag as before (`v1.2.3` → `1.2.3.0`)
- `install-dev.ps1` uses `Add-AppxPackage -Update` when upgrading, shows old → new version

Refs #231

## Test plan

- [ ] Trigger two workflow_dispatch builds — second should have a higher version
- [ ] Install first MSIX, then install second — should upgrade in-place
- [ ] Tag a release — should use the tag version, not run_number

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Build & Packaging**
  * Windows MSIX development builds now include unique build numbers in version identifiers for improved tracking and distinction between builds.
  * Installation process streamlined: existing MSIX installations now upgrade in-place rather than requiring uninstall-reinstall cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->