### PR TITLE
Replace key encoder with libghostty-vt Encoder API

### DIFF
--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -1097,9 +1097,12 @@ impl AmuxApp {
                     key,
                     pressed: true,
                     modifiers,
+                    repeat,
                     ..
                 } => {
-                    if let Some(bytes) = key_encode::encode_egui_key(key, modifiers) {
+                    if let Some(bytes) =
+                        key_encode::encode_egui_key(&mut surface.pane, key, modifiers, *repeat)
+                    {
                         surface.snap_scroll_to_bottom();
                         let _ = surface.pane.write_bytes(&bytes);
                     }

--- a/crates/amux-app/src/key_encode.rs
+++ b/crates/amux-app/src/key_encode.rs
@@ -1,96 +1,221 @@
-//! Map egui keyboard events to terminal byte sequences.
+//! Map egui keyboard events to libghostty-vt key events for encoding.
+//!
+//! This module translates egui's key types into libghostty-vt's key types,
+//! then delegates to the terminal backend's encoder which handles all keyboard
+//! protocols (legacy VT, CSI-u, Kitty, modifyOtherKeys).
 
-/// Encode an egui key event into terminal escape bytes.
-pub(crate) fn encode_egui_key(key: &egui::Key, modifiers: &egui::Modifiers) -> Option<Vec<u8>> {
-    use amux_core::keys;
+use amux_term::key_types::{Action, Key, Mods};
+use amux_term::TerminalBackend;
 
-    // Ctrl+key / Alt+key / Ctrl+Alt+key
-    if let Some(byte) = egui_ctrl_byte(key) {
-        if modifiers.ctrl && !modifiers.alt {
-            return Some(keys::encode_ctrl(byte));
-        }
-        if modifiers.alt && !modifiers.ctrl {
-            return Some(keys::encode_alt_char(byte - 1 + b'a'));
-        }
-        if modifiers.ctrl && modifiers.alt {
-            return Some(keys::encode_ctrl_alt(byte));
-        }
-    }
-
-    // Named keys — delegate to core encoder
-    let core_key = egui_key_to_core(key)?;
-    let mods = keys::Modifiers {
-        shift: modifiers.shift,
-        ctrl: modifiers.ctrl,
-        alt: modifiers.alt,
+/// Encode an egui key event by translating it to libghostty-vt types and
+/// delegating to the terminal's built-in key encoder.
+///
+/// Returns `None` for keys the encoder doesn't handle (e.g. plain character
+/// keys without Ctrl/Alt — those are handled via `Event::Text` instead).
+pub(crate) fn encode_egui_key(
+    pane: &mut impl TerminalBackend,
+    key: &egui::Key,
+    modifiers: &egui::Modifiers,
+    repeat: bool,
+) -> Option<Vec<u8>> {
+    let gkey = egui_key_to_ghostty(key)?;
+    let mods = egui_mods_to_ghostty(modifiers);
+    let action = if repeat {
+        Action::Repeat
+    } else {
+        Action::Press
     };
-    keys::encode_named(core_key, mods, false)
-}
 
-/// Map egui letter keys to their Ctrl control byte (A=0x01 .. Z=0x1a).
-fn egui_ctrl_byte(key: &egui::Key) -> Option<u8> {
-    match key {
-        egui::Key::A => Some(0x01),
-        egui::Key::B => Some(0x02),
-        egui::Key::C => Some(0x03),
-        egui::Key::D => Some(0x04),
-        egui::Key::E => Some(0x05),
-        egui::Key::F => Some(0x06),
-        egui::Key::G => Some(0x07),
-        egui::Key::H => Some(0x08),
-        egui::Key::I => Some(0x09),
-        egui::Key::J => Some(0x0a),
-        egui::Key::K => Some(0x0b),
-        egui::Key::L => Some(0x0c),
-        egui::Key::M => Some(0x0d),
-        egui::Key::N => Some(0x0e),
-        egui::Key::O => Some(0x0f),
-        egui::Key::P => Some(0x10),
-        egui::Key::Q => Some(0x11),
-        egui::Key::R => Some(0x12),
-        egui::Key::S => Some(0x13),
-        egui::Key::T => Some(0x14),
-        egui::Key::U => Some(0x15),
-        egui::Key::V => Some(0x16),
-        egui::Key::W => Some(0x17),
-        egui::Key::X => Some(0x18),
-        egui::Key::Y => Some(0x19),
-        egui::Key::Z => Some(0x1a),
-        _ => None,
+    // For character keys without Ctrl/Alt, return None so Event::Text handles them.
+    // This avoids double-sending: egui fires both Event::Key and Event::Text for
+    // plain character input.
+    if is_character_key(key) && !modifiers.ctrl && !modifiers.alt && !modifiers.command {
+        return None;
     }
+
+    // For character keys with modifiers, provide the unshifted codepoint and
+    // UTF-8 text so the encoder can produce correct Kitty/CSI-u sequences.
+    let (text, unshifted_cp) = if let Some(ch) = key_to_char(key) {
+        let text_str = if modifiers.shift {
+            ch.to_uppercase().to_string()
+        } else {
+            ch.to_string()
+        };
+        (Some(text_str), Some(ch))
+    } else {
+        (None, None)
+    };
+
+    pane.encode_key(gkey, mods, action, text.as_deref(), unshifted_cp)
 }
 
-/// Map egui Key to core NamedKey.
-fn egui_key_to_core(key: &egui::Key) -> Option<amux_core::keys::NamedKey> {
-    use amux_core::keys::NamedKey;
+/// Map an egui Key to the corresponding libghostty Key.
+/// Returns None for keys we don't handle (e.g. unknown/unrecognized).
+fn egui_key_to_ghostty(key: &egui::Key) -> Option<Key> {
     Some(match key {
-        egui::Key::Enter => NamedKey::Enter,
-        egui::Key::Tab => NamedKey::Tab,
-        egui::Key::Escape => NamedKey::Escape,
-        egui::Key::Backspace => NamedKey::Backspace,
-        egui::Key::Space => NamedKey::Space,
-        egui::Key::ArrowUp => NamedKey::ArrowUp,
-        egui::Key::ArrowDown => NamedKey::ArrowDown,
-        egui::Key::ArrowLeft => NamedKey::ArrowLeft,
-        egui::Key::ArrowRight => NamedKey::ArrowRight,
-        egui::Key::Home => NamedKey::Home,
-        egui::Key::End => NamedKey::End,
-        egui::Key::Insert => NamedKey::Insert,
-        egui::Key::Delete => NamedKey::Delete,
-        egui::Key::PageUp => NamedKey::PageUp,
-        egui::Key::PageDown => NamedKey::PageDown,
-        egui::Key::F1 => NamedKey::F1,
-        egui::Key::F2 => NamedKey::F2,
-        egui::Key::F3 => NamedKey::F3,
-        egui::Key::F4 => NamedKey::F4,
-        egui::Key::F5 => NamedKey::F5,
-        egui::Key::F6 => NamedKey::F6,
-        egui::Key::F7 => NamedKey::F7,
-        egui::Key::F8 => NamedKey::F8,
-        egui::Key::F9 => NamedKey::F9,
-        egui::Key::F10 => NamedKey::F10,
-        egui::Key::F11 => NamedKey::F11,
-        egui::Key::F12 => NamedKey::F12,
+        // Named keys
+        egui::Key::Enter => Key::Enter,
+        egui::Key::Tab => Key::Tab,
+        egui::Key::Escape => Key::Escape,
+        egui::Key::Backspace => Key::Backspace,
+        egui::Key::Space => Key::Space,
+        egui::Key::ArrowUp => Key::ArrowUp,
+        egui::Key::ArrowDown => Key::ArrowDown,
+        egui::Key::ArrowLeft => Key::ArrowLeft,
+        egui::Key::ArrowRight => Key::ArrowRight,
+        egui::Key::Home => Key::Home,
+        egui::Key::End => Key::End,
+        egui::Key::Insert => Key::Insert,
+        egui::Key::Delete => Key::Delete,
+        egui::Key::PageUp => Key::PageUp,
+        egui::Key::PageDown => Key::PageDown,
+
+        // Function keys
+        egui::Key::F1 => Key::F1,
+        egui::Key::F2 => Key::F2,
+        egui::Key::F3 => Key::F3,
+        egui::Key::F4 => Key::F4,
+        egui::Key::F5 => Key::F5,
+        egui::Key::F6 => Key::F6,
+        egui::Key::F7 => Key::F7,
+        egui::Key::F8 => Key::F8,
+        egui::Key::F9 => Key::F9,
+        egui::Key::F10 => Key::F10,
+        egui::Key::F11 => Key::F11,
+        egui::Key::F12 => Key::F12,
+
+        // Letter keys
+        egui::Key::A => Key::A,
+        egui::Key::B => Key::B,
+        egui::Key::C => Key::C,
+        egui::Key::D => Key::D,
+        egui::Key::E => Key::E,
+        egui::Key::F => Key::F,
+        egui::Key::G => Key::G,
+        egui::Key::H => Key::H,
+        egui::Key::I => Key::I,
+        egui::Key::J => Key::J,
+        egui::Key::K => Key::K,
+        egui::Key::L => Key::L,
+        egui::Key::M => Key::M,
+        egui::Key::N => Key::N,
+        egui::Key::O => Key::O,
+        egui::Key::P => Key::P,
+        egui::Key::Q => Key::Q,
+        egui::Key::R => Key::R,
+        egui::Key::S => Key::S,
+        egui::Key::T => Key::T,
+        egui::Key::U => Key::U,
+        egui::Key::V => Key::V,
+        egui::Key::W => Key::W,
+        egui::Key::X => Key::X,
+        egui::Key::Y => Key::Y,
+        egui::Key::Z => Key::Z,
+
+        // Digit keys
+        egui::Key::Num0 => Key::Digit0,
+        egui::Key::Num1 => Key::Digit1,
+        egui::Key::Num2 => Key::Digit2,
+        egui::Key::Num3 => Key::Digit3,
+        egui::Key::Num4 => Key::Digit4,
+        egui::Key::Num5 => Key::Digit5,
+        egui::Key::Num6 => Key::Digit6,
+        egui::Key::Num7 => Key::Digit7,
+        egui::Key::Num8 => Key::Digit8,
+        egui::Key::Num9 => Key::Digit9,
+
+        // Punctuation / symbol keys
+        egui::Key::Minus => Key::Minus,
+        egui::Key::Equals => Key::Equal,
+        egui::Key::OpenBracket => Key::BracketLeft,
+        egui::Key::CloseBracket => Key::BracketRight,
+        egui::Key::Backslash => Key::Backslash,
+        egui::Key::Semicolon => Key::Semicolon,
+        egui::Key::Quote => Key::Quote,
+        egui::Key::Comma => Key::Comma,
+        egui::Key::Period => Key::Period,
+        egui::Key::Slash => Key::Slash,
+        egui::Key::Backtick => Key::Backquote,
+
+        _ => return None,
+    })
+}
+
+/// Map egui Modifiers to libghostty Mods bitmask.
+fn egui_mods_to_ghostty(m: &egui::Modifiers) -> Mods {
+    let mut mods = Mods::empty();
+    if m.shift {
+        mods |= Mods::SHIFT;
+    }
+    if m.ctrl {
+        mods |= Mods::CTRL;
+    }
+    if m.alt {
+        mods |= Mods::ALT;
+    }
+    if m.command {
+        mods |= Mods::SUPER;
+    }
+    mods
+}
+
+/// Whether an egui Key represents a printable character (letter, digit, punctuation).
+/// Named keys like Enter/Tab/F-keys are NOT character keys.
+fn is_character_key(key: &egui::Key) -> bool {
+    key_to_char(key).is_some()
+}
+
+/// Map a character-producing egui Key to its base (unshifted, lowercase) character.
+fn key_to_char(key: &egui::Key) -> Option<char> {
+    Some(match key {
+        egui::Key::A => 'a',
+        egui::Key::B => 'b',
+        egui::Key::C => 'c',
+        egui::Key::D => 'd',
+        egui::Key::E => 'e',
+        egui::Key::F => 'f',
+        egui::Key::G => 'g',
+        egui::Key::H => 'h',
+        egui::Key::I => 'i',
+        egui::Key::J => 'j',
+        egui::Key::K => 'k',
+        egui::Key::L => 'l',
+        egui::Key::M => 'm',
+        egui::Key::N => 'n',
+        egui::Key::O => 'o',
+        egui::Key::P => 'p',
+        egui::Key::Q => 'q',
+        egui::Key::R => 'r',
+        egui::Key::S => 's',
+        egui::Key::T => 't',
+        egui::Key::U => 'u',
+        egui::Key::V => 'v',
+        egui::Key::W => 'w',
+        egui::Key::X => 'x',
+        egui::Key::Y => 'y',
+        egui::Key::Z => 'z',
+        egui::Key::Num0 => '0',
+        egui::Key::Num1 => '1',
+        egui::Key::Num2 => '2',
+        egui::Key::Num3 => '3',
+        egui::Key::Num4 => '4',
+        egui::Key::Num5 => '5',
+        egui::Key::Num6 => '6',
+        egui::Key::Num7 => '7',
+        egui::Key::Num8 => '8',
+        egui::Key::Num9 => '9',
+        egui::Key::Minus => '-',
+        egui::Key::Equals => '=',
+        egui::Key::OpenBracket => '[',
+        egui::Key::CloseBracket => ']',
+        egui::Key::Backslash => '\\',
+        egui::Key::Semicolon => ';',
+        egui::Key::Quote => '\'',
+        egui::Key::Comma => ',',
+        egui::Key::Period => '.',
+        egui::Key::Slash => '/',
+        egui::Key::Backtick => '`',
+        egui::Key::Space => ' ',
         _ => return None,
     })
 }

--- a/crates/amux-app/src/key_encode.rs
+++ b/crates/amux-app/src/key_encode.rs
@@ -38,8 +38,12 @@ pub(crate) fn encode_egui_key(
     // reliably from the key itself. For punctuation/digits, shifted output is
     // layout-dependent (e.g. '-' vs '_'), so omit text and let the encoder
     // rely on key + unshifted_codepoint.
+    //
+    // When Alt is active, do NOT synthesize text: on macOS, Option+key emits
+    // both Event::Key and Event::Text from egui, so synthesizing text here
+    // would cause double input. The encoder handles Alt as a pure modifier.
     let (text, unshifted_cp) = if let Some(ch) = key_to_char(key) {
-        let text = if ch.is_ascii_alphabetic() {
+        let text = if ch.is_ascii_alphabetic() && !modifiers.alt {
             let text_ch = if modifiers.shift {
                 ch.to_ascii_uppercase()
             } else {

--- a/crates/amux-app/src/key_encode.rs
+++ b/crates/amux-app/src/key_encode.rs
@@ -33,15 +33,23 @@ pub(crate) fn encode_egui_key(
         return None;
     }
 
-    // For character keys with modifiers, provide the unshifted codepoint and
-    // UTF-8 text so the encoder can produce correct Kitty/CSI-u sequences.
+    // For character keys with modifiers, provide the unshifted codepoint.
+    // Only synthesize UTF-8 text for alphabetic keys where Shift can be derived
+    // reliably from the key itself. For punctuation/digits, shifted output is
+    // layout-dependent (e.g. '-' vs '_'), so omit text and let the encoder
+    // rely on key + unshifted_codepoint.
     let (text, unshifted_cp) = if let Some(ch) = key_to_char(key) {
-        let text_str = if modifiers.shift {
-            ch.to_uppercase().to_string()
+        let text = if ch.is_ascii_alphabetic() {
+            let text_ch = if modifiers.shift {
+                ch.to_ascii_uppercase()
+            } else {
+                ch
+            };
+            Some(text_ch.to_string())
         } else {
-            ch.to_string()
+            None
         };
-        (Some(text_str), Some(ch))
+        (text, Some(ch))
     } else {
         (None, None)
     };
@@ -153,7 +161,11 @@ fn egui_mods_to_ghostty(m: &egui::Modifiers) -> Mods {
     if m.alt {
         mods |= Mods::ALT;
     }
-    if m.command {
+    // On macOS, `command` maps to the Cmd/Super key. On non-macOS, egui sets
+    // `command` as an alias for Ctrl (the "platform command key"), so mapping
+    // it to SUPER would incorrectly add SUPER to every Ctrl combo.
+    #[cfg(target_os = "macos")]
+    if m.mac_cmd || m.command {
         mods |= Mods::SUPER;
     }
     mods

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -823,7 +823,7 @@ pub(crate) fn spawn_surface(
     cmd.env("AMUX_WORKSPACE_ID", workspace_id.to_string());
     cmd.env("AMUX_SURFACE_ID", surface_id.to_string());
     cmd.env("TERM", "xterm-256color");
-    cmd.env("TERM_PROGRAM", "amux");
+    cmd.env("TERM_PROGRAM", "ghostty");
     cmd.env("TERM_PROGRAM_VERSION", env!("CARGO_PKG_VERSION"));
 
     // Point AMUX_BIN to the CLI binary so shell integration scripts can invoke it

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -321,12 +321,17 @@ impl KeybindingsConfig {
         }
         #[cfg(not(target_os = "macos"))]
         {
+            // All amux shortcuts use Ctrl+Shift+<key> so plain Ctrl+<key>
+            // combos pass through to the terminal (Ctrl+C, Ctrl+D, Ctrl+W, etc.).
             m.insert(Action::Copy, KeyCombo::parse("ctrl+shift+c").unwrap());
             m.insert(Action::Paste, KeyCombo::parse("ctrl+shift+v").unwrap());
-            m.insert(Action::Find, KeyCombo::parse("ctrl+f").unwrap());
+            m.insert(Action::Find, KeyCombo::parse("ctrl+shift+f").unwrap());
             m.insert(Action::SelectAll, KeyCombo::parse("ctrl+shift+a").unwrap());
             m.insert(Action::CopyMode, KeyCombo::parse("ctrl+shift+x").unwrap());
-            m.insert(Action::ToggleSidebar, KeyCombo::parse("ctrl+b").unwrap());
+            m.insert(
+                Action::ToggleSidebar,
+                KeyCombo::parse("ctrl+shift+b").unwrap(),
+            );
             m.insert(
                 Action::NewBrowserTab,
                 KeyCombo::parse("ctrl+shift+l").unwrap(),
@@ -344,11 +349,17 @@ impl KeybindingsConfig {
                 Action::PrevWorkspace,
                 KeyCombo::parse("ctrl+shift+[").unwrap(),
             );
-            m.insert(Action::NextTab, KeyCombo::parse("ctrl+tab").unwrap());
-            m.insert(Action::PrevTab, KeyCombo::parse("ctrl+shift+tab").unwrap());
-            m.insert(Action::SplitRight, KeyCombo::parse("ctrl+d").unwrap());
+            m.insert(
+                Action::NextTab,
+                KeyCombo::parse("ctrl+shift+pagedown").unwrap(),
+            );
+            m.insert(
+                Action::PrevTab,
+                KeyCombo::parse("ctrl+shift+pageup").unwrap(),
+            );
+            m.insert(Action::SplitRight, KeyCombo::parse("ctrl+shift+e").unwrap());
             m.insert(Action::SplitDown, KeyCombo::parse("ctrl+shift+d").unwrap());
-            m.insert(Action::ClosePane, KeyCombo::parse("ctrl+w").unwrap());
+            m.insert(Action::ClosePane, KeyCombo::parse("ctrl+shift+w").unwrap());
             m.insert(
                 Action::NavigateLeft,
                 KeyCombo::parse("ctrl+alt+left").unwrap(),
@@ -362,14 +373,11 @@ impl KeybindingsConfig {
                 Action::NavigateDown,
                 KeyCombo::parse("ctrl+alt+down").unwrap(),
             );
-            m.insert(
-                Action::ZoomToggle,
-                KeyCombo::parse("ctrl+shift+enter").unwrap(),
-            );
+            m.insert(Action::ZoomToggle, KeyCombo::parse("ctrl+shift+z").unwrap());
             m.insert(Action::DevTools, KeyCombo::parse("ctrl+shift+i").unwrap());
             m.insert(
                 Action::NotificationPanel,
-                KeyCombo::parse("ctrl+i").unwrap(),
+                KeyCombo::parse("ctrl+shift+p").unwrap(),
             );
             m.insert(
                 Action::JumpToUnread,

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -349,6 +349,16 @@ mod tests {
         }
         fn erase_scrollback(&mut self) {}
         fn focus_changed(&mut self, _focused: bool) {}
+        fn encode_key(
+            &mut self,
+            _key: amux_term::key_types::Key,
+            _mods: amux_term::key_types::Mods,
+            _action: amux_term::key_types::Action,
+            _text: Option<&str>,
+            _unshifted_codepoint: Option<char>,
+        ) -> Option<Vec<u8>> {
+            None
+        }
         fn drain_notifications(&self) -> Vec<NotificationEvent> {
             Vec::new()
         }

--- a/crates/amux-term/src/any_backend.rs
+++ b/crates/amux-term/src/any_backend.rs
@@ -170,6 +170,21 @@ impl TerminalBackend for AnyBackend {
         delegate!(self, focus_changed, focused: bool)
     }
 
+    fn encode_key(
+        &mut self,
+        key: libghostty_vt::key::Key,
+        mods: libghostty_vt::key::Mods,
+        action: libghostty_vt::key::Action,
+        text: Option<&str>,
+        unshifted_codepoint: Option<char>,
+    ) -> Option<Vec<u8>> {
+        match self {
+            AnyBackend::Ghostty(inner) => {
+                inner.encode_key(key, mods, action, text, unshifted_codepoint)
+            }
+        }
+    }
+
     fn drain_notifications(&self) -> Vec<NotificationEvent> {
         delegate!(self, drain_notifications)
     }

--- a/crates/amux-term/src/backend.rs
+++ b/crates/amux-term/src/backend.rs
@@ -316,6 +316,22 @@ pub trait TerminalBackend {
     /// Notify terminal of focus change (DECSET 1004).
     fn focus_changed(&mut self, focused: bool);
 
+    // --- Key encoding ---
+
+    /// Encode a key event into PTY bytes using the terminal's current keyboard
+    /// protocol state (legacy, CSI-u/fixterms, Kitty, etc.).
+    ///
+    /// Returns `None` when the key event produces no output (e.g. bare modifier
+    /// press, or a plain character key that should be handled as text input).
+    fn encode_key(
+        &mut self,
+        key: libghostty_vt::key::Key,
+        mods: libghostty_vt::key::Mods,
+        action: libghostty_vt::key::Action,
+        text: Option<&str>,
+        unshifted_codepoint: Option<char>,
+    ) -> Option<Vec<u8>>;
+
     // --- Notifications ---
 
     /// Drain pending notification events from the alert handler.

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -7,6 +7,7 @@ use std::cell::RefCell;
 use std::io::{Read, Write};
 use std::sync::{mpsc, Arc, Mutex};
 
+use libghostty_vt::key as gkey;
 use libghostty_vt::render::{CellIterator, CursorVisualStyle, Dirty, RenderState, RowIterator};
 use libghostty_vt::style::RgbColor;
 use libghostty_vt::terminal::{Mode, Options as TerminalOptions, Terminal};
@@ -48,6 +49,9 @@ pub struct GhosttyPane<'alloc, 'cb> {
     cached_cursor_shape: CursorShape,
     /// Cached working directory URL (from OSC 7 via pwd()).
     cached_working_dir: Option<Url>,
+    /// libghostty key encoder — reused across calls, configured from terminal
+    /// state on each encode so it picks up Kitty keyboard protocol flags.
+    key_encoder: gkey::Encoder<'alloc>,
 }
 
 impl<'alloc, 'cb> GhosttyPane<'alloc, 'cb>
@@ -133,6 +137,9 @@ where
         let render_state =
             RenderState::new().map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("{e}")))?;
 
+        let key_encoder = gkey::Encoder::new()
+            .map_err(|e| TermError::PtySetupFailed(anyhow::anyhow!("key encoder: {e}")))?;
+
         Ok(Self {
             terminal,
             render_state: RefCell::new(render_state),
@@ -147,6 +154,7 @@ where
             palette_overridden: false,
             cached_cursor_shape: CursorShape::Default,
             cached_working_dir: None,
+            key_encoder,
         })
     }
 
@@ -879,6 +887,37 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         let mut buf = [0u8; 8];
         if let Ok(n) = event.encode(&mut buf) {
             self.terminal.vt_write(&buf[..n]);
+        }
+    }
+
+    fn encode_key(
+        &mut self,
+        key: gkey::Key,
+        mods: gkey::Mods,
+        action: gkey::Action,
+        text: Option<&str>,
+        unshifted_codepoint: Option<char>,
+    ) -> Option<Vec<u8>> {
+        // Sync encoder options (Kitty flags, DECCKM, etc.) from terminal state.
+        self.key_encoder.set_options_from_terminal(&self.terminal);
+
+        #[cfg(target_os = "macos")]
+        self.key_encoder
+            .set_macos_option_as_alt(gkey::OptionAsAlt::True);
+
+        let mut event = gkey::Event::new().ok()?;
+        event.set_key(key);
+        event.set_mods(mods);
+        event.set_action(action);
+        event.set_utf8(text);
+        if let Some(cp) = unshifted_codepoint {
+            event.set_unshifted_codepoint(cp);
+        }
+
+        let mut buf = Vec::with_capacity(32);
+        match self.key_encoder.encode_to_vec(&event, &mut buf) {
+            Ok(()) if !buf.is_empty() => Some(buf),
+            _ => None,
         }
     }
 

--- a/crates/amux-term/src/lib.rs
+++ b/crates/amux-term/src/lib.rs
@@ -12,3 +12,8 @@ pub use backend::{
     AdvanceResult, Color, CursorPos, CursorShape, Palette, ProcessExit, ScreenCell, ScreenRow,
     SequenceNo, StableRow, TermError, TerminalBackend,
 };
+
+/// Re-export libghostty-vt key types for use by the input layer.
+pub mod key_types {
+    pub use libghostty_vt::key::{Action, Key, Mods};
+}


### PR DESCRIPTION
## Summary
- Replace hand-rolled `key_encode.rs` with libghostty-vt's `key::Encoder`, which supports Kitty keyboard protocol, CSI-u, modifyOtherKeys, and legacy VT — encoding adapts automatically based on what the child app requests
- Set `TERM_PROGRAM=ghostty` so Claude Code activates Kitty protocol (enables Shift+Enter for multi-line input)
- Set `macos_option_as_alt=True` on macOS so Option+key works as Alt+key in terminal apps
- Rebind all Windows/Linux shortcuts to `Ctrl+Shift+<key>` namespace — plain `Ctrl+<key>` combos now pass through to the terminal (fixes Ctrl+C/D/W/B/F being intercepted)

Refs #253

## Test plan
- [ ] Launch amux, open Claude Code — verify Shift+Enter produces a newline (not submit)
- [ ] Ctrl+C sends SIGINT, Ctrl+D sends EOF, Ctrl+Z sends SIGTSTP
- [ ] Arrow keys, Home/End, F-keys all work normally
- [ ] Alt+key combos work (e.g. Alt+B/F for word navigation in bash)
- [ ] On macOS: Option+key sends Alt escape sequences
- [ ] On Windows/Linux: verify new Ctrl+Shift shortcuts (Ctrl+Shift+F for find, Ctrl+Shift+B for sidebar, etc.)
- [ ] Plain text input (typing characters) still works normally
- [ ] vim/nano/htop keyboard input works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved keyboard input handling with proper key repeat support
  * Enhanced keyboard encoding for modifier key combinations

* **Changes**
  * Default keyboard shortcuts updated to use Ctrl+Shift combinations (e.g., Find: Ctrl+Shift+F, Toggle Sidebar: Ctrl+Shift+B, Tab navigation: Ctrl+Shift+Page Down/Up)
  * Terminal identification improved for better compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->