### PR TITLE
Add minimal auto-hiding scrollbar with anchor-based dragging

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -141,6 +141,17 @@ impl eframe::App for AmuxApp {
                         Err(_) => break,
                     }
                 }
+                // When new output arrives and the backend manages its own
+                // scroll, ghostty auto-scrolls to bottom. Sync our tracked
+                // scroll_offset so the scrollbar doesn't get stuck visible.
+                if bytes_this_frame > 0
+                    && surface.scroll_offset > 0
+                    && surface.pane.manages_own_scroll()
+                {
+                    // If the user was scrolled up and new output arrived,
+                    // ghostty scrolls to bottom. Reset our offset to match.
+                    surface.scroll_offset = 0;
+                }
                 if bytes_this_frame >= MAX_BYTES_PER_SURFACE_PER_FRAME {
                     pending_data = true;
                 }

--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -549,6 +549,7 @@ impl AmuxApp {
                         let whole_lines = surface.scroll_accum.trunc() as isize;
                         if whole_lines != 0 {
                             surface.scroll_accum -= whole_lines as f32;
+                            surface.last_scroll_at = Instant::now();
                             self.do_scroll_lines_for(pane_id, whole_lines);
                         }
                     }

--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -870,6 +870,16 @@ impl AmuxApp {
             return false;
         }
 
+        // Skip selection when the pointer is in the scrollbar hit zone
+        // (rightmost 16px of the content area) so the scrollbar drag
+        // interaction takes priority over text selection.
+        if let Some(pos) = pointer_pos {
+            let scrollbar_zone_left = content_rect.max.x - 16.0;
+            if pos.x >= scrollbar_zone_left && content_rect.contains(pos) {
+                return false;
+            }
+        }
+
         if primary_pressed {
             if let Some(pos) = pointer_pos {
                 if !content_rect.contains(pos) {

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -252,6 +252,15 @@ struct AmuxApp {
     config_last_modified: Option<std::time::SystemTime>,
     /// When we last checked the config file's mtime (throttle to ~2s).
     config_last_checked: Instant,
+    /// Active scrollbar thumb drag: pane + anchor offset (click_y - thumb_top).
+    scrollbar_drag: Option<ScrollbarDrag>,
+}
+
+struct ScrollbarDrag {
+    pane_id: PaneId,
+    /// Distance from the mousedown point to the top of the thumb.
+    /// During drag: effective_thumb_top = mouse_y - anchor_offset.
+    anchor_offset: f32,
 }
 
 /// Editing state for a browser pane's omnibar.

--- a/crates/amux-app/src/managed_pane.rs
+++ b/crates/amux-app/src/managed_pane.rs
@@ -177,6 +177,8 @@ pub(crate) struct PaneSurface {
     pub(crate) byte_rx: mpsc::Receiver<Vec<u8>>,
     pub(crate) scroll_offset: usize,
     pub(crate) scroll_accum: f32,
+    /// When the user last scrolled this surface (for scrollbar auto-hide).
+    pub(crate) last_scroll_at: std::time::Instant,
     pub(crate) metadata: SurfaceMetadata,
     /// User-set title override. When set, takes precedence over OSC 0/2 title.
     pub(crate) user_title: Option<String>,

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -795,6 +795,62 @@ impl AmuxApp {
             pane_id,
         );
 
+        // Scrollbar overlay — thin, auto-hiding, drawn on top of content.
+        {
+            let total_rows = surface.pane.scrollback_rows();
+            let (_, viewport_rows) = surface.pane.dimensions();
+            if total_rows > viewport_rows {
+                // Fade out after 1.5s of no scrolling
+                let since_scroll = surface.last_scroll_at.elapsed();
+                let alpha = if surface.scroll_offset > 0 {
+                    // Always visible when scrolled up (not at bottom)
+                    0.5_f32
+                } else if since_scroll.as_millis() < 1500 {
+                    // Fade: full opacity for 1s, then fade over 0.5s
+                    let fade_start = 1000;
+                    let fade_dur = 500;
+                    let ms = since_scroll.as_millis() as u32;
+                    if ms < fade_start {
+                        0.5
+                    } else {
+                        0.5 * (1.0 - (ms - fade_start) as f32 / fade_dur as f32)
+                    }
+                } else {
+                    0.0
+                };
+
+                if alpha > 0.01 {
+                    let bar_width = 4.0_f32;
+                    let bar_margin = 2.0_f32;
+                    let track_top = content_rect.min.y + 2.0;
+                    let track_bottom = content_rect.max.y - 2.0;
+                    let track_height = track_bottom - track_top;
+
+                    let viewport_frac = viewport_rows as f32 / total_rows as f32;
+                    let thumb_height = (track_height * viewport_frac).max(12.0);
+
+                    // scroll_offset is lines from the bottom
+                    let scroll_frac =
+                        surface.scroll_offset as f32 / (total_rows - viewport_rows) as f32;
+                    let thumb_top = track_top + (track_height - thumb_height) * (1.0 - scroll_frac);
+
+                    let thumb_rect = egui::Rect::from_min_size(
+                        egui::pos2(content_rect.max.x - bar_width - bar_margin, thumb_top),
+                        egui::vec2(bar_width, thumb_height),
+                    );
+
+                    let a = (alpha * 255.0) as u8;
+                    let color = egui::Color32::from_rgba_unmultiplied(200, 200, 200, a);
+                    ui.painter().rect_filled(thumb_rect, bar_width / 2.0, color);
+
+                    // Request repaint during fade animation
+                    if alpha < 0.5 {
+                        ui.ctx().request_repaint();
+                    }
+                }
+            }
+        }
+
         // Render exit overlay when process has exited
         if let Some(exit_info) = &surface.exited {
             render::render_exit_overlay(ui, content_rect, &exit_info.message, self.font_size);

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -812,108 +812,113 @@ impl AmuxApp {
                 let bar_margin = 2.0_f32;
                 let track_top = content_rect.min.y + 2.0;
                 let track_bottom = content_rect.max.y - 2.0;
-                let track_height = track_bottom - track_top;
+                let track_height = (track_bottom - track_top).max(0.0);
+                if track_height < 20.0 {
+                    // Pane too small for a meaningful scrollbar
+                } else {
+                    let viewport_frac = viewport_rows as f32 / total_rows as f32;
+                    let thumb_height = (track_height * viewport_frac).max(12.0);
+                    let available = track_height - thumb_height;
 
-                let viewport_frac = viewport_rows as f32 / total_rows as f32;
-                let thumb_height = (track_height * viewport_frac).max(12.0);
-                let available = track_height - thumb_height;
+                    let scroll_frac = surface.scroll_offset as f32 / max_offset as f32;
+                    let thumb_top = track_top + available * (1.0 - scroll_frac);
 
-                let scroll_frac = surface.scroll_offset as f32 / max_offset as f32;
-                let thumb_top = track_top + available * (1.0 - scroll_frac);
+                    let thumb_rect = egui::Rect::from_min_size(
+                        egui::pos2(content_rect.max.x - bar_width - bar_margin, thumb_top),
+                        egui::vec2(bar_width, thumb_height),
+                    );
 
-                let thumb_rect = egui::Rect::from_min_size(
-                    egui::pos2(content_rect.max.x - bar_width - bar_margin, thumb_top),
-                    egui::vec2(bar_width, thumb_height),
-                );
+                    // Expanded thumb hit rect for easier grabbing
+                    let thumb_hit = egui::Rect::from_min_max(
+                        egui::pos2(content_rect.max.x - hit_width, thumb_top),
+                        egui::pos2(content_rect.max.x, thumb_top + thumb_height),
+                    );
 
-                // Expanded thumb hit rect for easier grabbing
-                let thumb_hit = egui::Rect::from_min_max(
-                    egui::pos2(content_rect.max.x - hit_width, thumb_top),
-                    egui::pos2(content_rect.max.x, thumb_top + thumb_height),
-                );
+                    let hit_left = content_rect.max.x - hit_width;
+                    let pointer_pos = ui.input(|i| i.pointer.hover_pos());
+                    let primary_pressed = ui.input(|i| i.pointer.primary_pressed());
+                    let primary_down = ui.input(|i| i.pointer.primary_down());
+                    let primary_released = ui.input(|i| i.pointer.primary_released());
 
-                let hit_left = content_rect.max.x - hit_width;
-                let pointer_pos = ui.input(|i| i.pointer.hover_pos());
-                let primary_pressed = ui.input(|i| i.pointer.primary_pressed());
-                let primary_down = ui.input(|i| i.pointer.primary_down());
-                let primary_released = ui.input(|i| i.pointer.primary_released());
+                    let in_hit_zone = pointer_pos.is_some_and(|p| {
+                        p.x >= hit_left && p.y >= track_top && p.y <= track_bottom
+                    });
+                    let on_thumb = pointer_pos.is_some_and(|p| thumb_hit.contains(p));
 
-                let in_hit_zone = pointer_pos
-                    .is_some_and(|p| p.x >= hit_left && p.y >= track_top && p.y <= track_bottom);
-                let on_thumb = pointer_pos.is_some_and(|p| thumb_hit.contains(p));
+                    // Drag state machine
+                    let is_dragging = self
+                        .scrollbar_drag
+                        .as_ref()
+                        .is_some_and(|d| d.pane_id == pane_id);
 
-                // Drag state machine
-                let is_dragging = self
-                    .scrollbar_drag
-                    .as_ref()
-                    .is_some_and(|d| d.pane_id == pane_id);
-
-                if primary_released {
-                    if is_dragging {
-                        self.scrollbar_drag = None;
-                    }
-                } else if primary_pressed && on_thumb {
-                    // Start anchor-based drag
-                    if let Some(pos) = pointer_pos {
-                        self.scrollbar_drag = Some(ScrollbarDrag {
-                            pane_id,
-                            anchor_offset: pos.y - thumb_top,
-                        });
-                    }
-                } else if primary_pressed && in_hit_zone && !on_thumb {
-                    // Click above/below thumb → page up/down
-                    if let Some(pos) = pointer_pos {
-                        if pos.y < thumb_top {
-                            // Page up (increase scroll_offset)
-                            let new_off = (surface.scroll_offset + viewport_rows).min(max_offset);
-                            scrollbar_jump = Some(new_off);
-                        } else {
-                            // Page down (decrease scroll_offset)
-                            let new_off = surface.scroll_offset.saturating_sub(viewport_rows);
-                            scrollbar_jump = Some(new_off);
+                    if primary_released {
+                        if is_dragging {
+                            self.scrollbar_drag = None;
+                        }
+                    } else if primary_pressed && on_thumb {
+                        // Start anchor-based drag
+                        if let Some(pos) = pointer_pos {
+                            self.scrollbar_drag = Some(ScrollbarDrag {
+                                pane_id,
+                                anchor_offset: pos.y - thumb_top,
+                            });
+                        }
+                    } else if primary_pressed && in_hit_zone && !on_thumb {
+                        // Click above/below thumb → page up/down
+                        if let Some(pos) = pointer_pos {
+                            if pos.y < thumb_top {
+                                // Page up (increase scroll_offset)
+                                let new_off =
+                                    (surface.scroll_offset + viewport_rows).min(max_offset);
+                                scrollbar_jump = Some(new_off);
+                            } else {
+                                // Page down (decrease scroll_offset)
+                                let new_off = surface.scroll_offset.saturating_sub(viewport_rows);
+                                scrollbar_jump = Some(new_off);
+                            }
                         }
                     }
-                }
 
-                // During drag: compute scroll from anchor
-                if is_dragging && primary_down {
-                    if let Some(pos) = pointer_pos {
-                        let anchor = self.scrollbar_drag.as_ref().unwrap().anchor_offset;
-                        let effective_top = (pos.y - anchor - track_top).clamp(0.0, available);
-                        let frac = effective_top / available;
-                        let new_offset = ((1.0 - frac) * max_offset as f32).round() as usize;
-                        scrollbar_jump = Some(new_offset);
+                    // During drag: compute scroll from anchor
+                    if is_dragging && primary_down {
+                        if let Some(pos) = pointer_pos {
+                            let anchor = self.scrollbar_drag.as_ref().unwrap().anchor_offset;
+                            let effective_top = (pos.y - anchor - track_top).clamp(0.0, available);
+                            let frac = effective_top / available;
+                            let new_offset = ((1.0 - frac) * max_offset as f32).round() as usize;
+                            scrollbar_jump = Some(new_offset);
+                        }
                     }
-                }
 
-                let hovering = in_hit_zone || is_dragging;
+                    let hovering = in_hit_zone || is_dragging;
 
-                // Fade: visible while hovering/dragging, otherwise hold
-                // for 1.5s after last scroll then fade over 0.5s.
-                let since_scroll = surface.last_scroll_at.elapsed();
-                let alpha = if hovering || is_dragging {
-                    0.6_f32
-                } else {
-                    let hold_ms: u32 = 1500;
-                    let fade_ms: u32 = 500;
-                    let ms = since_scroll.as_millis() as u32;
-                    if ms < hold_ms {
-                        0.5
-                    } else if ms < hold_ms + fade_ms {
-                        0.5 * (1.0 - (ms - hold_ms) as f32 / fade_ms as f32)
+                    // Fade: visible while hovering/dragging, otherwise hold
+                    // for 1.5s after last scroll then fade over 0.5s.
+                    let since_scroll = surface.last_scroll_at.elapsed();
+                    let alpha = if hovering || is_dragging {
+                        0.6_f32
                     } else {
-                        0.0
-                    }
-                };
+                        let hold_ms: u32 = 1500;
+                        let fade_ms: u32 = 500;
+                        let ms = since_scroll.as_millis() as u32;
+                        if ms < hold_ms {
+                            0.5
+                        } else if ms < hold_ms + fade_ms {
+                            0.5 * (1.0 - (ms - hold_ms) as f32 / fade_ms as f32)
+                        } else {
+                            0.0
+                        }
+                    };
 
-                if alpha > 0.01 {
-                    let a = (alpha * 255.0) as u8;
-                    let color = egui::Color32::from_rgba_unmultiplied(200, 200, 200, a);
-                    ui.painter().rect_filled(thumb_rect, bar_width / 2.0, color);
-                    if alpha < 0.5 {
-                        ui.ctx().request_repaint();
+                    if alpha > 0.01 {
+                        let a = (alpha * 255.0) as u8;
+                        let color = egui::Color32::from_rgba_unmultiplied(200, 200, 200, a);
+                        ui.painter().rect_filled(thumb_rect, bar_width / 2.0, color);
+                        if alpha < 0.5 {
+                            ui.ctx().request_repaint();
+                        }
                     }
-                }
+                } // track_height >= 20
             }
         }
 

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -796,17 +796,60 @@ impl AmuxApp {
         );
 
         // Scrollbar overlay — thin, auto-hiding, drawn on top of content.
+        // Captures a scroll-jump target if the user clicks/drags in the
+        // scrollbar track; applied mutably after this block.
+        let mut scrollbar_jump: Option<usize> = None;
         {
             let total_rows = surface.pane.scrollback_rows();
             let (_, viewport_rows) = surface.pane.dimensions();
             if total_rows > viewport_rows {
-                // Fade out after 1.5s of no scrolling
+                let max_offset = total_rows - viewport_rows;
+                let bar_width = 6.0_f32;
+                let hit_width = 16.0_f32; // wider invisible hit zone
+                let bar_margin = 2.0_f32;
+                let track_top = content_rect.min.y + 2.0;
+                let track_bottom = content_rect.max.y - 2.0;
+                let track_height = track_bottom - track_top;
+
+                let viewport_frac = viewport_rows as f32 / total_rows as f32;
+                let thumb_height = (track_height * viewport_frac).max(12.0);
+
+                // scroll_offset is lines from the bottom
+                let scroll_frac = surface.scroll_offset as f32 / max_offset as f32;
+                let thumb_top = track_top + (track_height - thumb_height) * (1.0 - scroll_frac);
+
+                let thumb_rect = egui::Rect::from_min_size(
+                    egui::pos2(content_rect.max.x - bar_width - bar_margin, thumb_top),
+                    egui::vec2(bar_width, thumb_height),
+                );
+
+                // Hit-test zone: wider than the visible thumb for easy grabbing
+                let hit_rect = egui::Rect::from_min_max(
+                    egui::pos2(content_rect.max.x - hit_width, track_top),
+                    egui::pos2(content_rect.max.x, track_bottom),
+                );
+
+                // Interaction: click/drag in the track to scroll
+                let scrollbar_id = ui.id().with("scrollbar").with(pane_id);
+                let response = ui.interact(hit_rect, scrollbar_id, egui::Sense::drag());
+                let hovering = response.hovered() || response.dragged();
+
+                if response.dragged() {
+                    if let Some(pos) = ui.input(|i| i.pointer.hover_pos()) {
+                        // Map pointer Y to scroll fraction
+                        let y_frac =
+                            ((pos.y - track_top) / (track_height - thumb_height)).clamp(0.0, 1.0);
+                        let new_offset = ((1.0 - y_frac) * max_offset as f32).round() as usize;
+                        scrollbar_jump = Some(new_offset);
+                    }
+                }
+
+                // Fade out after 1.5s of no scrolling (always visible when
+                // scrolled up, hovered, or dragged)
                 let since_scroll = surface.last_scroll_at.elapsed();
-                let alpha = if surface.scroll_offset > 0 {
-                    // Always visible when scrolled up (not at bottom)
+                let alpha = if surface.scroll_offset > 0 || hovering {
                     0.5_f32
                 } else if since_scroll.as_millis() < 1500 {
-                    // Fade: full opacity for 1s, then fade over 0.5s
                     let fade_start = 1000;
                     let fade_dur = 500;
                     let ms = since_scroll.as_millis() as u32;
@@ -820,30 +863,10 @@ impl AmuxApp {
                 };
 
                 if alpha > 0.01 {
-                    let bar_width = 4.0_f32;
-                    let bar_margin = 2.0_f32;
-                    let track_top = content_rect.min.y + 2.0;
-                    let track_bottom = content_rect.max.y - 2.0;
-                    let track_height = track_bottom - track_top;
-
-                    let viewport_frac = viewport_rows as f32 / total_rows as f32;
-                    let thumb_height = (track_height * viewport_frac).max(12.0);
-
-                    // scroll_offset is lines from the bottom
-                    let scroll_frac =
-                        surface.scroll_offset as f32 / (total_rows - viewport_rows) as f32;
-                    let thumb_top = track_top + (track_height - thumb_height) * (1.0 - scroll_frac);
-
-                    let thumb_rect = egui::Rect::from_min_size(
-                        egui::pos2(content_rect.max.x - bar_width - bar_margin, thumb_top),
-                        egui::vec2(bar_width, thumb_height),
-                    );
-
                     let a = (alpha * 255.0) as u8;
                     let color = egui::Color32::from_rgba_unmultiplied(200, 200, 200, a);
                     ui.painter().rect_filled(thumb_rect, bar_width / 2.0, color);
 
-                    // Request repaint during fade animation
                     if alpha < 0.5 {
                         ui.ctx().request_repaint();
                     }
@@ -851,9 +874,31 @@ impl AmuxApp {
             }
         }
 
+        // Capture values from the immutable surface borrow before we
+        // need mutable access for the scrollbar drag.
+        let exit_message = surface.exited.as_ref().map(|e| e.message.clone());
+
+        // Apply scrollbar drag (needs mutable access).
+        if let Some(new_offset) = scrollbar_jump {
+            if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&pane_id) {
+                if let Some(surface) = managed.active_surface_mut() {
+                    let (_, rows) = surface.pane.dimensions();
+                    let total = surface.pane.scrollback_rows();
+                    let max_offset = total.saturating_sub(rows);
+                    let clamped = new_offset.min(max_offset);
+                    let delta = surface.scroll_offset as isize - clamped as isize;
+                    if surface.pane.manages_own_scroll() && delta != 0 {
+                        surface.pane.scroll_viewport(delta);
+                    }
+                    surface.scroll_offset = clamped;
+                    surface.last_scroll_at = Instant::now();
+                }
+            }
+        }
+
         // Render exit overlay when process has exited
-        if let Some(exit_info) = &surface.exited {
-            render::render_exit_overlay(ui, content_rect, &exit_info.message, self.font_size);
+        if let Some(msg) = &exit_message {
+            render::render_exit_overlay(ui, content_rect, msg, self.font_size);
         }
 
         // Render copy mode cursor overlay

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -795,9 +795,12 @@ impl AmuxApp {
             pane_id,
         );
 
-        // Scrollbar overlay — thin, auto-hiding, drawn on top of content.
-        // Captures a scroll-jump target if the user clicks/drags in the
-        // scrollbar track; applied mutably after this block.
+        // Scrollbar overlay — thin, auto-hiding, anchor-based dragging.
+        // Interaction model follows wezterm / OS scrollbar conventions:
+        //   mousedown on thumb → start drag with anchor offset
+        //   drag → thumb follows mouse exactly (no jump)
+        //   click above thumb → page up
+        //   click below thumb → page down
         let mut scrollbar_jump: Option<usize> = None;
         {
             let total_rows = surface.pane.scrollback_rows();
@@ -805,7 +808,7 @@ impl AmuxApp {
             if total_rows > viewport_rows {
                 let max_offset = total_rows - viewport_rows;
                 let bar_width = 6.0_f32;
-                let hit_width = 16.0_f32; // wider invisible hit zone
+                let hit_width = 16.0_f32;
                 let bar_margin = 2.0_f32;
                 let track_top = content_rect.min.y + 2.0;
                 let track_bottom = content_rect.max.y - 2.0;
@@ -813,60 +816,100 @@ impl AmuxApp {
 
                 let viewport_frac = viewport_rows as f32 / total_rows as f32;
                 let thumb_height = (track_height * viewport_frac).max(12.0);
+                let available = track_height - thumb_height;
 
-                // scroll_offset is lines from the bottom
                 let scroll_frac = surface.scroll_offset as f32 / max_offset as f32;
-                let thumb_top = track_top + (track_height - thumb_height) * (1.0 - scroll_frac);
+                let thumb_top = track_top + available * (1.0 - scroll_frac);
 
                 let thumb_rect = egui::Rect::from_min_size(
                     egui::pos2(content_rect.max.x - bar_width - bar_margin, thumb_top),
                     egui::vec2(bar_width, thumb_height),
                 );
 
-                // Hit-test zone: wider than the visible thumb for easy grabbing
-                let hit_rect = egui::Rect::from_min_max(
-                    egui::pos2(content_rect.max.x - hit_width, track_top),
-                    egui::pos2(content_rect.max.x, track_bottom),
+                // Expanded thumb hit rect for easier grabbing
+                let thumb_hit = egui::Rect::from_min_max(
+                    egui::pos2(content_rect.max.x - hit_width, thumb_top),
+                    egui::pos2(content_rect.max.x, thumb_top + thumb_height),
                 );
 
-                // Interaction: click/drag in the track to scroll
-                let scrollbar_id = ui.id().with("scrollbar").with(pane_id);
-                let response = ui.interact(hit_rect, scrollbar_id, egui::Sense::drag());
-                let hovering = response.hovered() || response.dragged();
+                let hit_left = content_rect.max.x - hit_width;
+                let pointer_pos = ui.input(|i| i.pointer.hover_pos());
+                let primary_pressed = ui.input(|i| i.pointer.primary_pressed());
+                let primary_down = ui.input(|i| i.pointer.primary_down());
+                let primary_released = ui.input(|i| i.pointer.primary_released());
 
-                if response.dragged() {
-                    if let Some(pos) = ui.input(|i| i.pointer.hover_pos()) {
-                        // Map pointer Y to scroll fraction
-                        let y_frac =
-                            ((pos.y - track_top) / (track_height - thumb_height)).clamp(0.0, 1.0);
-                        let new_offset = ((1.0 - y_frac) * max_offset as f32).round() as usize;
+                let in_hit_zone = pointer_pos
+                    .is_some_and(|p| p.x >= hit_left && p.y >= track_top && p.y <= track_bottom);
+                let on_thumb = pointer_pos.is_some_and(|p| thumb_hit.contains(p));
+
+                // Drag state machine
+                let is_dragging = self
+                    .scrollbar_drag
+                    .as_ref()
+                    .is_some_and(|d| d.pane_id == pane_id);
+
+                if primary_released {
+                    if is_dragging {
+                        self.scrollbar_drag = None;
+                    }
+                } else if primary_pressed && on_thumb {
+                    // Start anchor-based drag
+                    if let Some(pos) = pointer_pos {
+                        self.scrollbar_drag = Some(ScrollbarDrag {
+                            pane_id,
+                            anchor_offset: pos.y - thumb_top,
+                        });
+                    }
+                } else if primary_pressed && in_hit_zone && !on_thumb {
+                    // Click above/below thumb → page up/down
+                    if let Some(pos) = pointer_pos {
+                        if pos.y < thumb_top {
+                            // Page up (increase scroll_offset)
+                            let new_off = (surface.scroll_offset + viewport_rows).min(max_offset);
+                            scrollbar_jump = Some(new_off);
+                        } else {
+                            // Page down (decrease scroll_offset)
+                            let new_off = surface.scroll_offset.saturating_sub(viewport_rows);
+                            scrollbar_jump = Some(new_off);
+                        }
+                    }
+                }
+
+                // During drag: compute scroll from anchor
+                if is_dragging && primary_down {
+                    if let Some(pos) = pointer_pos {
+                        let anchor = self.scrollbar_drag.as_ref().unwrap().anchor_offset;
+                        let effective_top = (pos.y - anchor - track_top).clamp(0.0, available);
+                        let frac = effective_top / available;
+                        let new_offset = ((1.0 - frac) * max_offset as f32).round() as usize;
                         scrollbar_jump = Some(new_offset);
                     }
                 }
 
-                // Fade out after 1.5s of no scrolling (always visible when
-                // scrolled up, hovered, or dragged)
+                let hovering = in_hit_zone || is_dragging;
+
+                // Fade: visible while hovering/dragging, otherwise hold
+                // for 1.5s after last scroll then fade over 0.5s.
                 let since_scroll = surface.last_scroll_at.elapsed();
-                let alpha = if surface.scroll_offset > 0 || hovering {
-                    0.5_f32
-                } else if since_scroll.as_millis() < 1500 {
-                    let fade_start = 1000;
-                    let fade_dur = 500;
-                    let ms = since_scroll.as_millis() as u32;
-                    if ms < fade_start {
-                        0.5
-                    } else {
-                        0.5 * (1.0 - (ms - fade_start) as f32 / fade_dur as f32)
-                    }
+                let alpha = if hovering || is_dragging {
+                    0.6_f32
                 } else {
-                    0.0
+                    let hold_ms: u32 = 1500;
+                    let fade_ms: u32 = 500;
+                    let ms = since_scroll.as_millis() as u32;
+                    if ms < hold_ms {
+                        0.5
+                    } else if ms < hold_ms + fade_ms {
+                        0.5 * (1.0 - (ms - hold_ms) as f32 / fade_ms as f32)
+                    } else {
+                        0.0
+                    }
                 };
 
                 if alpha > 0.01 {
                     let a = (alpha * 255.0) as u8;
                     let color = egui::Color32::from_rgba_unmultiplied(200, 200, 200, a);
                     ui.painter().rect_filled(thumb_rect, bar_width / 2.0, color);
-
                     if alpha < 0.5 {
                         ui.ctx().request_repaint();
                     }
@@ -886,9 +929,15 @@ impl AmuxApp {
                     let total = surface.pane.scrollback_rows();
                     let max_offset = total.saturating_sub(rows);
                     let clamped = new_offset.min(max_offset);
-                    let delta = surface.scroll_offset as isize - clamped as isize;
-                    if surface.pane.manages_own_scroll() && delta != 0 {
-                        surface.pane.scroll_viewport(delta);
+                    if surface.pane.manages_own_scroll() {
+                        // Absolute positioning: reset to bottom then scroll
+                        // up by the exact desired offset. Incremental deltas
+                        // drift because we can't query ghostty's actual
+                        // viewport position.
+                        surface.pane.scroll_to_bottom();
+                        if clamped > 0 {
+                            surface.pane.scroll_viewport(-(clamped as isize));
+                        }
                     }
                     surface.scroll_offset = clamped;
                     surface.last_scroll_at = Instant::now();

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -981,7 +981,8 @@ pub(crate) fn spawn_surface(
         byte_rx,
         scroll_offset: 0,
         scroll_accum: 0.0,
-        last_scroll_at: Instant::now(),
+        // Use a past instant so the scrollbar doesn't flash on startup.
+        last_scroll_at: Instant::now() - Duration::from_secs(10),
         metadata,
         user_title: None,
         exited: None,

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -980,6 +980,7 @@ pub(crate) fn spawn_surface(
         byte_rx,
         scroll_offset: 0,
         scroll_accum: 0.0,
+        last_scroll_at: Instant::now(),
         metadata,
         user_title: None,
         exited: None,

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -530,6 +530,7 @@ pub(crate) fn run() -> anyhow::Result<()> {
                     .and_then(|p| std::fs::metadata(p).ok()?.modified().ok()),
                 config_file_path,
                 config_last_checked: Instant::now(),
+                scrollbar_drag: None,
             }))
         }),
     )

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -469,17 +469,18 @@ impl AmuxApp {
                 let (_, rows) = surface.pane.dimensions();
                 let page_size = rows.saturating_sub(1).max(1);
                 let lines = pages * page_size as isize;
+                let total = surface.pane.scrollback_rows();
+                let max_offset = total.saturating_sub(rows);
+
                 if surface.pane.manages_own_scroll() {
-                    // Delegate to backend (e.g., libghostty manages its own viewport).
-                    // Delta convention: positive = toward bottom, negative = toward top.
-                    // `lines` from pages: positive pages = scroll down (toward bottom).
                     surface.pane.scroll_viewport(lines);
-                } else {
-                    let total = surface.pane.scrollback_rows();
-                    let max_offset = total.saturating_sub(rows);
-                    let new_offset = surface.scroll_offset as isize - lines;
-                    surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
                 }
+
+                // Always track scroll_offset + last_scroll_at so the
+                // scrollbar overlay works (same as do_scroll_lines_for).
+                let new_offset = surface.scroll_offset as isize - lines;
+                surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
+                surface.last_scroll_at = Instant::now();
             }
         }
         true

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -488,15 +488,18 @@ impl AmuxApp {
     pub(crate) fn do_scroll_lines_for(&mut self, pane_id: PaneId, lines: isize) {
         if let Some(PaneEntry::Terminal(managed)) = self.panes.get_mut(&pane_id) {
             if let Some(surface) = managed.active_surface_mut() {
+                let (_, rows) = surface.pane.dimensions();
+                let total = surface.pane.scrollback_rows();
+                let max_offset = total.saturating_sub(rows);
+
                 if surface.pane.manages_own_scroll() {
                     surface.pane.scroll_viewport(lines);
-                } else {
-                    let (_, rows) = surface.pane.dimensions();
-                    let total = surface.pane.scrollback_rows();
-                    let max_offset = total.saturating_sub(rows);
-                    let new_offset = surface.scroll_offset as isize - lines;
-                    surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
                 }
+
+                // Always track scroll_offset — even when the backend manages
+                // scrolling internally — so the scrollbar overlay can read it.
+                let new_offset = surface.scroll_offset as isize - lines;
+                surface.scroll_offset = (new_offset.max(0) as usize).min(max_offset);
             }
         }
     }


### PR DESCRIPTION
## Summary

Thin (6px visible, 16px hit zone), semi-transparent scrollbar overlay with macOS-style auto-hide and proper anchor-based thumb dragging.

### Visual
- Pill-shaped thumb, light gray with alpha blending
- No track, no arrows — just the thumb
- Only appears when scrollback exceeds viewport
- 1.5s hold + 0.5s fade after scroll activity
- Brighter (60% opacity) when hovering or dragging

### Interaction (wezterm model)
- **Drag thumb**: anchor-based — records offset on mousedown so the thumb follows the mouse exactly with no jump on initial click
- **Click above thumb**: page up (scroll by viewport height)
- **Click below thumb**: page down
- Uses raw pointer events (not egui widgets) since terminal content allocation blocks ui.interact()
- Text selection excluded from the scrollbar hit zone (rightmost 16px)

### Scroll state tracking
- `scroll_offset` tracked even when ghostty manages scrolling internally, so the scrollbar has a position to render
- Reset when new PTY output arrives and ghostty auto-scrolls to bottom (prevents stuck-visible state)
- Absolute positioning for drag (scroll_to_bottom + scroll_viewport) to avoid drift from incremental deltas

Fixes #239

## Test plan

- [ ] Scroll up — scrollbar appears, thumb moves proportionally
- [ ] Stop scrolling — scrollbar fades after 1.5s
- [ ] Drag thumb — smooth, no jump on initial click, follows mouse exactly
- [ ] Click above/below thumb — pages up/down
- [ ] New output while scrolled up — scrollbar resets to bottom
- [ ] Hover scrollbar zone — scrollbar stays visible
- [ ] Short output (fits on screen) — no scrollbar
- [ ] Split panes — each has independent scrollbar