### PR TITLE
Fix garbled display after pane split

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -419,8 +419,8 @@ impl eframe::App for AmuxApp {
                     if sel_changed {
                         self.selection_changed = true;
                     }
-                    self.render_single_pane(ui, zoomed_id, panel_rect, true);
                     self.resize_pane_if_needed(zoomed_id, panel_rect, ui);
+                    self.render_single_pane(ui, zoomed_id, panel_rect, true);
                 } else {
                     // Normal mode: render all panes at computed rects
                     let layout = self.active_workspace().tree.layout(panel_rect);
@@ -475,12 +475,18 @@ impl eframe::App for AmuxApp {
                         painter.rect_filled(div.rect, 0.0, self.theme.chrome.divider);
                     }
 
+                    // Resize panes BEFORE rendering so the terminal state
+                    // matches the new layout on the same frame. Without this,
+                    // the first frame after a split renders stale dimensions.
+                    for &(id, rect) in &layout {
+                        self.resize_pane_if_needed(id, rect, ui);
+                    }
+
                     // Render each pane (with its own tab bar)
                     let focused = self.focused_pane_id();
                     for &(id, rect) in &layout {
                         let is_focused = id == focused;
                         self.render_single_pane(ui, id, rect, is_focused);
-                        self.resize_pane_if_needed(id, rect, ui);
                     }
                 }
 

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -475,6 +475,11 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         self.terminal
             .resize(cols, rows, 0, 0)
             .map_err(|e| TermError::ResizeFailed(anyhow::anyhow!("{e}")))?;
+        // Bump seqno so the renderer takes a fresh snapshot at the new
+        // dimensions. Without this, the render state stays stale until
+        // new bytes arrive — causing garbled output after pane splits.
+        self.seqno += 1;
+        self.refresh_render_cache();
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Bump `seqno` and refresh render cache after `resize()` so the GPU renderer takes a fresh snapshot at the new dimensions instead of rendering stale data
- Reorder frame update: resize panes BEFORE rendering them (was render-then-resize, causing one-frame garble on splits)

Refs #257

## Test plan
- [ ] Split a pane while Claude Code is running — TUI should redraw cleanly, no garbled first frame
- [ ] Split a pane with a shell prompt — prompt should appear at correct width immediately
- [ ] Resize window — terminal content should update without flashing stale dimensions
- [ ] Zoom/unzoom a pane — same as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)