### PR TITLE
Stop auto-clearing notifications on workspace switch

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -285,11 +285,6 @@ impl eframe::App for AmuxApp {
                 match action {
                     sidebar::SidebarAction::SwitchWorkspace(idx) => {
                         self.active_workspace_idx = idx;
-                        // Mark notifications read when switching to a workspace
-                        if idx < self.workspaces.len() {
-                            let pane_ids: Vec<u64> = self.workspaces[idx].tree.iter_panes();
-                            self.notifications.mark_workspace_read(&pane_ids);
-                        }
                     }
                     sidebar::SidebarAction::CreateWorkspace => {
                         self.create_workspace(None);

--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -364,8 +364,6 @@ impl AmuxApp {
                     if self.workspaces.len() > 1 {
                         self.active_workspace_idx =
                             (self.active_workspace_idx + 1) % self.workspaces.len();
-                        let pane_ids: Vec<u64> = self.active_workspace().tree.iter_panes();
-                        self.notifications.mark_workspace_read(&pane_ids);
                     }
                     return true;
                 }
@@ -378,8 +376,6 @@ impl AmuxApp {
                         } else {
                             self.active_workspace_idx - 1
                         };
-                        let pane_ids: Vec<u64> = self.active_workspace().tree.iter_panes();
-                        self.notifications.mark_workspace_read(&pane_ids);
                     }
                     return true;
                 }
@@ -409,8 +405,6 @@ impl AmuxApp {
                         }
                         if idx < self.workspaces.len() {
                             self.active_workspace_idx = idx;
-                            let pane_ids: Vec<u64> = self.workspaces[idx].tree.iter_panes();
-                            self.notifications.mark_workspace_read(&pane_ids);
                             return true;
                         }
                     }


### PR DESCRIPTION
## Summary

Workspace switch no longer auto-clears all notifications. Badge and ring persist until you click the specific pane. Pure deletion — 11 lines removed.

Fixes #267

## Test plan

- [x] Send delayed notification, switch away, switch back → badge still there
- [ ] Click the pane with the notification → ring clears
- [ ] "Mark All Read" context menu → still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Workspace switching no longer automatically marks all workspace notifications as read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->