### PR TITLE
Fix idle icon box on Windows: remove variation selector

### DIFF
--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -588,7 +588,7 @@ fn render_workspace_row(
         let (icon, default_text) = match status.state {
             amux_notify::AgentState::Active => ("\u{26A1}", "Running"), // ⚡
             amux_notify::AgentState::Waiting => ("\u{1F514}", "Needs input"), // 🔔
-            amux_notify::AgentState::Idle => ("\u{23F8}\u{FE0E}", "Idle"), // ⏸︎
+            amux_notify::AgentState::Idle => ("\u{23F8}", "Idle"), // ⏸ (no variation selector — FE0E renders as box on Windows)
         };
         let label = status.label.as_deref().unwrap_or(default_text);
         content_bottom += 4.0;


### PR DESCRIPTION
U+FE0E (Variation Selector 15) renders as a visible box on Windows instead of being invisible. Remove it — ⏸ renders correctly without it.

Fixes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the appearance of the idle status indicator in the sidebar for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->