### PR TITLE
Make user-set workspace titles sticky over agent status

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -633,6 +633,7 @@ impl AmuxApp {
             saved_workspaces.push(amux_session::SavedWorkspace {
                 id: ws.id,
                 title: ws.title.clone(),
+                user_title: ws.user_title.clone(),
                 tree: ws.tree.clone(),
                 focused_pane: ws.focused_pane,
                 zoomed: ws.zoomed,

--- a/crates/amux-app/src/rename_modal.rs
+++ b/crates/amux-app/src/rename_modal.rs
@@ -113,7 +113,8 @@ impl AmuxApp {
                 match self.rename_modal.as_ref().unwrap().target {
                     RenameTarget::Workspace(ws_id) => {
                         if let Some(ws) = self.workspaces.iter_mut().find(|w| w.id == ws_id) {
-                            ws.title = new_name;
+                            ws.title = new_name.clone();
+                            ws.user_title = Some(new_name);
                         }
                     }
                     RenameTarget::Tab {

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -323,7 +323,13 @@ fn render_workspace_row(
 
     // Compute title text early so we can measure if it needs two lines.
     let title_font = crate::fonts::bold_font(TITLE_FONT_SIZE);
-    let display_title = if let Some(task) = status.as_ref().and_then(|s| s.task.as_ref()) {
+    // Title priority: user-set name (sticky) > agent task > surface
+    // title > default workspace name. A user who explicitly renamed
+    // the workspace via the rename modal should not have their choice
+    // overwritten by agent status or auto-detected titles.
+    let display_title = if let Some(ref ut) = ws.user_title {
+        ut.clone()
+    } else if let Some(task) = status.as_ref().and_then(|s| s.task.as_ref()) {
         format!("\u{2731} {task}")
     } else if let Some(st) = metadata.and_then(|m| m.surface_title.as_ref()) {
         st.clone()

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -587,6 +587,7 @@ pub(crate) fn fresh_startup(
     let workspace = Workspace {
         id: 0,
         title: "Terminal 1".to_string(),
+        user_title: None,
         tree: PaneTree::new(initial_pane_id),
         focused_pane: initial_pane_id,
         zoomed: None,
@@ -736,6 +737,7 @@ pub(crate) fn restore_session(
         workspaces.push(Workspace {
             id: saved_ws.id,
             title: saved_ws.title.clone(),
+            user_title: saved_ws.user_title.clone(),
             tree: saved_ws.tree.clone(),
             focused_pane: focused,
             zoomed: saved_ws.zoomed.filter(|z| panes.contains_key(z)),

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -112,6 +112,7 @@ impl AmuxApp {
                 let workspace = Workspace {
                     id: ws_id,
                     title,
+                    user_title: None,
                     tree: PaneTree::new(pane_id),
                     focused_pane: pane_id,
                     zoomed: None,

--- a/crates/amux-core/src/model.rs
+++ b/crates/amux-core/src/model.rs
@@ -16,6 +16,11 @@ use amux_layout::{PaneId, PaneTree, SplitDirection};
 pub struct Workspace {
     pub id: u64,
     pub title: String,
+    /// User-set title from the rename modal. When `Some`, this takes
+    /// precedence over agent status and auto-detected titles in the
+    /// sidebar display. Only written by the rename modal; never
+    /// overwritten by agent hooks or OSC sequences.
+    pub user_title: Option<String>,
     pub tree: PaneTree,
     pub focused_pane: PaneId,
     pub zoomed: Option<PaneId>,

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -73,6 +73,10 @@ pub struct SessionData {
 pub struct SavedWorkspace {
     pub id: u64,
     pub title: String,
+    /// User-set title from the rename modal. Takes precedence over
+    /// agent-derived titles in the sidebar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_title: Option<String>,
     pub tree: PaneTree,
     pub focused_pane: u64,
     #[serde(default)]
@@ -320,6 +324,7 @@ mod tests {
             workspaces: vec![SavedWorkspace {
                 id: 0,
                 title: "default".to_string(),
+                user_title: None,
                 tree,
                 focused_pane: 0,
                 zoomed: None,


### PR DESCRIPTION
## Summary

When a user renames a workspace via the rename modal, the name now sticks — agent hooks and auto-detected titles no longer overwrite it.

**Title priority (sidebar):**
1. `user_title` (sticky, from rename modal) — **new, highest**
2. Agent task label (`✱ Running tests...`)
3. Surface title (shell/OSC)
4. Default workspace name (`Terminal 1`)

Tab titles already had this via `PaneSurface.user_title`. This aligns workspaces with the same pattern.

Fixes #233

## Changes

- `Workspace` gains `user_title: Option<String>` field
- Rename modal sets both `title` and `user_title`
- Sidebar checks `user_title` first before agent/surface titles
- Persisted in session save/restore (backwards compatible — `None` is skipped)

## Test plan

- [ ] Rename a workspace to "Backend API"
- [ ] Launch Claude Code in that workspace — title should stay "Backend API"
- [ ] Close and relaunch — title should still be "Backend API" after session restore
- [ ] Un-renamed workspaces still show agent status/surface title as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)