### PR TITLE
Make chrome colors configurable: accent, sidebar, notification ring, pane dim

### DIFF
--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -789,6 +789,7 @@ impl AmuxApp {
             &find_highlights,
             current_highlight,
             cursor_blink_on,
+            self.theme.chrome.pane_dim_alpha,
             #[cfg(feature = "gpu-renderer")]
             self.gpu_renderer.as_ref(),
             #[cfg(feature = "gpu-renderer")]
@@ -998,7 +999,8 @@ impl AmuxApp {
         // 1. Persistent unread ring (NOT on focused pane, NOT during flash)
         if !is_focused && !flash_active && self.notifications.pane_unread(pane_u64) > 0 {
             // Steady blue ring with glow
-            let ring_color = egui::Color32::from_rgba_unmultiplied(40, 120, 255, 89); // 0.35 * 255
+            let rc = self.theme.chrome.notification_ring;
+            let ring_color = egui::Color32::from_rgba_unmultiplied(rc.r(), rc.g(), rc.b(), 89);
             ui.painter().rect_stroke(
                 ring_rect,
                 6.0,
@@ -1014,7 +1016,8 @@ impl AmuxApp {
                 let elapsed = started.elapsed().as_secs_f32();
                 if elapsed < FLASH_DURATION {
                     let alpha = flash_alpha(elapsed);
-                    let base_color = [40u8, 120, 255]; // blue
+                    let rc = self.theme.chrome.notification_ring;
+                    let base_color = [rc.r(), rc.g(), rc.b()];
                     let glow_alpha = (alpha * 0.6 * 255.0) as u8;
                     let ring_alpha = (alpha * 255.0) as u8;
                     // Glow (wider, more transparent). Anchor on ring_rect with

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -998,7 +998,7 @@ impl AmuxApp {
 
         // 1. Persistent unread ring (NOT on focused pane, NOT during flash)
         if !is_focused && !flash_active && self.notifications.pane_unread(pane_u64) > 0 {
-            // Steady blue ring with glow
+            // Steady notification ring using the configured theme color
             let rc = self.theme.chrome.notification_ring;
             let ring_color = egui::Color32::from_rgba_unmultiplied(rc.r(), rc.g(), rc.b(), 89);
             ui.painter().rect_stroke(

--- a/crates/amux-app/src/render.rs
+++ b/crates/amux-app/src/render.rs
@@ -24,6 +24,7 @@ pub(crate) fn render_pane(
     find_highlights: &[(usize, usize, usize)],
     current_highlight: Option<usize>,
     cursor_blink_on: bool,
+    pane_dim_alpha: u8,
     #[cfg(feature = "gpu-renderer")] gpu_renderer: Option<&GpuRenderer>,
     #[cfg(feature = "gpu-renderer")] pane_id: u64,
 ) {
@@ -90,7 +91,7 @@ pub(crate) fn render_pane(
 
     // Dim unfocused panes with a semi-transparent overlay
     if !is_focused {
-        let dim_overlay = egui::Color32::from_rgba_unmultiplied(0, 0, 0, 100);
+        let dim_overlay = egui::Color32::from_rgba_unmultiplied(0, 0, 0, pane_dim_alpha);
         painter.rect_filled(rect, 0.0, dim_overlay);
     }
 

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -38,7 +38,7 @@ pub(crate) struct ChromeColors {
     pub tab_border: Color32,
     pub divider: Color32,
     pub accent: Color32,
-    /// Notification ring color (blue ring on panes with unread notifications).
+    /// Notification ring shown on panes with unread notifications.
     pub notification_ring: Color32,
     /// Unfocused pane dim overlay alpha (0 = no dimming, 255 = fully opaque).
     pub pane_dim_alpha: u8,

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -38,6 +38,10 @@ pub(crate) struct ChromeColors {
     pub tab_border: Color32,
     pub divider: Color32,
     pub accent: Color32,
+    /// Notification ring color (blue ring on panes with unread notifications).
+    pub notification_ring: Color32,
+    /// Unfocused pane dim overlay alpha (0 = no dimming, 255 = fully opaque).
+    pub pane_dim_alpha: u8,
 }
 
 /// Combined theme: terminal colors + UI chrome.
@@ -159,6 +163,8 @@ impl ChromeColors {
             tab_border: lighten_rgb(br, bg_g, bb, 0.15),
             divider: lighten_rgb(br, bg_g, bb, 0.18),
             accent,
+            notification_ring: Color32::from_rgb(40, 120, 255),
+            pane_dim_alpha: 100,
         }
     }
 }
@@ -206,6 +212,28 @@ impl Theme {
             if let Some(rgb) = config::ColorsConfig::parse_hex(hex) {
                 self.terminal.ansi[i] = rgb;
             }
+        }
+
+        // Chrome color overrides
+        if let Some(ref hex) = colors.accent {
+            if let Some([r, g, b]) = config::ColorsConfig::parse_hex(hex) {
+                let c = Color32::from_rgb(r, g, b);
+                self.chrome.accent = c;
+                self.chrome.sidebar_active_bg = c;
+            }
+        }
+        if let Some(ref hex) = colors.sidebar_bg {
+            if let Some([r, g, b]) = config::ColorsConfig::parse_hex(hex) {
+                self.chrome.sidebar_bg = Color32::from_rgb(r, g, b);
+            }
+        }
+        if let Some(ref hex) = colors.notification_ring {
+            if let Some([r, g, b]) = config::ColorsConfig::parse_hex(hex) {
+                self.chrome.notification_ring = Color32::from_rgb(r, g, b);
+            }
+        }
+        if let Some(alpha) = colors.pane_dim_alpha {
+            self.chrome.pane_dim_alpha = alpha;
         }
     }
 }
@@ -292,6 +320,8 @@ impl Default for Theme {
                 tab_border: Color32::from_rgb(0x3a, 0x3c, 0x43),
                 divider: Color32::from_rgb(0x3a, 0x3c, 0x43),
                 accent: Color32::from_rgb(0x3d, 0x7d, 0xff),
+                notification_ring: Color32::from_rgb(40, 120, 255),
+                pane_dim_alpha: 100,
             },
         }
     }

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -28,7 +28,7 @@ pub struct ColorsConfig {
     pub accent: Option<String>,
     /// Sidebar background color.
     pub sidebar_bg: Option<String>,
-    /// Notification ring color (the blue ring on panes with unread notifications).
+    /// Notification ring color (the ring shown on panes with unread notifications).
     pub notification_ring: Option<String>,
     /// Unfocused pane dim overlay alpha (0 = no dimming, 255 = fully opaque).
     /// Default: 100 (~39% opacity black overlay).

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -22,6 +22,17 @@ pub struct ColorsConfig {
     /// e.g. palette = ["#000000", "#cc0000", ...] for colors 0, 1, etc.
     #[serde(default)]
     pub palette: Vec<String>,
+
+    // --- Chrome colors ---
+    /// Accent color for active workspace highlight and active tab indicator.
+    pub accent: Option<String>,
+    /// Sidebar background color.
+    pub sidebar_bg: Option<String>,
+    /// Notification ring color (the blue ring on panes with unread notifications).
+    pub notification_ring: Option<String>,
+    /// Unfocused pane dim overlay alpha (0 = no dimming, 255 = fully opaque).
+    /// Default: 100 (~39% opacity black overlay).
+    pub pane_dim_alpha: Option<u8>,
 }
 
 impl ColorsConfig {

--- a/resources/default-config.toml
+++ b/resources/default-config.toml
@@ -73,6 +73,12 @@ palette = [
     "#fdfff1",  # 15 bright white
 ]
 
+# Chrome / UI accent colors
+accent           = "#3d7dff"   # active workspace highlight + active tab indicator
+sidebar_bg       = "#1d1f25"   # sidebar background
+notification_ring = "#2878ff"  # blue ring on panes with unread notifications
+pane_dim_alpha   = 100         # unfocused pane overlay opacity (0-255, 0=none, 255=black)
+
 # ── Notifications ─────────────────────────────────────────────────────────────
 
 [notifications]

--- a/resources/default-config.toml
+++ b/resources/default-config.toml
@@ -76,7 +76,7 @@ palette = [
 # Chrome / UI accent colors
 accent           = "#3d7dff"   # active workspace highlight + active tab indicator
 sidebar_bg       = "#1d1f25"   # sidebar background
-notification_ring = "#2878ff"  # blue ring on panes with unread notifications
+notification_ring = "#2878ff"  # ring on panes with unread notifications
 pane_dim_alpha   = 100         # unfocused pane overlay opacity (0-255, 0=none, 255=black)
 
 # ── Notifications ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Four new fields in the `[colors]` config section, all hot-reloadable:

| Field | Default | Controls |
|---|---|---|
| `accent` | `#3d7dff` | Active workspace highlight + active tab indicator |
| `sidebar_bg` | `#1d1f25` | Sidebar background |
| `notification_ring` | `#2878ff` | Blue ring on panes with unread notifications |
| `pane_dim_alpha` | `100` | Unfocused pane overlay opacity (0=none, 255=black) |

All defaults match previous hardcoded values — no visual change unless overridden.

## Test plan

- [ ] Edit `accent` in config → workspace highlight + tab indicator change
- [ ] Edit `sidebar_bg` → sidebar background changes
- [ ] Edit `notification_ring` → trigger a notification, ring shows new color
- [ ] Edit `pane_dim_alpha` → split panes, unfocused pane dimming changes
- [ ] Delete all four fields → defaults apply, looks the same as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)