### PR TITLE
Clear notifications on pane click and keyboard workspace switch

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -435,15 +435,22 @@ impl eframe::App for AmuxApp {
                     if ui.input(|i| i.pointer.primary_pressed()) {
                         if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
                             for &(id, rect) in &layout {
-                                if rect.contains(pos) && id != focused {
-                                    // Clear selection on old pane
-                                    let old_focused = focused;
-                                    if let Some(PaneEntry::Terminal(m)) =
-                                        self.panes.get_mut(&old_focused)
-                                    {
-                                        m.selection = None;
+                                if rect.contains(pos) {
+                                    if id != focused {
+                                        // Clear selection on old pane
+                                        let old_focused = focused;
+                                        if let Some(PaneEntry::Terminal(m)) =
+                                            self.panes.get_mut(&old_focused)
+                                        {
+                                            m.selection = None;
+                                        }
+                                        self.set_focus(id);
+                                    } else {
+                                        // Clicking the already-focused pane: clear
+                                        // any unread notifications so the sidebar
+                                        // badge disappears.
+                                        self.notifications.mark_pane_read(id);
                                     }
-                                    self.set_focus(id);
                                     break;
                                 }
                             }

--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -364,6 +364,8 @@ impl AmuxApp {
                     if self.workspaces.len() > 1 {
                         self.active_workspace_idx =
                             (self.active_workspace_idx + 1) % self.workspaces.len();
+                        let pane_ids: Vec<u64> = self.active_workspace().tree.iter_panes();
+                        self.notifications.mark_workspace_read(&pane_ids);
                     }
                     return true;
                 }
@@ -376,6 +378,8 @@ impl AmuxApp {
                         } else {
                             self.active_workspace_idx - 1
                         };
+                        let pane_ids: Vec<u64> = self.active_workspace().tree.iter_panes();
+                        self.notifications.mark_workspace_read(&pane_ids);
                     }
                     return true;
                 }
@@ -405,6 +409,8 @@ impl AmuxApp {
                         }
                         if idx < self.workspaces.len() {
                             self.active_workspace_idx = idx;
+                            let pane_ids: Vec<u64> = self.workspaces[idx].tree.iter_panes();
+                            self.notifications.mark_workspace_read(&pane_ids);
                             return true;
                         }
                     }


### PR DESCRIPTION
## Summary

Three gaps in notification clearing:

1. **Clicking the already-focused pane** skipped `set_focus()` (guarded by `id != focused`), so `mark_pane_read()` never ran. The ring hid visually but the sidebar badge persisted.
2. **Next/prev workspace shortcuts** changed `active_workspace_idx` without calling `mark_workspace_read()`.
3. **Jump-to-workspace (Cmd+1-9)** same issue.

Now all paths clear notifications consistently.

Fixes #243

## Test plan

- [ ] Single-pane workspace with notification → click the pane → sidebar badge clears
- [ ] Split panes, notification on pane B → click pane B → badge clears
- [ ] Keyboard next/prev workspace → target workspace's notifications clear
- [ ] Cmd+1-9 jump → target workspace's notifications clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)