### PR TITLE
Thin divider (4px → 1px) and wider tabs (240px → 360px)

### DIFF
--- a/crates/amux-app/src/layout_ops.rs
+++ b/crates/amux-app/src/layout_ops.rs
@@ -49,7 +49,7 @@ impl AmuxApp {
 
         if let Some(pos) = pointer_pos {
             if !is_dragging {
-                if let Some(div) = dividers.iter().find(|d| d.rect.contains(pos)) {
+                if let Some(div) = dividers.iter().find(|d| d.rect.expand(4.0).contains(pos)) {
                     match div.direction {
                         SplitDirection::Horizontal => {
                             ui.ctx().set_cursor_icon(egui::CursorIcon::ResizeHorizontal);

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -123,7 +123,7 @@ const DEFAULT_BROWSER_URL: &str = "https://www.google.com";
 const DEFAULT_SIDEBAR_WIDTH: f32 = 200.0;
 const TAB_BAR_HEIGHT: f32 = 26.0;
 const TAB_MIN_WIDTH: f32 = 100.0;
-const TAB_MAX_WIDTH: f32 = 240.0;
+const TAB_MAX_WIDTH: f32 = 360.0;
 /// Content top inset: tab bar height + 1px border between tab bar and content.
 const TAB_CONTENT_TOP_INSET: f32 = TAB_BAR_HEIGHT + 1.0;
 /// Height of the titlebar icon strip (sidebar toggle / bell / + icons

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -7,6 +7,32 @@
 
 use crate::*;
 
+/// Truncate a tab title to fit within `max_chars`. When `is_path`
+/// is true (title sourced from CWD metadata), uses middle ellipsis
+/// to keep both the root and leaf visible: `~/src/…/my-branch`.
+/// Otherwise truncates from the end with trailing `…`.
+fn truncate_tab_title(title: &str, max_chars: usize, is_path: bool) -> String {
+    let len = title.chars().count();
+    if len <= max_chars {
+        return title.to_string();
+    }
+
+    if is_path {
+        // Middle ellipsis: keep the start (root) and end (leaf).
+        // Split roughly 40% start / 60% end so the leaf (most
+        // distinguishing part) gets more space.
+        let budget = max_chars.saturating_sub(1); // 1 char for …
+        let start_len = budget * 2 / 5;
+        let end_len = budget - start_len;
+        let start: String = title.chars().take(start_len).collect();
+        let end: String = title.chars().skip(len - end_len).collect();
+        format!("{start}\u{2026}{end}")
+    } else {
+        let prefix: String = title.chars().take(max_chars - 1).collect();
+        format!("{prefix}\u{2026}")
+    }
+}
+
 impl AmuxApp {
     /// Render a single pane: tab bar (if >1 surface) + terminal content.
     pub(crate) fn render_single_pane(
@@ -130,6 +156,7 @@ impl AmuxApp {
             struct TabInfo {
                 icon: TabIcon,
                 title: String,
+                is_path: bool,
                 is_dead: bool,
                 is_browser: bool,
             }
@@ -150,8 +177,8 @@ impl AmuxApp {
                             .user_title
                             .as_deref()
                             .unwrap_or(sanitized_pane_title.as_ref());
-                        let raw = if raw_title.is_empty() || raw_title == "?" {
-                            surface
+                        let (raw, is_path) = if raw_title.is_empty() || raw_title == "?" {
+                            let cwd_title = surface
                                 .metadata
                                 .cwd
                                 .as_deref()
@@ -167,12 +194,14 @@ impl AmuxApp {
                                     }
                                     p.to_string()
                                 })
-                                .unwrap_or_else(|| "Tab".to_string())
+                                .unwrap_or_else(|| "Tab".to_string());
+                            (cwd_title, true)
                         } else {
-                            raw_title.to_string()
+                            (raw_title.to_string(), false)
                         };
                         TabInfo {
                             icon: TabIcon::Terminal,
+                            is_path,
                             title: raw,
                             is_dead: surface.exited.is_some(),
                             is_browser: false,
@@ -189,6 +218,7 @@ impl AmuxApp {
                                 None => TabIcon::None,
                             },
                             title,
+                            is_path: false,
                             is_dead: false,
                             is_browser: true,
                         }
@@ -198,13 +228,7 @@ impl AmuxApp {
 
             for (idx, tab) in tabs.iter().enumerate() {
                 let is_active = idx == active_idx;
-                // Cap at 20 chars
-                let title = if tab.title.chars().count() > 20 {
-                    let prefix: String = tab.title.chars().take(17).collect();
-                    format!("{prefix}...")
-                } else {
-                    tab.title.clone()
-                };
+                let title = truncate_tab_title(&tab.title, 30, tab.is_path);
                 let is_dead = tab.is_dead;
                 let has_icon = !matches!(tab.icon, TabIcon::None);
                 let icon_space = if has_icon {

--- a/crates/amux-layout/src/lib.rs
+++ b/crates/amux-layout/src/lib.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 pub type PaneId = u64;
 
-/// Divider thickness in logical pixels (split between the two children).
-const DIVIDER_PX: f32 = 4.0;
+/// Visible divider thickness in logical pixels.
+const DIVIDER_PX: f32 = 1.0;
 
 /// Minimum pane dimension in pixels (prevents degenerate splits).
 const MIN_PANE_PX: f32 = 20.0;


### PR DESCRIPTION
## Summary

Two quick visual polish fixes:

**Divider (#235):** 4px → 1px visible thickness. Drag hit zone stays 9px (4px expand on each side). Hover cursor zone also expanded to match so the resize cursor appears before hitting the 1px line.

**Tabs (#236):** Max width 240px → 360px so auto-detected titles (paths, branches, agent status) show more useful context before truncating.

Fixes #235, fixes #236

## Test plan

- [ ] Split panes — divider should be a thin 1px line
- [ ] Hover near the divider — resize cursor should appear within ~4px
- [ ] Drag to resize — should work smoothly
- [ ] Open multiple tabs with long titles — should show more text before truncating

🤖 Generated with [Claude Code](https://claude.com/claude-code)