### PR TITLE
Remove navigation flash on pane focus change

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -44,9 +44,7 @@ use amux_core::model::{DragState, SidebarState, Workspace};
 use amux_core::shell;
 use amux_ipc::IpcCommand;
 use amux_layout::{NavDirection, PaneId, PaneTree, SplitDirection};
-use amux_notify::{
-    flash_alpha, FlashReason, NotificationSource, NotificationStore, FLASH_DURATION,
-};
+use amux_notify::{flash_alpha, NotificationSource, NotificationStore, FLASH_DURATION};
 use amux_session::SessionData;
 use amux_term::config::AmuxTermConfig;
 use amux_term::font;
@@ -377,19 +375,7 @@ impl AmuxApp {
 
             // Clear notifications on the newly focused pane
             self.notifications.mark_pane_read(pane_id);
-            // Navigation flash — but suppress if other panes have unread
-            let pane_ids: Vec<u64> = self.active_workspace().tree.iter_panes();
-            if !self.notifications.has_unread_excluding(&pane_ids, pane_id) {
-                self.notifications
-                    .flash_pane(pane_id, FlashReason::Navigation);
-            }
         }
-    }
-
-    fn flash_focus(&mut self) {
-        let pane_id = self.focused_pane_id();
-        self.notifications
-            .flash_pane(pane_id, FlashReason::Navigation);
     }
 
     fn focused_pane_id(&self) -> PaneId {

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -1014,10 +1014,7 @@ impl AmuxApp {
                 let elapsed = started.elapsed().as_secs_f32();
                 if elapsed < FLASH_DURATION {
                     let alpha = flash_alpha(elapsed);
-                    let base_color = match state.flash_reason {
-                        Some(FlashReason::Navigation) => [0u8, 128, 128], // teal
-                        _ => [40, 120, 255],                              // blue
-                    };
+                    let base_color = [40u8, 120, 255]; // blue
                     let glow_alpha = (alpha * 0.6 * 255.0) as u8;
                     let ring_alpha = (alpha * 255.0) as u8;
                     // Glow (wider, more transparent). Anchor on ring_rect with

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -445,8 +445,6 @@ impl AmuxApp {
             let ws = self.active_workspace();
             if let Some(neighbor) = ws.tree.neighbor(ws.focused_pane, dir, rect) {
                 self.set_focus(neighbor);
-            } else {
-                self.flash_focus();
             }
         }
         true

--- a/crates/amux-notify/src/store.rs
+++ b/crates/amux-notify/src/store.rs
@@ -582,9 +582,9 @@ mod tests {
     #[test]
     fn flash_pane_sets_flash() {
         let mut store = NotificationStore::new();
-        store.flash_pane(10, FlashReason::Navigation);
+        store.flash_pane(10, FlashReason::NotificationArrival);
         let state = store.pane_state(10).unwrap();
-        assert_eq!(state.flash_reason, Some(FlashReason::Navigation));
+        assert_eq!(state.flash_reason, Some(FlashReason::NotificationArrival));
         assert!(state.flash_started_at.is_some());
         assert_eq!(state.unread_count, 0);
     }

--- a/crates/amux-notify/src/types.rs
+++ b/crates/amux-notify/src/types.rs
@@ -39,8 +39,6 @@ impl NotificationSource {
 /// Why a pane is flashing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlashReason {
-    /// Pane received focus via keyboard nav or click (teal).
-    Navigation,
     /// A notification just arrived (blue).
     NotificationArrival,
     /// A notification was dismissed (blue).


### PR DESCRIPTION
## Summary

Remove the teal "navigation flash" that fired every time the user switched focus between split panes. It was visual noise — indistinguishable from a real notification to the user.

Blue notification flashes (NotificationArrival, NotificationDismiss) are unaffected.

Fixes #241

## Test plan

- [ ] Split panes, click between them — no flash
- [ ] Keyboard navigate between panes — no flash
- [ ] Trigger a real notification — blue flash still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified pane notification flash behavior with consistent visual styling.
  * Panes are now automatically marked as read when they receive focus.
  * Removed feedback animation when navigation fails due to no available neighboring pane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->