### PR TITLE
Add settings modal with live preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "serde_json",
  "sysinfo",
  "toml 0.8.2",
+ "toml_edit 0.22.27",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2017,7 +2018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3856,11 +3857,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
 ]
 
@@ -5017,15 +5017,15 @@ checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
@@ -5046,7 +5046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
@@ -5059,8 +5059,20 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5083,6 +5095,12 @@ checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ winit = "0.30"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+toml_edit = "0.22"
 url = "2"
 
 # UI framework

--- a/crates/amux-app/Cargo.toml
+++ b/crates/amux-app/Cargo.toml
@@ -31,6 +31,7 @@ chrono = { workspace = true }
 dirs = { workspace = true }
 open = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 notify-rust = { workspace = true }
 rodio = { workspace = true }
 winit = { workspace = true }

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -244,6 +244,7 @@ impl eframe::App for AmuxApp {
         if !shortcut_consumed
             && self.copy_mode.is_none()
             && self.rename_modal.is_none()
+            && self.settings_modal.is_none()
             && self.find_state.is_none()
         {
             sent_input = self.handle_input(ctx);

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -508,6 +508,11 @@ impl eframe::App for AmuxApp {
             self.render_rename_modal(ctx);
         }
 
+        // Settings modal
+        if self.settings_modal.is_some() {
+            self.render_settings_modal(ctx);
+        }
+
         // Hyperlink hover detection + Cmd+click handling
         self.handle_hyperlinks(ctx);
 

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -23,6 +23,7 @@ mod popup_theme;
 mod rename_modal;
 mod render;
 mod selection;
+mod settings_modal;
 mod sidebar;
 mod startup;
 mod system_notify;
@@ -186,6 +187,8 @@ struct AmuxApp {
     tab_drag: Option<TabDragState>,
     /// Rename modal state for workspaces and tabs.
     rename_modal: Option<RenameModal>,
+    /// Settings modal state.
+    settings_modal: Option<settings_modal::SettingsModal>,
     /// Whether the app window currently has OS-level focus.
     app_focused: bool,
     /// Persisted application configuration.

--- a/crates/amux-app/src/menu_bar.rs
+++ b/crates/amux-app/src/menu_bar.rs
@@ -64,6 +64,7 @@ pub(crate) enum MenuAction {
     Copy,
     Paste,
     SelectAll,
+    Settings,
 }
 
 // ---------------------------------------------------------------------
@@ -187,6 +188,12 @@ pub(crate) const MENU_MODEL: &[SubmenuDef] = &[
                 shortcut: Some(shortcuts::SELECT_ALL),
                 action: MenuAction::SelectAll,
             },
+            MenuItemDef::Separator,
+            MenuItemDef::Action {
+                label: "Settings",
+                shortcut: None,
+                action: MenuAction::Settings,
+            },
         ],
     },
     SubmenuDef {
@@ -267,6 +274,7 @@ struct MacMenuItems {
     copy: muda::MenuId,
     paste: muda::MenuId,
     select_all: muda::MenuId,
+    settings: muda::MenuId,
 }
 
 #[cfg(target_os = "macos")]
@@ -307,6 +315,7 @@ pub(crate) fn build() -> Menu {
     let copy = MenuItem::new("Copy", true, accel(CMD, Code::KeyC));
     let paste = MenuItem::new("Paste", true, accel(CMD, Code::KeyV));
     let select_all = MenuItem::new("Select All", true, accel(CMD, Code::KeyA));
+    let settings = MenuItem::new("Settings…", true, accel(CMD, Code::Comma));
 
     // Stash IDs for event matching before the items get moved into
     // their submenus — muda's MenuId is cheap to clone but we need to
@@ -326,6 +335,7 @@ pub(crate) fn build() -> Menu {
             copy: copy.id().clone(),
             paste: paste.id().clone(),
             select_all: select_all.id().clone(),
+            settings: settings.id().clone(),
         })
         .is_err()
     {
@@ -344,6 +354,8 @@ pub(crate) fn build() -> Menu {
                 ..Default::default()
             }),
         ),
+        &PredefinedMenuItem::separator(),
+        &settings,
         &PredefinedMenuItem::separator(),
         &PredefinedMenuItem::services(None),
         &PredefinedMenuItem::separator(),
@@ -440,6 +452,8 @@ fn drain_muda_events() {
             Some(MenuAction::Paste)
         } else if *id == items.select_all {
             Some(MenuAction::SelectAll)
+        } else if *id == items.settings {
+            Some(MenuAction::Settings)
         } else {
             // Predefined OS item or unknown — no local handler.
             None

--- a/crates/amux-app/src/render.rs
+++ b/crates/amux-app/src/render.rs
@@ -53,6 +53,7 @@ pub(crate) fn render_pane(
             seqno,
             find_highlights.to_vec(),
             current_highlight,
+            pane_dim_alpha,
         );
 
         // Apply cursor blink: hide cursor during "off" phase for blinking shapes.

--- a/crates/amux-app/src/settings_modal.rs
+++ b/crates/amux-app/src/settings_modal.rs
@@ -154,7 +154,13 @@ impl AmuxApp {
 
                     ui.horizontal(|ui| {
                         ui.label("Font size:");
-                        ui.add(egui::Slider::new(&mut modal.font_size, 4.0..=96.0).step_by(1.0));
+                        if ui.small_button("−").clicked() {
+                            modal.font_size = (modal.font_size - 1.0).max(4.0);
+                        }
+                        ui.label(format!("{}", modal.font_size as u32));
+                        if ui.small_button("+").clicked() {
+                            modal.font_size = (modal.font_size + 1.0).min(96.0);
+                        }
                     });
 
                     ui.horizontal(|ui| {

--- a/crates/amux-app/src/settings_modal.rs
+++ b/crates/amux-app/src/settings_modal.rs
@@ -1,0 +1,248 @@
+//! Settings modal UI.
+//!
+//! Presents a centered window with configurable settings for appearance
+//! and notifications. Changes are applied immediately (live preview) and
+//! persisted to config.toml on Save.
+
+use crate::*;
+
+/// Editable settings state — populated from AppConfig on open,
+/// applied back on Save.
+pub(crate) struct SettingsModal {
+    pub(crate) font_size: f32,
+    pub(crate) font_family: String,
+    pub(crate) theme_source: String,
+    pub(crate) shell: String,
+    pub(crate) system_notifications: bool,
+    pub(crate) dock_badge: bool,
+    pub(crate) auto_reorder_workspaces: bool,
+    pub(crate) sound: String,
+    pub(crate) play_when_focused: bool,
+    /// Snapshot of original values for cancel/revert.
+    original_font_size: f32,
+    original_font_family: String,
+}
+
+impl SettingsModal {
+    pub(crate) fn from_config(config: &config::AppConfig) -> Self {
+        Self {
+            font_size: config.font_size,
+            font_family: config.font_family.clone(),
+            theme_source: config.theme_source.clone(),
+            shell: config.shell.clone().unwrap_or_default(),
+            system_notifications: config.notifications.system_notifications,
+            dock_badge: config.notifications.dock_badge,
+            auto_reorder_workspaces: config.notifications.auto_reorder_workspaces,
+            sound: config.notifications.sound.sound.clone(),
+            play_when_focused: config.notifications.sound.play_when_focused,
+            original_font_size: config.font_size,
+            original_font_family: config.font_family.clone(),
+        }
+    }
+}
+
+impl AmuxApp {
+    pub(crate) fn render_settings_modal(&mut self, ctx: &egui::Context) {
+        let mut save = false;
+        let mut cancel = false;
+
+        let palette = crate::popup_theme::MenuPalette::from_theme(&self.theme);
+        crate::popup_theme::with_modal_palette(ctx, palette, || {
+            egui::Window::new("Settings")
+                .collapsible(false)
+                .resizable(false)
+                .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+                .fixed_size([360.0, 0.0])
+                .show(ctx, |ui| {
+                    let modal = self.settings_modal.as_mut().unwrap();
+
+                    // --- Appearance ---
+                    ui.heading("Appearance");
+                    ui.add_space(4.0);
+
+                    ui.horizontal(|ui| {
+                        ui.label("Font size:");
+                        ui.add(egui::Slider::new(&mut modal.font_size, 6.0..=48.0).step_by(1.0));
+                    });
+
+                    ui.horizontal(|ui| {
+                        ui.label("Font family:");
+                        ui.text_edit_singleline(&mut modal.font_family);
+                    });
+
+                    ui.horizontal(|ui| {
+                        ui.label("Theme:");
+                        egui::ComboBox::from_id_salt("theme_source")
+                            .selected_text(&modal.theme_source)
+                            .show_ui(ui, |ui| {
+                                ui.selectable_value(
+                                    &mut modal.theme_source,
+                                    "default".to_string(),
+                                    "Default (Monokai Classic)",
+                                );
+                                ui.selectable_value(
+                                    &mut modal.theme_source,
+                                    "ghostty".to_string(),
+                                    "Ghostty",
+                                );
+                            });
+                    });
+
+                    ui.horizontal(|ui| {
+                        ui.label("Shell:");
+                        ui.text_edit_singleline(&mut modal.shell);
+                    });
+
+                    ui.add_space(8.0);
+
+                    // --- Notifications ---
+                    ui.heading("Notifications");
+                    ui.add_space(4.0);
+
+                    ui.checkbox(&mut modal.system_notifications, "System notifications");
+                    ui.checkbox(&mut modal.dock_badge, "Dock / taskbar badge");
+                    ui.checkbox(
+                        &mut modal.auto_reorder_workspaces,
+                        "Auto-reorder workspaces on notification",
+                    );
+
+                    ui.horizontal(|ui| {
+                        ui.label("Sound:");
+                        egui::ComboBox::from_id_salt("sound")
+                            .selected_text(&modal.sound)
+                            .show_ui(ui, |ui| {
+                                ui.selectable_value(
+                                    &mut modal.sound,
+                                    "system".to_string(),
+                                    "System",
+                                );
+                                ui.selectable_value(&mut modal.sound, "none".to_string(), "None");
+                            });
+                    });
+
+                    ui.checkbox(&mut modal.play_when_focused, "Play sound when focused");
+
+                    ui.add_space(8.0);
+
+                    // --- Buttons ---
+                    ui.horizontal(|ui| {
+                        if ui.button("Save").clicked() {
+                            save = true;
+                        }
+                        if ui.button("Cancel").clicked() {
+                            cancel = true;
+                        }
+                    });
+
+                    // Live preview font size changes
+                    if modal.font_size != self.font_size {
+                        self.font_size = modal.font_size;
+                        #[cfg(feature = "gpu-renderer")]
+                        if let Some(gpu) = &mut self.gpu_renderer {
+                            gpu.set_font_size(self.font_size);
+                        }
+                    }
+                });
+        });
+
+        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+            cancel = true;
+        }
+
+        if save {
+            self.apply_settings();
+            self.save_config_to_disk();
+            self.settings_modal = None;
+        } else if cancel {
+            // Revert live-previewed changes
+            let modal = self.settings_modal.as_ref().unwrap();
+            self.font_size = modal.original_font_size;
+            #[cfg(feature = "gpu-renderer")]
+            if let Some(gpu) = &mut self.gpu_renderer {
+                gpu.set_font_size(self.font_size);
+            }
+            self.settings_modal = None;
+        }
+    }
+
+    fn apply_settings(&mut self) {
+        let modal = self.settings_modal.as_ref().unwrap();
+
+        self.font_size = modal.font_size;
+        self.app_config.font_size = modal.font_size;
+        self.app_config.font_family = modal.font_family.clone();
+        self.app_config.theme_source = modal.theme_source.clone();
+        self.app_config.shell = if modal.shell.is_empty() {
+            None
+        } else {
+            Some(modal.shell.clone())
+        };
+        self.app_config.notifications.system_notifications = modal.system_notifications;
+        self.app_config.notifications.dock_badge = modal.dock_badge;
+        self.app_config.notifications.auto_reorder_workspaces = modal.auto_reorder_workspaces;
+        self.app_config.notifications.sound.sound = modal.sound.clone();
+        self.app_config.notifications.sound.play_when_focused = modal.play_when_focused;
+
+        #[cfg(feature = "gpu-renderer")]
+        if let Some(gpu) = &mut self.gpu_renderer {
+            gpu.set_font_size(self.font_size);
+            if modal.font_family != modal.original_font_family {
+                gpu.set_font_family(&modal.font_family, self.font_size);
+            }
+        }
+    }
+
+    fn save_config_to_disk(&self) {
+        let Some(path) = &self.config_file_path else {
+            tracing::warn!("No config file path — settings not saved to disk");
+            return;
+        };
+
+        // Read existing file content to preserve comments and unknown fields.
+        let existing = std::fs::read_to_string(path).unwrap_or_default();
+        let mut doc = match existing.parse::<toml_edit::DocumentMut>() {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!("Failed to parse config for update: {e}");
+                return;
+            }
+        };
+
+        // Update known fields
+        doc["font_size"] = toml_edit::value(self.app_config.font_size as f64);
+        doc["font_family"] = toml_edit::value(&self.app_config.font_family);
+        doc["theme_source"] = toml_edit::value(&self.app_config.theme_source);
+        if let Some(shell) = &self.app_config.shell {
+            doc["shell"] = toml_edit::value(shell);
+        } else if doc.contains_key("shell") {
+            doc.remove("shell");
+        }
+
+        // Notifications
+        let notif = doc["notifications"]
+            .or_insert(toml_edit::Item::Table(toml_edit::Table::new()))
+            .as_table_mut();
+        if let Some(t) = notif {
+            t["system_notifications"] =
+                toml_edit::value(self.app_config.notifications.system_notifications);
+            t["dock_badge"] = toml_edit::value(self.app_config.notifications.dock_badge);
+            t["auto_reorder_workspaces"] =
+                toml_edit::value(self.app_config.notifications.auto_reorder_workspaces);
+
+            let sound = t["sound"]
+                .or_insert(toml_edit::Item::Table(toml_edit::Table::new()))
+                .as_table_mut();
+            if let Some(s) = sound {
+                s["sound"] = toml_edit::value(&self.app_config.notifications.sound.sound);
+                s["play_when_focused"] =
+                    toml_edit::value(self.app_config.notifications.sound.play_when_focused);
+            }
+        }
+
+        if let Err(e) = std::fs::write(path, doc.to_string()) {
+            tracing::error!("Failed to write config: {e}");
+        } else {
+            tracing::info!("Settings saved to {}", path.display());
+        }
+    }
+}

--- a/crates/amux-app/src/settings_modal.rs
+++ b/crates/amux-app/src/settings_modal.rs
@@ -21,14 +21,24 @@ fn color_picker_row(
     if response.changed() {
         *color = Some(rgb);
     }
-    if color.is_some() {
-        if ui.small_button("Reset").clicked() {
-            *color = None;
-        }
-    } else {
-        ui.weak("default");
-    }
     ui.end_row();
+}
+
+/// Build a ColorsConfig from the modal's current color state.
+fn colors_from_modal(modal: &SettingsModal) -> config::ColorsConfig {
+    config::ColorsConfig {
+        foreground: modal.foreground.map(rgb_to_hex),
+        background: modal.background.map(rgb_to_hex),
+        cursor_fg: modal.cursor_fg.map(rgb_to_hex),
+        cursor_bg: modal.cursor_bg.map(rgb_to_hex),
+        selection_fg: modal.selection_fg.map(rgb_to_hex),
+        selection_bg: modal.selection_bg.map(rgb_to_hex),
+        accent: modal.accent.map(rgb_to_hex),
+        sidebar_bg: modal.sidebar_bg.map(rgb_to_hex),
+        notification_ring: modal.notification_ring.map(rgb_to_hex),
+        pane_dim_alpha: Some(modal.pane_dim_alpha),
+        palette: Vec::new(),
+    }
 }
 
 fn hex_to_rgb(s: &str) -> Option<[u8; 3]> {
@@ -65,6 +75,7 @@ pub(crate) struct SettingsModal {
     /// Snapshot of original values for cancel/revert.
     original_font_size: f32,
     original_font_family: String,
+    original_colors: config::ColorsConfig,
 }
 
 impl SettingsModal {
@@ -95,6 +106,7 @@ impl SettingsModal {
             pane_dim_alpha: config.colors.pane_dim_alpha.unwrap_or(100),
             original_font_size: config.font_size,
             original_font_family: config.font_family.clone(),
+            original_colors: config.colors.clone(),
         }
     }
 }
@@ -197,7 +209,7 @@ impl AmuxApp {
                     ];
 
                     egui::Grid::new("colors_grid")
-                        .num_columns(3)
+                        .num_columns(2)
                         .spacing([8.0, 4.0])
                         .show(ui, |ui| {
                             color_picker_row(
@@ -229,7 +241,6 @@ impl AmuxApp {
                             // Chrome
                             ui.separator();
                             ui.separator();
-                            ui.separator();
                             ui.end_row();
                             color_picker_row(ui, "Accent", &mut modal.accent, accent_default);
                             color_picker_row(
@@ -251,6 +262,20 @@ impl AmuxApp {
                         ui.add(egui::Slider::new(&mut modal.pane_dim_alpha, 0..=255));
                     });
 
+                    ui.add_space(4.0);
+                    if ui.button("Reset colors to defaults").clicked() {
+                        modal.foreground = None;
+                        modal.background = None;
+                        modal.cursor_fg = None;
+                        modal.cursor_bg = None;
+                        modal.selection_fg = None;
+                        modal.selection_bg = None;
+                        modal.accent = None;
+                        modal.sidebar_bg = None;
+                        modal.notification_ring = None;
+                        modal.pane_dim_alpha = 100;
+                    }
+
                     ui.add_space(8.0);
 
                     // --- Buttons ---
@@ -271,6 +296,14 @@ impl AmuxApp {
                             gpu.set_font_size(self.font_size);
                         }
                     }
+
+                    // Live preview color changes — rebuild theme + propagate
+                    // to all panes whenever the modal's color state changes.
+                    let live_colors = colors_from_modal(modal);
+                    if live_colors != self.app_config.colors {
+                        self.app_config.colors = live_colors;
+                        self.rebuild_theme_and_propagate();
+                    }
                 });
         });
 
@@ -283,14 +316,48 @@ impl AmuxApp {
             self.save_config_to_disk();
             self.settings_modal = None;
         } else if cancel {
-            // Revert live-previewed changes
+            // Revert live-previewed font + colors
             let modal = self.settings_modal.as_ref().unwrap();
             self.font_size = modal.original_font_size;
             #[cfg(feature = "gpu-renderer")]
             if let Some(gpu) = &mut self.gpu_renderer {
                 gpu.set_font_size(self.font_size);
             }
+            let original_colors = modal.original_colors.clone();
+            if self.app_config.colors != original_colors {
+                self.app_config.colors = original_colors;
+                self.rebuild_theme_and_propagate();
+            }
             self.settings_modal = None;
+        }
+    }
+
+    /// Rebuild the theme from app_config.colors and propagate the new
+    /// palette to all running panes. Used by both live color preview
+    /// and the cancel-revert path.
+    fn rebuild_theme_and_propagate(&mut self) {
+        let mut new_theme = match self.app_config.theme_source.as_str() {
+            "ghostty" => {
+                if let Some(ghostty_cfg) = amux_ghostty_config::GhosttyConfig::load() {
+                    crate::theme::Theme::from_ghostty(&ghostty_cfg)
+                } else {
+                    crate::theme::Theme::default()
+                }
+            }
+            _ => crate::theme::Theme::default(),
+        };
+        new_theme.apply_color_config(&self.app_config.colors);
+        let mut term_config = (*self.config).clone();
+        new_theme.apply_to_palette(&mut term_config.color_palette);
+        let new_palette = term_config.color_palette.clone();
+        self.config = std::sync::Arc::new(term_config);
+        self.theme = new_theme;
+        for entry in self.panes.values_mut() {
+            if let PaneEntry::Terminal(managed) = entry {
+                for surface in managed.surfaces_mut() {
+                    surface.pane.set_palette(new_palette.clone());
+                }
+            }
         }
     }
 

--- a/crates/amux-app/src/settings_modal.rs
+++ b/crates/amux-app/src/settings_modal.rs
@@ -24,6 +24,18 @@ fn color_picker_row(
     ui.end_row();
 }
 
+/// If the given text-field response has focus and a pending paste is
+/// available, append the paste text to the field. Used to handle Cmd+V
+/// on macOS where muda's native menu bar consumes the keystroke before
+/// egui can dispatch Event::Paste.
+fn apply_paste_if_focused(response: &egui::Response, field: &mut String, paste: Option<&str>) {
+    if let Some(text) = paste {
+        if response.has_focus() {
+            field.push_str(text);
+        }
+    }
+}
+
 /// Build a ColorsConfig from the modal's current color state.
 fn colors_from_modal(modal: &SettingsModal) -> config::ColorsConfig {
     config::ColorsConfig {
@@ -116,6 +128,11 @@ impl AmuxApp {
         let mut save = false;
         let mut cancel = false;
 
+        // The macOS native menu bar consumes Cmd+V before egui sees it.
+        // workspace_ops stores the clipboard text in pending_text_field_paste;
+        // here we route it to whichever text field is currently focused.
+        let pending_paste = self.pending_text_field_paste.take();
+
         let palette = crate::popup_theme::MenuPalette::from_theme(&self.theme);
         crate::popup_theme::with_modal_palette(ctx, palette, || {
             egui::Window::new("Settings")
@@ -137,7 +154,12 @@ impl AmuxApp {
 
                     ui.horizontal(|ui| {
                         ui.label("Font family:");
-                        ui.text_edit_singleline(&mut modal.font_family);
+                        let r = ui.text_edit_singleline(&mut modal.font_family);
+                        apply_paste_if_focused(
+                            &r,
+                            &mut modal.font_family,
+                            pending_paste.as_deref(),
+                        );
                     });
 
                     ui.horizontal(|ui| {
@@ -160,7 +182,8 @@ impl AmuxApp {
 
                     ui.horizontal(|ui| {
                         ui.label("Shell:");
-                        ui.text_edit_singleline(&mut modal.shell);
+                        let r = ui.text_edit_singleline(&mut modal.shell);
+                        apply_paste_if_focused(&r, &mut modal.shell, pending_paste.as_deref());
                     });
 
                     ui.add_space(8.0);

--- a/crates/amux-app/src/settings_modal.rs
+++ b/crates/amux-app/src/settings_modal.rs
@@ -6,6 +6,34 @@
 
 use crate::*;
 
+/// A labeled color picker with optional "clear" button.
+/// `color` is None when using theme default, Some([r,g,b]) when overridden.
+fn color_picker_field(ui: &mut egui::Ui, label: &str, color: &mut Option<[u8; 3]>) {
+    ui.horizontal(|ui| {
+        ui.label(label);
+        let mut rgb = color.unwrap_or([128, 128, 128]);
+        let response = ui.color_edit_button_srgb(&mut rgb);
+        if response.changed() {
+            *color = Some(rgb);
+        }
+        if color.is_some() {
+            if ui.small_button("Clear").clicked() {
+                *color = None;
+            }
+        } else {
+            ui.weak("(default)");
+        }
+    });
+}
+
+fn hex_to_rgb(s: &str) -> Option<[u8; 3]> {
+    config::ColorsConfig::parse_hex(s)
+}
+
+fn rgb_to_hex(rgb: [u8; 3]) -> String {
+    format!("#{:02x}{:02x}{:02x}", rgb[0], rgb[1], rgb[2])
+}
+
 /// Editable settings state — populated from AppConfig on open,
 /// applied back on Save.
 pub(crate) struct SettingsModal {
@@ -18,6 +46,17 @@ pub(crate) struct SettingsModal {
     pub(crate) auto_reorder_workspaces: bool,
     pub(crate) sound: String,
     pub(crate) play_when_focused: bool,
+    // Colors (None = use theme default)
+    pub(crate) foreground: Option<[u8; 3]>,
+    pub(crate) background: Option<[u8; 3]>,
+    pub(crate) cursor_fg: Option<[u8; 3]>,
+    pub(crate) cursor_bg: Option<[u8; 3]>,
+    pub(crate) selection_fg: Option<[u8; 3]>,
+    pub(crate) selection_bg: Option<[u8; 3]>,
+    pub(crate) accent: Option<[u8; 3]>,
+    pub(crate) sidebar_bg: Option<[u8; 3]>,
+    pub(crate) notification_ring: Option<[u8; 3]>,
+    pub(crate) pane_dim_alpha: u8,
     /// Snapshot of original values for cancel/revert.
     original_font_size: f32,
     original_font_family: String,
@@ -35,6 +74,20 @@ impl SettingsModal {
             auto_reorder_workspaces: config.notifications.auto_reorder_workspaces,
             sound: config.notifications.sound.sound.clone(),
             play_when_focused: config.notifications.sound.play_when_focused,
+            foreground: config.colors.foreground.as_deref().and_then(hex_to_rgb),
+            background: config.colors.background.as_deref().and_then(hex_to_rgb),
+            cursor_fg: config.colors.cursor_fg.as_deref().and_then(hex_to_rgb),
+            cursor_bg: config.colors.cursor_bg.as_deref().and_then(hex_to_rgb),
+            selection_fg: config.colors.selection_fg.as_deref().and_then(hex_to_rgb),
+            selection_bg: config.colors.selection_bg.as_deref().and_then(hex_to_rgb),
+            accent: config.colors.accent.as_deref().and_then(hex_to_rgb),
+            sidebar_bg: config.colors.sidebar_bg.as_deref().and_then(hex_to_rgb),
+            notification_ring: config
+                .colors
+                .notification_ring
+                .as_deref()
+                .and_then(hex_to_rgb),
+            pane_dim_alpha: config.colors.pane_dim_alpha.unwrap_or(100),
             original_font_size: config.font_size,
             original_font_family: config.font_family.clone(),
         }
@@ -124,6 +177,31 @@ impl AmuxApp {
 
                     ui.add_space(8.0);
 
+                    // --- Colors ---
+                    ui.heading("Colors");
+                    ui.add_space(4.0);
+                    ui.label("Leave blank for theme default. Use #rrggbb hex.");
+                    ui.add_space(2.0);
+
+                    color_picker_field(ui, "Foreground:", &mut modal.foreground);
+                    color_picker_field(ui, "Background:", &mut modal.background);
+                    color_picker_field(ui, "Cursor fg:", &mut modal.cursor_fg);
+                    color_picker_field(ui, "Cursor bg:", &mut modal.cursor_bg);
+                    color_picker_field(ui, "Selection fg:", &mut modal.selection_fg);
+                    color_picker_field(ui, "Selection bg:", &mut modal.selection_bg);
+
+                    ui.add_space(4.0);
+                    ui.label("Chrome");
+                    color_picker_field(ui, "Accent:", &mut modal.accent);
+                    color_picker_field(ui, "Sidebar bg:", &mut modal.sidebar_bg);
+                    color_picker_field(ui, "Notif ring:", &mut modal.notification_ring);
+                    ui.horizontal(|ui| {
+                        ui.label("Pane dim:");
+                        ui.add(egui::Slider::new(&mut modal.pane_dim_alpha, 0..=255));
+                    });
+
+                    ui.add_space(8.0);
+
                     // --- Buttons ---
                     ui.horizontal(|ui| {
                         if ui.button("Save").clicked() {
@@ -183,6 +261,18 @@ impl AmuxApp {
         self.app_config.notifications.sound.sound = modal.sound.clone();
         self.app_config.notifications.sound.play_when_focused = modal.play_when_focused;
 
+        // Colors
+        self.app_config.colors.foreground = modal.foreground.map(rgb_to_hex);
+        self.app_config.colors.background = modal.background.map(rgb_to_hex);
+        self.app_config.colors.cursor_fg = modal.cursor_fg.map(rgb_to_hex);
+        self.app_config.colors.cursor_bg = modal.cursor_bg.map(rgb_to_hex);
+        self.app_config.colors.selection_fg = modal.selection_fg.map(rgb_to_hex);
+        self.app_config.colors.selection_bg = modal.selection_bg.map(rgb_to_hex);
+        self.app_config.colors.accent = modal.accent.map(rgb_to_hex);
+        self.app_config.colors.sidebar_bg = modal.sidebar_bg.map(rgb_to_hex);
+        self.app_config.colors.notification_ring = modal.notification_ring.map(rgb_to_hex);
+        self.app_config.colors.pane_dim_alpha = Some(modal.pane_dim_alpha);
+
         #[cfg(feature = "gpu-renderer")]
         if let Some(gpu) = &mut self.gpu_renderer {
             gpu.set_font_size(self.font_size);
@@ -236,6 +326,37 @@ impl AmuxApp {
                 s["sound"] = toml_edit::value(&self.app_config.notifications.sound.sound);
                 s["play_when_focused"] =
                     toml_edit::value(self.app_config.notifications.sound.play_when_focused);
+            }
+        }
+
+        // Colors
+        let colors = doc["colors"]
+            .or_insert(toml_edit::Item::Table(toml_edit::Table::new()))
+            .as_table_mut();
+        if let Some(c) = colors {
+            fn set_opt_color(table: &mut toml_edit::Table, key: &str, val: &Option<String>) {
+                match val {
+                    Some(v) => table[key] = toml_edit::value(v),
+                    None => {
+                        table.remove(key);
+                    }
+                }
+            }
+            set_opt_color(c, "foreground", &self.app_config.colors.foreground);
+            set_opt_color(c, "background", &self.app_config.colors.background);
+            set_opt_color(c, "cursor_fg", &self.app_config.colors.cursor_fg);
+            set_opt_color(c, "cursor_bg", &self.app_config.colors.cursor_bg);
+            set_opt_color(c, "selection_fg", &self.app_config.colors.selection_fg);
+            set_opt_color(c, "selection_bg", &self.app_config.colors.selection_bg);
+            set_opt_color(c, "accent", &self.app_config.colors.accent);
+            set_opt_color(c, "sidebar_bg", &self.app_config.colors.sidebar_bg);
+            set_opt_color(
+                c,
+                "notification_ring",
+                &self.app_config.colors.notification_ring,
+            );
+            if let Some(alpha) = self.app_config.colors.pane_dim_alpha {
+                c["pane_dim_alpha"] = toml_edit::value(alpha as i64);
             }
         }
 

--- a/crates/amux-app/src/settings_modal.rs
+++ b/crates/amux-app/src/settings_modal.rs
@@ -6,24 +6,29 @@
 
 use crate::*;
 
-/// A labeled color picker with optional "clear" button.
-/// `color` is None when using theme default, Some([r,g,b]) when overridden.
-fn color_picker_field(ui: &mut egui::Ui, label: &str, color: &mut Option<[u8; 3]>) {
-    ui.horizontal(|ui| {
-        ui.label(label);
-        let mut rgb = color.unwrap_or([128, 128, 128]);
-        let response = ui.color_edit_button_srgb(&mut rgb);
-        if response.changed() {
-            *color = Some(rgb);
+/// A color picker grid row. Shows the theme default color in the swatch when
+/// no override is set; clicking the swatch promotes it to an explicit override.
+/// "Reset" clears back to theme default.
+fn color_picker_row(
+    ui: &mut egui::Ui,
+    label: &str,
+    color: &mut Option<[u8; 3]>,
+    theme_default: [u8; 3],
+) {
+    ui.label(label);
+    let mut rgb = color.unwrap_or(theme_default);
+    let response = ui.color_edit_button_srgb(&mut rgb);
+    if response.changed() {
+        *color = Some(rgb);
+    }
+    if color.is_some() {
+        if ui.small_button("Reset").clicked() {
+            *color = None;
         }
-        if color.is_some() {
-            if ui.small_button("Clear").clicked() {
-                *color = None;
-            }
-        } else {
-            ui.weak("(default)");
-        }
-    });
+    } else {
+        ui.weak("default");
+    }
+    ui.end_row();
 }
 
 fn hex_to_rgb(s: &str) -> Option<[u8; 3]> {
@@ -180,21 +185,67 @@ impl AmuxApp {
                     // --- Colors ---
                     ui.heading("Colors");
                     ui.add_space(4.0);
-                    ui.label("Leave blank for theme default. Use #rrggbb hex.");
-                    ui.add_space(2.0);
 
-                    color_picker_field(ui, "Foreground:", &mut modal.foreground);
-                    color_picker_field(ui, "Background:", &mut modal.background);
-                    color_picker_field(ui, "Cursor fg:", &mut modal.cursor_fg);
-                    color_picker_field(ui, "Cursor bg:", &mut modal.cursor_bg);
-                    color_picker_field(ui, "Selection fg:", &mut modal.selection_fg);
-                    color_picker_field(ui, "Selection bg:", &mut modal.selection_bg);
+                    let tc = &self.theme.terminal;
+                    let cc = &self.theme.chrome;
+                    let accent_default = [cc.accent.r(), cc.accent.g(), cc.accent.b()];
+                    let sidebar_default = [cc.sidebar_bg.r(), cc.sidebar_bg.g(), cc.sidebar_bg.b()];
+                    let ring_default = [
+                        cc.notification_ring.r(),
+                        cc.notification_ring.g(),
+                        cc.notification_ring.b(),
+                    ];
 
-                    ui.add_space(4.0);
-                    ui.label("Chrome");
-                    color_picker_field(ui, "Accent:", &mut modal.accent);
-                    color_picker_field(ui, "Sidebar bg:", &mut modal.sidebar_bg);
-                    color_picker_field(ui, "Notif ring:", &mut modal.notification_ring);
+                    egui::Grid::new("colors_grid")
+                        .num_columns(3)
+                        .spacing([8.0, 4.0])
+                        .show(ui, |ui| {
+                            color_picker_row(
+                                ui,
+                                "Foreground",
+                                &mut modal.foreground,
+                                tc.foreground,
+                            );
+                            color_picker_row(
+                                ui,
+                                "Background",
+                                &mut modal.background,
+                                tc.background,
+                            );
+                            color_picker_row(ui, "Cursor fg", &mut modal.cursor_fg, tc.cursor_fg);
+                            color_picker_row(ui, "Cursor bg", &mut modal.cursor_bg, tc.cursor_bg);
+                            color_picker_row(
+                                ui,
+                                "Selection fg",
+                                &mut modal.selection_fg,
+                                tc.selection_fg,
+                            );
+                            color_picker_row(
+                                ui,
+                                "Selection bg",
+                                &mut modal.selection_bg,
+                                tc.selection_bg,
+                            );
+                            // Chrome
+                            ui.separator();
+                            ui.separator();
+                            ui.separator();
+                            ui.end_row();
+                            color_picker_row(ui, "Accent", &mut modal.accent, accent_default);
+                            color_picker_row(
+                                ui,
+                                "Sidebar bg",
+                                &mut modal.sidebar_bg,
+                                sidebar_default,
+                            );
+                            color_picker_row(
+                                ui,
+                                "Notif ring",
+                                &mut modal.notification_ring,
+                                ring_default,
+                            );
+                        });
+
                     ui.horizontal(|ui| {
                         ui.label("Pane dim:");
                         ui.add(egui::Slider::new(&mut modal.pane_dim_alpha, 0..=255));

--- a/crates/amux-app/src/settings_modal.rs
+++ b/crates/amux-app/src/settings_modal.rs
@@ -1,8 +1,13 @@
 //! Settings modal UI.
 //!
-//! Presents a centered window with configurable settings for appearance
-//! and notifications. Changes are applied immediately (live preview) and
-//! persisted to config.toml on Save.
+//! Presents a centered window with configurable settings for appearance,
+//! notifications, and colors. Font size and color changes are
+//! live-previewed (applied immediately to running panes); other fields
+//! (font family, theme source, shell, notification toggles, sound) take
+//! effect on Save. Cancel reverts live-previewed changes.
+//!
+//! Save persists the full settings state to `config.toml` via `toml_edit`
+//! so user comments and unknown fields are preserved.
 
 use crate::*;
 
@@ -149,7 +154,7 @@ impl AmuxApp {
 
                     ui.horizontal(|ui| {
                         ui.label("Font size:");
-                        ui.add(egui::Slider::new(&mut modal.font_size, 6.0..=48.0).step_by(1.0));
+                        ui.add(egui::Slider::new(&mut modal.font_size, 4.0..=96.0).step_by(1.0));
                     });
 
                     ui.horizontal(|ui| {
@@ -387,9 +392,19 @@ impl AmuxApp {
     fn apply_settings(&mut self) {
         let modal = self.settings_modal.as_ref().unwrap();
 
-        self.font_size = modal.font_size;
-        self.app_config.font_size = modal.font_size;
-        self.app_config.font_family = modal.font_family.clone();
+        // Normalize: clamp font size to validated range, trim font family
+        // and fall back to default when empty.
+        let validated_size = config::validate_font_size(modal.font_size);
+        let trimmed_family = modal.font_family.trim();
+        let normalized_family = if trimmed_family.is_empty() {
+            config::DEFAULT_FONT_FAMILY.to_string()
+        } else {
+            trimmed_family.to_string()
+        };
+
+        self.font_size = validated_size;
+        self.app_config.font_size = validated_size;
+        self.app_config.font_family = normalized_family;
         self.app_config.theme_source = modal.theme_source.clone();
         self.app_config.shell = if modal.shell.is_empty() {
             None
@@ -401,6 +416,11 @@ impl AmuxApp {
         self.app_config.notifications.auto_reorder_workspaces = modal.auto_reorder_workspaces;
         self.app_config.notifications.sound.sound = modal.sound.clone();
         self.app_config.notifications.sound.play_when_focused = modal.play_when_focused;
+        // Reconfigure the runtime sound player so the new sound mode takes
+        // effect immediately (without requiring a restart).
+        if let Some(player) = &mut self.sound_player {
+            player.configure(&modal.sound);
+        }
 
         // Colors
         self.app_config.colors.foreground = modal.foreground.map(rgb_to_hex);
@@ -424,18 +444,48 @@ impl AmuxApp {
     }
 
     fn save_config_to_disk(&self) {
-        let Some(path) = &self.config_file_path else {
-            tracing::warn!("No config file path — settings not saved to disk");
+        // Resolve path: prefer the loaded config path; otherwise fall back to
+        // ~/.amux/config.toml so Save still works when the user's existing
+        // config failed to parse at startup (load returned no path) or when
+        // there's no config file yet.
+        let path = self
+            .config_file_path
+            .clone()
+            .or_else(|| dirs::home_dir().map(|h| h.join(".amux").join("config.toml")));
+        let Some(path) = path else {
+            tracing::warn!("Could not resolve config path — settings not saved");
             return;
         };
 
+        // Ensure parent directory exists.
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                tracing::warn!("Failed to create config dir {}: {e}", parent.display());
+            }
+        }
+
         // Read existing file content to preserve comments and unknown fields.
-        let existing = std::fs::read_to_string(path).unwrap_or_default();
-        let mut doc = match existing.parse::<toml_edit::DocumentMut>() {
-            Ok(d) => d,
+        // Distinguish "missing/empty file" from "read error". On read error,
+        // log it but proceed with an empty doc so Save still works.
+        let existing = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
             Err(e) => {
-                tracing::warn!("Failed to parse config for update: {e}");
-                return;
+                tracing::warn!("Failed to read existing config: {e} — starting fresh");
+                String::new()
+            }
+        };
+        let mut doc = if existing.trim().is_empty() {
+            toml_edit::DocumentMut::new()
+        } else {
+            match existing.parse::<toml_edit::DocumentMut>() {
+                Ok(d) => d,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to parse existing config ({e}) — overwriting with fresh doc"
+                    );
+                    toml_edit::DocumentMut::new()
+                }
             }
         };
 
@@ -501,8 +551,8 @@ impl AmuxApp {
             }
         }
 
-        if let Err(e) = std::fs::write(path, doc.to_string()) {
-            tracing::error!("Failed to write config: {e}");
+        if let Err(e) = std::fs::write(&path, doc.to_string()) {
+            tracing::error!("Failed to write config to {}: {e}", path.display());
         } else {
             tracing::info!("Settings saved to {}", path.display());
         }

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -523,6 +523,7 @@ pub(crate) fn run() -> anyhow::Result<()> {
                 selection_changed: false,
                 tab_drag: None,
                 rename_modal: None,
+                settings_modal: None,
                 app_focused: true,
                 app_config,
                 keybindings,

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -293,6 +293,12 @@ impl AmuxApp {
                         self.select_all_visible();
                     }
                 }
+                menu_bar::MenuAction::Settings => {
+                    if self.settings_modal.is_none() {
+                        self.settings_modal =
+                            Some(settings_modal::SettingsModal::from_config(&self.app_config));
+                    }
+                }
             }
         }
     }

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -6,6 +6,7 @@ impl AmuxApp {
     /// Check if any egui text field (omnibar, rename modal, find bar) has focus.
     pub(crate) fn has_focused_text_field(&self) -> bool {
         self.rename_modal.is_some()
+            || self.settings_modal.is_some()
             || self.find_state.is_some()
             || self.omnibar_state.values().any(|s| s.focused)
     }

--- a/crates/amux-core/src/config.rs
+++ b/crates/amux-core/src/config.rs
@@ -9,7 +9,7 @@ pub const DEFAULT_FONT_SIZE: f32 = 14.0;
 
 /// Custom color palette configuration.
 /// Colors are specified as hex strings: "#rrggbb" or "rrggbb".
-#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Deserialize)]
 #[serde(default)]
 pub struct ColorsConfig {
     pub foreground: Option<String>,

--- a/crates/amux-render-gpu/src/snapshot.rs
+++ b/crates/amux-render-gpu/src/snapshot.rs
@@ -22,6 +22,10 @@ pub struct TerminalSnapshot {
     pub cursor_bg: [f32; 4],
     pub cursor_fg: [f32; 4],
     pub is_focused: bool,
+    /// Configured dim overlay alpha (0–255) for unfocused panes. Stored
+    /// here so the GPU renderer's dirty-check can detect changes and
+    /// rebuild cell buffers when the user adjusts pane_dim_alpha.
+    pub pane_dim_alpha: u8,
     pub scroll_offset: usize,
     /// Text under the cursor (for block cursor rendering).
     pub cursor_text: String,
@@ -121,6 +125,9 @@ impl TerminalSnapshot {
         seqno: usize,
         highlight_ranges: Vec<(usize, usize, usize)>,
         current_highlight: Option<usize>,
+        // Dim overlay alpha (0–255, matches CPU path semantics): 0 = no dim,
+        // 255 = fully black. Applied to unfocused panes.
+        pane_dim_alpha: u8,
     ) -> Self {
         let palette = backend.palette();
         let cursor = backend.cursor();
@@ -216,8 +223,14 @@ impl TerminalSnapshot {
             }
         }
 
-        // Dim background colors for unfocused panes.
-        let dim_factor = if is_focused { 1.0 } else { 0.6 };
+        // Dim background colors for unfocused panes. The CPU path overlays a
+        // black rect with alpha=pane_dim_alpha; approximate the same visual by
+        // multiplying cell backgrounds by (1 - alpha/255).
+        let dim_factor = if is_focused {
+            1.0
+        } else {
+            1.0 - (pane_dim_alpha as f32 / 255.0)
+        };
         let dimmed_bg = dim_color(default_bg, dim_factor);
         if !is_focused {
             for cell in &mut cells {
@@ -240,6 +253,7 @@ impl TerminalSnapshot {
             cursor_bg,
             cursor_fg,
             is_focused,
+            pane_dim_alpha,
             scroll_offset,
             cursor_text,
             cursor_text_bold,
@@ -401,8 +415,19 @@ mod tests {
             palette: Palette::default(),
         };
 
-        let snap =
-            TerminalSnapshot::from_backend(&backend, 2, 1, 0, true, None, 0, 0, Vec::new(), None);
+        let snap = TerminalSnapshot::from_backend(
+            &backend,
+            2,
+            1,
+            0,
+            true,
+            None,
+            0,
+            0,
+            Vec::new(),
+            None,
+            0,
+        );
 
         // Normal cell: fg=red, bg=blue (unchanged)
         assert_eq!(snap.cells[0].fg, [1.0, 0.0, 0.0, 1.0]);

--- a/crates/amux-render-gpu/src/state.rs
+++ b/crates/amux-render-gpu/src/state.rs
@@ -53,6 +53,7 @@ pub struct PaneRenderState {
     cursor_shape: CursorShape,
     scroll_offset: usize,
     is_focused: bool,
+    pane_dim_alpha: u8,
     selection_range: Option<((usize, usize), (usize, usize))>,
     highlight_hash: u64,
     current_highlight: Option<usize>,
@@ -106,6 +107,7 @@ impl PaneRenderState {
             cursor_shape: CursorShape::Default,
             scroll_offset: 0,
             is_focused: false,
+            pane_dim_alpha: 0,
             selection_range: None,
             highlight_hash: 0,
             current_highlight: None,
@@ -142,6 +144,7 @@ impl PaneRenderState {
             || self.cursor_shape != snap.cursor_shape
             || self.scroll_offset != snap.scroll_offset
             || self.is_focused != snap.is_focused
+            || self.pane_dim_alpha != snap.pane_dim_alpha
             || self.rect_x != rect.x
             || self.rect_y != rect.y
             || self.rect_w != rect.width
@@ -175,6 +178,7 @@ impl PaneRenderState {
         self.cursor_shape = snap.cursor_shape;
         self.scroll_offset = snap.scroll_offset;
         self.is_focused = snap.is_focused;
+        self.pane_dim_alpha = snap.pane_dim_alpha;
         self.selection_range = snap.selection_range;
         self.highlight_hash = hash_highlight_ranges(&snap.highlight_ranges);
         self.current_highlight = snap.current_highlight;


### PR DESCRIPTION
## Summary
- New settings modal: Edit > Settings (Win/Linux) or amux > Settings… / Cmd+, (macOS)
- **Appearance**: font size slider with live preview, font family, theme source, shell override
- **Notifications**: system notifications, dock badge, auto-reorder, sound, play when focused
- Saves to `config.toml` using `toml_edit` to preserve comments and unknown fields
- Cancel reverts any live-previewed changes

Fixes #25

## Test plan
- [ ] macOS: Cmd+, opens settings, Escape closes, Save persists to `~/.amux/config.toml`
- [ ] Windows/Linux: Edit > Settings opens it
- [ ] Drag font size slider — terminal text updates live
- [ ] Cancel after changing font size — reverts to original
- [ ] Save — verify `~/.amux/config.toml` is updated with new values
- [ ] Change theme to Ghostty, save, reopen settings — should show Ghostty selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Settings modal accessible from the menu, enabling users to customize appearance (font size, font family, theme, shell), manage notification preferences, adjust sound settings, and override theme colors with the ability to reset to defaults.
  * Settings changes are persisted to disk with Save/Cancel options to revert live previews.

* **Chores**
  * Added dependency for improved configuration file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->