### PR TITLE
Fix crash on Windows after pane split/close

### DIFF
--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -476,10 +476,12 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
             .resize(cols, rows, 0, 0)
             .map_err(|e| TermError::ResizeFailed(anyhow::anyhow!("{e}")))?;
         // Bump seqno so the renderer takes a fresh snapshot at the new
-        // dimensions. Without this, the render state stays stale until
-        // new bytes arrive — causing garbled output after pane splits.
+        // dimensions on the next frame. Don't call refresh_render_cache()
+        // here — the Zig VT engine may not be in a consistent state for
+        // snapshotting immediately after resize (STATUS_BREAKPOINT crash
+        // on Windows). The renderer will snapshot on the next frame when
+        // it sees the bumped seqno.
         self.seqno += 1;
-        self.refresh_render_cache();
         Ok(())
     }
 

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -476,11 +476,11 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
             .resize(cols, rows, 0, 0)
             .map_err(|e| TermError::ResizeFailed(anyhow::anyhow!("{e}")))?;
         // Bump seqno so the renderer takes a fresh snapshot at the new
-        // dimensions on the next frame. Don't call refresh_render_cache()
+        // dimensions on the next render. Don't call refresh_render_cache()
         // here — the Zig VT engine may not be in a consistent state for
         // snapshotting immediately after resize (STATUS_BREAKPOINT crash
-        // on Windows). The renderer will snapshot on the next frame when
-        // it sees the bumped seqno.
+        // on Windows). The renderer will snapshot during the subsequent
+        // render pass when it sees the bumped seqno.
         self.seqno += 1;
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Remove `refresh_render_cache()` call from `resize()` — the Zig VT engine isn't in a consistent state for render snapshotting immediately after resize, causing a `STATUS_BREAKPOINT` (0x80000003) crash in `ghostty-vt.dll` on Windows
- Keep the `seqno` bump so the renderer takes a fresh snapshot on the next frame when the terminal is stable

The crash was introduced in #270. Repro: create a split, close it → crash.

## Test plan
- [ ] On Windows: create vertical split, close it — should not crash
- [ ] Create horizontal split, close it — should not crash
- [ ] Split + resize window — terminal content should still update correctly (seqno bump ensures re-snapshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)