### PR TITLE
Hot-reload font_family

### DIFF
--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -574,10 +574,10 @@ impl AmuxApp {
         // Font size
         // Font family
         if new_config.font_family != self.app_config.font_family {
+            self.font_size = new_config.font_size;
             #[cfg(feature = "gpu-renderer")]
             if let Some(gpu) = &mut self.gpu_renderer {
                 gpu.set_font_family(&new_config.font_family, new_config.font_size);
-                self.font_size = new_config.font_size;
             }
             tracing::info!("Hot-reloaded font_family: {}", new_config.font_family);
         } else if (new_config.font_size - self.app_config.font_size).abs() > f32::EPSILON {

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -572,7 +572,16 @@ impl AmuxApp {
         // Apply hot-reloadable fields:
 
         // Font size
-        if (new_config.font_size - self.app_config.font_size).abs() > f32::EPSILON {
+        // Font family
+        if new_config.font_family != self.app_config.font_family {
+            #[cfg(feature = "gpu-renderer")]
+            if let Some(gpu) = &mut self.gpu_renderer {
+                gpu.set_font_family(&new_config.font_family, new_config.font_size);
+                self.font_size = new_config.font_size;
+            }
+            tracing::info!("Hot-reloaded font_family: {}", new_config.font_family);
+        } else if (new_config.font_size - self.app_config.font_size).abs() > f32::EPSILON {
+            // Font size (only if family didn't change — set_font_family handles both)
             self.font_size = new_config.font_size;
             #[cfg(feature = "gpu-renderer")]
             if let Some(gpu) = &mut self.gpu_renderer {
@@ -613,16 +622,13 @@ impl AmuxApp {
         tracing::info!("Hot-reloaded theme/colors");
 
         // Store the full new config but preserve non-hot-reloadable fields
-        // (keybindings, shell, menu_bar_style, font_family require a restart
-        // or a FontSystem rebuild — see issue #216).
+        // (keybindings, shell, menu_bar_style require a restart).
         let keybindings_saved = self.app_config.keybindings.clone();
         let shell_saved = self.app_config.shell.clone();
         let menu_bar_style_saved = self.app_config.menu_bar_style;
-        let font_family_saved = self.app_config.font_family.clone();
         self.app_config = new_config;
         self.app_config.keybindings = keybindings_saved;
         self.app_config.shell = shell_saved;
         self.app_config.menu_bar_style = menu_bar_style_saved;
-        self.app_config.font_family = font_family_saved;
     }
 }

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -145,10 +145,9 @@ impl GpuRenderer {
         self.cell_height
     }
 
-    /// Update font size, re-measure cell dimensions, and invalidate caches.
     /// Replace the font family. Creates a new `FontSystem`, recalculates
-    /// cell metrics, and invalidates all caches. If the font isn't found,
-    /// cosmic-text falls back to the system default (logged by the caller).
+    /// cell metrics, and invalidates all caches. If the requested family
+    /// isn't installed, cosmic-text silently falls back to its default.
     pub fn set_font_family(&mut self, family: &str, font_size: f32) {
         let config = FontConfig {
             family: family.to_string(),

--- a/crates/amux-render-gpu/src/lib.rs
+++ b/crates/amux-render-gpu/src/lib.rs
@@ -146,6 +146,40 @@ impl GpuRenderer {
     }
 
     /// Update font size, re-measure cell dimensions, and invalidate caches.
+    /// Replace the font family. Creates a new `FontSystem`, recalculates
+    /// cell metrics, and invalidates all caches. If the font isn't found,
+    /// cosmic-text falls back to the system default (logged by the caller).
+    pub fn set_font_family(&mut self, family: &str, font_size: f32) {
+        let config = FontConfig {
+            family: family.to_string(),
+            size: font_size,
+        };
+        let mut new_font_system = font::create_font_system(&config);
+        let line_height = (font_size * 1.3).ceil();
+        let metrics = Metrics::new(font_size, line_height);
+
+        if let Some(r) = self
+            .render_state
+            .renderer
+            .write()
+            .callback_resources
+            .get_mut::<TerminalGpuResources>()
+        {
+            let cell_width = font::measure_cell_width(&mut new_font_system, metrics);
+            r.font_system = new_font_system;
+            r.swash_cache = SwashCache::new();
+            r.metrics = metrics;
+            r.decoration_metrics = font::measure_decoration_metrics(&mut r.font_system, font_size);
+            r.pane_states.clear();
+            r.shape_cache.clear();
+            r.curly_tile = None;
+            r.dotted_tile = None;
+            r.atlas_bind_group_dirty = true;
+            self.cell_width = cell_width;
+            self.cell_height = line_height;
+        }
+    }
+
     pub fn set_font_size(&mut self, font_size: f32) {
         let line_height = (font_size * 1.3).ceil();
         let metrics = Metrics::new(font_size, line_height);


### PR DESCRIPTION
## Summary

Changing `font_family` in `~/.amux/config.toml` now takes effect live within 2 seconds, without restarting amux.

New `GpuRenderer::set_font_family()` creates a fresh `FontSystem` with the new family, replaces it in `TerminalGpuResources`, resets the `SwashCache`, recalculates cell metrics, and clears all caches.

Fixes #216

## Test plan

- [ ] Edit `font_family` in config → terminal font changes within 2s
- [ ] Change to a non-existent font → cosmic-text falls back to system default
- [ ] Change font_family AND font_size at once → both apply
- [ ] Change only font_size (no family change) → still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)