### PR TITLE
Fix notifications: always visible for notify.send + agent hooks

### DIFF
--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -948,18 +948,41 @@ impl AmuxApp {
                             .pane_id
                             .parse::<u64>()
                             .unwrap_or(self.focused_pane_id());
+                        let surface_id = params
+                            .surface_id
+                            .as_ref()
+                            .and_then(|s| s.parse::<u64>().ok())
+                            .unwrap_or(0);
                         let title = params.title.unwrap_or_default();
                         let subtitle = params.subtitle.unwrap_or_default();
-                        let nid = self.deliver_notification(
+                        // Explicit notify.send always creates an unread
+                        // notification — no Tier 3 suppression. If
+                        // someone (agent, user, hook) explicitly sends
+                        // a notification, it should always be visible:
+                        // ring, badge, reorder, sound, system toast.
+                        // The user might be looking at scrollback, a
+                        // different part of the screen, or just not
+                        // paying attention.
+                        let nid = self.notifications.push(
                             ws_id,
                             pane_id,
-                            0,
-                            title,
+                            surface_id,
+                            title.clone(),
                             subtitle,
-                            params.body,
+                            params.body.clone(),
                             NotificationSource::Cli,
-                            false,
                         );
+                        if self.app_config.notifications.auto_reorder_workspaces {
+                            self.bubble_workspace(ws_id);
+                        }
+                        // System toast + sound (same as Tier 1/2)
+                        if self.app_config.notifications.system_notifications {
+                            self.system_notifier
+                                .send(&title, &params.body, ws_id, pane_id);
+                        }
+                        if let Some(player) = &self.sound_player {
+                            player.play();
+                        }
                         Response::ok(req.id.clone(), serde_json::json!({"notification_id": nid}))
                     }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),

--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -944,10 +944,26 @@ impl AmuxApp {
                 ) {
                     Ok(params) => {
                         let ws_id = params.workspace_id.parse::<u64>().unwrap_or(0);
-                        let pane_id = params
-                            .pane_id
-                            .parse::<u64>()
-                            .unwrap_or(self.focused_pane_id());
+                        // The CLI sends AMUX_SURFACE_ID as pane_id (since
+                        // there's no AMUX_PANE_ID env var). Resolve the
+                        // actual pane_id by searching for a managed pane
+                        // that contains a surface with this ID.
+                        let raw_id = params.pane_id.parse::<u64>().unwrap_or(0);
+                        let pane_id = self
+                            .panes
+                            .iter()
+                            .find_map(|(&pid, entry)| {
+                                if pid == raw_id {
+                                    return Some(pid);
+                                }
+                                if let PaneEntry::Terminal(managed) = entry {
+                                    if managed.surfaces().any(|s| s.id == raw_id) {
+                                        return Some(pid);
+                                    }
+                                }
+                                None
+                            })
+                            .unwrap_or_else(|| self.focused_pane_id());
                         let surface_id = params
                             .surface_id
                             .as_ref()

--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -944,26 +944,33 @@ impl AmuxApp {
                 ) {
                     Ok(params) => {
                         let ws_id = params.workspace_id.parse::<u64>().unwrap_or(0);
-                        // The CLI sends AMUX_SURFACE_ID as pane_id (since
-                        // there's no AMUX_PANE_ID env var). Resolve the
-                        // actual pane_id by searching for a managed pane
-                        // that contains a surface with this ID.
-                        let raw_id = params.pane_id.parse::<u64>().unwrap_or(0);
-                        let pane_id = self
-                            .panes
-                            .iter()
-                            .find_map(|(&pid, entry)| {
-                                if pid == raw_id {
-                                    return Some(pid);
-                                }
-                                if let PaneEntry::Terminal(managed) = entry {
-                                    if managed.surfaces().any(|s| s.id == raw_id) {
+                        // Resolve pane_id: CLI may send a surface ID, a
+                        // pane ID, or nothing. Search managed panes for
+                        // a match by pane ID or surface ID, then fall
+                        // back to the focused pane.
+                        let raw_id = params
+                            .pane_id
+                            .as_ref()
+                            .and_then(|s| s.parse::<u64>().ok())
+                            .unwrap_or(0);
+                        let pane_id = if raw_id == 0 {
+                            self.focused_pane_id()
+                        } else {
+                            self.panes
+                                .iter()
+                                .find_map(|(&pid, entry)| {
+                                    if pid == raw_id {
                                         return Some(pid);
                                     }
-                                }
-                                None
-                            })
-                            .unwrap_or_else(|| self.focused_pane_id());
+                                    if let PaneEntry::Terminal(managed) = entry {
+                                        if managed.surfaces().any(|s| s.id == raw_id) {
+                                            return Some(pid);
+                                        }
+                                    }
+                                    None
+                                })
+                                .unwrap_or_else(|| self.focused_pane_id())
+                        };
                         let surface_id = params
                             .surface_id
                             .as_ref()
@@ -971,34 +978,46 @@ impl AmuxApp {
                             .unwrap_or(0);
                         let title = params.title.unwrap_or_default();
                         let subtitle = params.subtitle.unwrap_or_default();
+                        let body = params.body;
                         // Explicit notify.send always creates an unread
                         // notification — no Tier 3 suppression. If
                         // someone (agent, user, hook) explicitly sends
-                        // a notification, it should always be visible:
-                        // ring, badge, reorder, sound, system toast.
-                        // The user might be looking at scrollback, a
-                        // different part of the screen, or just not
-                        // paying attention.
+                        // a notification, it should always be visible.
                         let nid = self.notifications.push(
                             ws_id,
                             pane_id,
                             surface_id,
                             title.clone(),
-                            subtitle,
-                            params.body.clone(),
+                            subtitle.clone(),
+                            body.clone(),
                             NotificationSource::Cli,
                         );
                         if self.app_config.notifications.auto_reorder_workspaces {
                             self.bubble_workspace(ws_id);
                         }
-                        // System toast + sound (same as Tier 1/2)
+                        // System toast + sound + custom command
                         if self.app_config.notifications.system_notifications {
-                            self.system_notifier
-                                .send(&title, &params.body, ws_id, pane_id);
+                            self.system_notifier.send(&title, &body, ws_id, pane_id);
                         }
                         if let Some(player) = &self.sound_player {
                             player.play();
                         }
+                        if let Some(cmd) = &self.app_config.notifications.custom_command {
+                            self.system_notifier
+                                .run_custom_command(cmd, &title, &body, "cli");
+                        }
+                        // Broadcast to IPC subscribers
+                        self.event_broadcaster.send(amux_ipc::ServerEvent {
+                            event: "notification".to_string(),
+                            data: serde_json::json!({
+                                "notification_id": nid,
+                                "workspace_id": ws_id,
+                                "pane_id": pane_id,
+                                "title": title,
+                                "subtitle": subtitle,
+                                "body": body,
+                            }),
+                        });
                         Response::ok(req.id.clone(), serde_json::json!({"notification_id": nid}))
                     }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),

--- a/crates/amux-cli/src/claude_hook.rs
+++ b/crates/amux-cli/src/claude_hook.rs
@@ -124,6 +124,29 @@ pub async fn handle_claude_hook(client: &mut IpcClient, event: &str) -> anyhow::
     if let Some(params) = status_update_for(event, &data, &ws_id) {
         client.call("status.set", params).await?;
     }
+
+    // "Notification" means Claude needs input. In addition to updating
+    // the status pill (above), deliver a stored notification so the
+    // pane ring, sidebar badge, and auto_reorder_workspaces all fire.
+    if event == "Notification" {
+        let surface_id = std::env::var("AMUX_SURFACE_ID").unwrap_or_else(|_| "0".to_string());
+        let message = data
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Needs input");
+        let _ = client
+            .call(
+                "notify.send",
+                json!({
+                    "workspace_id": ws_id,
+                    "surface_id": surface_id,
+                    "title": "Claude Code",
+                    "body": message,
+                }),
+            )
+            .await;
+    }
+
     Ok(())
 }
 

--- a/crates/amux-cli/src/claude_hook.rs
+++ b/crates/amux-cli/src/claude_hook.rs
@@ -130,6 +130,7 @@ pub async fn handle_claude_hook(client: &mut IpcClient, event: &str) -> anyhow::
     // pane ring, sidebar badge, and auto_reorder_workspaces all fire.
     if event == "Notification" {
         let surface_id = std::env::var("AMUX_SURFACE_ID").unwrap_or_else(|_| "0".to_string());
+        let pane_id = surface_id.clone();
         let message = data
             .get("message")
             .and_then(|v| v.as_str())
@@ -139,6 +140,7 @@ pub async fn handle_claude_hook(client: &mut IpcClient, event: &str) -> anyhow::
                 "notify.send",
                 json!({
                     "workspace_id": ws_id,
+                    "pane_id": pane_id,
                     "surface_id": surface_id,
                     "title": "Claude Code",
                     "body": message,

--- a/crates/amux-cli/src/gemini_hook.rs
+++ b/crates/amux-cli/src/gemini_hook.rs
@@ -151,14 +151,20 @@ pub async fn handle_gemini_hook(client: &mut IpcClient, event: &str) -> anyhow::
     // auto_reorder_workspaces all fire.
     if event == "Notification" {
         let surface_id = std::env::var("AMUX_SURFACE_ID").unwrap_or_else(|_| "0".to_string());
+        let pane_id = surface_id.clone();
+        let message = data
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Needs input");
         let _ = client
             .call(
                 "notify.send",
                 json!({
                     "workspace_id": ws_id,
+                    "pane_id": pane_id,
                     "surface_id": surface_id,
                     "title": "Gemini CLI",
-                    "body": "Needs input",
+                    "body": message,
                 }),
             )
             .await;

--- a/crates/amux-cli/src/gemini_hook.rs
+++ b/crates/amux-cli/src/gemini_hook.rs
@@ -139,12 +139,31 @@ fn truncate(s: &str, max: usize) -> String {
 pub async fn handle_gemini_hook(client: &mut IpcClient, event: &str) -> anyhow::Result<()> {
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input)?;
-    let data: Value = serde_json::from_str(&input).unwrap_or_default();
+    let data: Value = serde_json::from_str(&input).unwrap_or_else(|_| json!({}));
     let ws_id = std::env::var("AMUX_WORKSPACE_ID").unwrap_or_else(|_| "0".to_string());
 
     if let Some(params) = status_update_for(event, &data, &ws_id) {
         client.call("status.set", params).await?;
     }
+
+    // "Notification" means Gemini needs input. Deliver a stored
+    // notification so pane ring, sidebar badge, and
+    // auto_reorder_workspaces all fire.
+    if event == "Notification" {
+        let surface_id = std::env::var("AMUX_SURFACE_ID").unwrap_or_else(|_| "0".to_string());
+        let _ = client
+            .call(
+                "notify.send",
+                json!({
+                    "workspace_id": ws_id,
+                    "surface_id": surface_id,
+                    "title": "Gemini CLI",
+                    "body": "Needs input",
+                }),
+            )
+            .await;
+    }
+
     Ok(())
 }
 

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -738,7 +738,9 @@ async fn main() -> anyhow::Result<()> {
             let ws_id = workspace
                 .or_else(|| std::env::var("AMUX_WORKSPACE_ID").ok())
                 .unwrap_or_else(|| "0".to_string());
-            let pane_id = pane.unwrap_or_else(|| "0".to_string());
+            let pane_id = pane
+                .or_else(|| std::env::var("AMUX_SURFACE_ID").ok())
+                .unwrap_or_else(|| "0".to_string());
             let mut params = serde_json::json!({
                 "workspace_id": ws_id,
                 "pane_id": pane_id,

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -156,6 +156,8 @@ pub struct NotifySendParams {
     pub workspace_id: String,
     pub pane_id: String,
     #[serde(default)]
+    pub surface_id: Option<String>,
+    #[serde(default)]
     pub title: Option<String>,
     #[serde(default)]
     pub subtitle: Option<String>,

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -154,7 +154,8 @@ pub struct SetPrParams {
 #[derive(Debug, Deserialize)]
 pub struct NotifySendParams {
     pub workspace_id: String,
-    pub pane_id: String,
+    #[serde(default)]
+    pub pane_id: Option<String>,
     #[serde(default)]
     pub surface_id: Option<String>,
     #[serde(default)]


### PR DESCRIPTION
## Summary

Notifications from agents were completely broken — no ring, no badge, no reorder. Two root causes:

**1. Agent hooks never sent stored notifications**
Claude and Gemini hooks only called `status.set` on "Notification" events. No `notify.send` = no stored notification = no ring/badge/reorder.

**2. notify.send suppressed on focused pane**
The IPC `notify.send` path went through `deliver_notification` which has Tier 3 suppression: same-pane notifications get `push_read()` (marked read immediately, no ring). Since the agent runs IN the focused pane, every notification was silently suppressed.

## Fix

- Agent hooks now call `notify.send` alongside `status.set` for "Notification" events
- `notify.send` IPC bypasses `deliver_notification` entirely — always creates an unread notification with ring + badge + sound + system toast + workspace reorder, regardless of focus state

No Tier 3 suppression for explicit notifications. If someone/something explicitly sends a notification, it should always be visible.

Fixes #262, fixes #263

## Test plan

- [ ] Run Claude Code, let it ask for input → ring appears on pane, badge on workspace
- [ ] Be on a different workspace when notification fires → workspace reorders to top
- [ ] Be on the SAME pane when notification fires → ring still appears
- [ ] `amux notify "test"` from CLI → ring + badge + sound

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved notification system with enhanced surface and workspace routing
  * Claude Code and Gemini CLI integrations now emit notifications for relevant workflow events
  * System-level toast notifications support
  * Sound playback capability for notifications
  * Configurable automatic workspace reordering triggered by notification activity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->