### PR TITLE
Remove notification and workspace status persistence

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -637,52 +637,6 @@ impl AmuxApp {
             });
         }
 
-        let notifications: Vec<amux_session::SavedNotification> = self
-            .notifications
-            .all_notifications()
-            .iter()
-            .map(|n| amux_session::SavedNotification {
-                id: n.id,
-                workspace_id: n.workspace_id,
-                pane_id: n.pane_id,
-                surface_id: n.surface_id,
-                title: n.title.clone(),
-                subtitle: n.subtitle.clone(),
-                body: n.body.clone(),
-                source: match n.source {
-                    NotificationSource::Toast => "toast",
-                    NotificationSource::Bell => "bell",
-                    NotificationSource::Cli => "cli",
-                }
-                .to_string(),
-                read: n.read,
-            })
-            .collect();
-
-        let workspace_statuses: std::collections::HashMap<u64, amux_session::SavedWorkspaceStatus> =
-            self.workspaces
-                .iter()
-                .filter_map(|ws| {
-                    self.notifications.workspace_status(ws.id).map(|status| {
-                        (
-                            ws.id,
-                            amux_session::SavedWorkspaceStatus {
-                                state: match status.state {
-                                    amux_notify::AgentState::Active => "active",
-                                    amux_notify::AgentState::Waiting => "waiting",
-                                    amux_notify::AgentState::Idle => "idle",
-                                }
-                                .to_string(),
-                                label: status.label.clone(),
-                                // task/message are transient agent state — don't persist
-                                task: None,
-                                message: None,
-                            },
-                        )
-                    })
-                })
-                .collect();
-
         SessionData {
             version: 1,
             saved_at: chrono_now(),
@@ -695,8 +649,6 @@ impl AmuxApp {
                 visible: self.sidebar.visible,
                 width: self.sidebar.width,
             },
-            notifications,
-            workspace_statuses,
         }
     }
 }

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -766,28 +766,10 @@ pub(crate) fn restore_session(
         drag: None,
     };
 
-    // Restore only already-read notifications (unread ones are stale — the
-    // agent that created them is gone after restart).
-    let mut store = NotificationStore::new();
-    for saved_n in &session.notifications {
-        if !saved_n.read {
-            continue;
-        }
-        let source = match saved_n.source.as_str() {
-            "toast" => NotificationSource::Toast,
-            "bell" => NotificationSource::Bell,
-            _ => NotificationSource::Cli,
-        };
-        store.push_restored(
-            saved_n.workspace_id,
-            saved_n.pane_id,
-            saved_n.surface_id,
-            saved_n.title.clone(),
-            saved_n.subtitle.clone(),
-            saved_n.body.clone(),
-            source,
-        );
-    }
+    // Don't restore notifications — they're from dead agent sessions
+    // that can't be reattached. Starting fresh avoids stale unread
+    // badges in the sidebar. See #244.
+    let store = NotificationStore::new();
 
     // Don't restore workspace statuses — agent processes don't survive restart,
     // so any Active/Waiting state would be stale. They start as Idle implicitly.

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -63,10 +63,6 @@ pub struct SessionData {
     pub next_workspace_id: u64,
     pub next_surface_id: u64,
     pub sidebar: SavedSidebar,
-    #[serde(default)]
-    pub notifications: Vec<SavedNotification>,
-    #[serde(default)]
-    pub workspace_statuses: HashMap<u64, SavedWorkspaceStatus>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -172,31 +168,6 @@ pub struct SavedSurface {
 pub struct SavedSidebar {
     pub visible: bool,
     pub width: f32,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SavedNotification {
-    pub id: u64,
-    pub workspace_id: u64,
-    pub pane_id: u64,
-    pub surface_id: u64,
-    pub title: String,
-    #[serde(default)]
-    pub subtitle: String,
-    pub body: String,
-    pub source: String,
-    pub read: bool,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SavedWorkspaceStatus {
-    pub state: String,
-    #[serde(default)]
-    pub label: Option<String>,
-    #[serde(default)]
-    pub task: Option<String>,
-    #[serde(default)]
-    pub message: Option<String>,
 }
 
 // --- File Operations ---
@@ -339,8 +310,6 @@ mod tests {
                 visible: true,
                 width: 200.0,
             },
-            notifications: vec![],
-            workspace_statuses: HashMap::new(),
         }
     }
 
@@ -540,21 +509,5 @@ mod tests {
         let result = truncate_scrollback(text, 10);
         // excess=6, no newline found, returns text[6..] = "ghijklmnop"
         assert_eq!(result, "ghijklmnop");
-    }
-
-    #[test]
-    fn deserialize_notification_without_subtitle_defaults_empty() {
-        let json = r#"{
-            "id": 1,
-            "workspace_id": 1,
-            "pane_id": 10,
-            "surface_id": 100,
-            "title": "T",
-            "body": "B",
-            "source": "cli",
-            "read": false
-        }"#;
-        let n: SavedNotification = serde_json::from_str(json).unwrap();
-        assert_eq!(n.subtitle, "");
     }
 }


### PR DESCRIPTION
## Summary

Notifications and workspace statuses are no longer saved to or restored from the session file. Agents don't survive restart, so restored state was stale noise — unread badges from dead sessions, Active/Waiting pills for agents that aren't running.

Removed entirely: `SavedNotification`, `SavedWorkspaceStatus`, both fields on `SessionData`, all save/restore code, related test. 117 lines deleted.

Old session files still load fine — serde ignores unknown fields.

Fixes #244

## Test plan

- [ ] Close and relaunch amux — no stale notification badges in sidebar
- [ ] Old session file with notification data — loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)