### PR TITLE
Fix modal mouse passthrough + selection bugs

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -427,8 +427,12 @@ impl eframe::App for AmuxApp {
                     let layout = self.active_workspace().tree.layout(panel_rect);
                     let focused = self.focused_pane_id();
 
-                    // Click-to-focus + selection start
-                    if ui.input(|i| i.pointer.primary_pressed()) {
+                    // Click-to-focus + selection start. Skip when the click
+                    // landed on an egui overlay (modal, popup) so clicking
+                    // inside a Settings or rename modal doesn't change the
+                    // focused pane behind it.
+                    if ui.input(|i| i.pointer.primary_pressed()) && !ui.ctx().is_pointer_over_area()
+                    {
                         if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
                             for &(id, rect) in &layout {
                                 if rect.contains(pos) {

--- a/crates/amux-app/src/input.rs
+++ b/crates/amux-app/src/input.rs
@@ -870,6 +870,19 @@ impl AmuxApp {
             return false;
         }
 
+        // Don't start a new selection (or extend an existing one with a fresh
+        // press) when an egui overlay (modal, popup, context menu) is over the
+        // pointer. The terminal pane sits in the Background layer; clicks on
+        // egui Windows above it would otherwise bleed through and start a
+        // text selection in the terminal behind the modal.
+        //
+        // We only block the *press*. An ongoing drag (`primary_down` without
+        // `primary_pressed`) keeps working so a selection started on the
+        // terminal can extend even if the mouse passes under an overlay.
+        if primary_pressed && ui.ctx().is_pointer_over_area() {
+            return false;
+        }
+
         // Skip selection when the pointer is in the scrollbar hit zone
         // (rightmost 16px of the content area) so the scrollbar drag
         // interaction takes priority over text selection.
@@ -913,46 +926,88 @@ impl AmuxApp {
                 self.last_click_time = now;
                 self.last_click_pos = pos;
 
-                let (anchor, end, mode) = match self.click_count {
+                // Single-click cell selection: defer creating the selection
+                // state until the user actually drags past this cell. Painting
+                // a 1×1 selection on every click produces a flicker square on
+                // the terminal that's visually noisy (and any leftover from
+                // event coalescing wouldn't be cleared by the release path).
+                // Word/line selections (double/triple click) paint immediately
+                // — those are explicit "select this" gestures.
+                let selection = match self.click_count {
                     2 => {
                         // Word selection
-                        // `surface` borrow ends at the match guard so this borrow is safe
                         let Some(surface) = managed.active_surface() else {
                             return false;
                         };
                         let text = selection::line_text_string(&surface.pane, stable_row, cols);
                         let (wstart, wend) = selection::word_bounds_in_line(&text, col);
-                        (
-                            (wstart, stable_row),
-                            (wend, stable_row),
-                            SelectionMode::Word,
-                        )
+                        Some(SelectionState {
+                            anchor: (wstart, stable_row),
+                            end: (wend, stable_row),
+                            mode: SelectionMode::Word,
+                            active: true,
+                        })
                     }
                     3 => {
                         // Line selection
-                        (
-                            (0, stable_row),
-                            (cols.saturating_sub(1), stable_row),
-                            SelectionMode::Line,
-                        )
+                        Some(SelectionState {
+                            anchor: (0, stable_row),
+                            end: (cols.saturating_sub(1), stable_row),
+                            mode: SelectionMode::Line,
+                            active: true,
+                        })
                     }
                     _ => {
-                        // Cell selection
-                        ((col, stable_row), (col, stable_row), SelectionMode::Cell)
+                        // Defer cell selection until drag. Stash the press
+                        // location; the down branch promotes it once the
+                        // mouse moves.
+                        self.pending_selection_start = Some((pane_id, col, stable_row));
+                        None
                     }
                 };
 
+                // Apply the new selection (word/line) or clear the existing
+                // one (single click — matches standard terminal behavior of
+                // any-click-clears-selection).
                 if let Some(PaneEntry::Terminal(m)) = self.panes.get_mut(&pane_id) {
-                    m.selection = Some(SelectionState {
-                        anchor,
-                        end,
-                        mode,
-                        active: true,
-                    });
+                    m.selection = selection;
                 }
                 return true;
             }
         } else if primary_down {
+            // If we have a deferred press waiting to become a real selection,
+            // check whether the mouse has moved to a different cell. If so,
+            // promote it now (anchor=press cell, end=current cell) and let
+            // the normal drag-update path take over from here.
+            if let Some((pending_pane, anchor_col, anchor_row)) = self.pending_selection_start {
+                if pending_pane == pane_id {
+                    if let Some(pos) = pointer_pos {
+                        let (col, stable_row) = selection::pointer_to_cell(
+                            pos,
+                            content_rect,
+                            cell_width,
+                            cell_height,
+                            scroll_offset,
+                            total_rows,
+                            visible_rows,
+                        );
+                        let col = col.min(cols.saturating_sub(1));
+                        if (col, stable_row) != (anchor_col, anchor_row) {
+                            if let Some(PaneEntry::Terminal(m)) = self.panes.get_mut(&pane_id) {
+                                m.selection = Some(SelectionState {
+                                    anchor: (anchor_col, anchor_row),
+                                    end: (col, stable_row),
+                                    mode: SelectionMode::Cell,
+                                    active: true,
+                                });
+                            }
+                            self.pending_selection_start = None;
+                            return true;
+                        }
+                    }
+                }
+            }
+
             // Drag — update selection end
             let has_active_selection = self
                 .panes
@@ -1129,11 +1184,21 @@ impl AmuxApp {
                     return true;
                 }
             }
-        } else if primary_released {
+        }
+
+        // Release is handled independently of press/down so a fast click
+        // (where egui can deliver press + release in the same frame) still
+        // discards the deferred press. Without this it'd be an `else if`
+        // and the press branch would shadow the release.
+        if primary_released {
+            // Click without drag: discard the deferred press, no selection
+            // ever painted.
+            self.pending_selection_start = None;
             if let Some(PaneEntry::Terminal(m)) = self.panes.get_mut(&pane_id) {
                 if let Some(ref mut sel) = m.selection {
                     sel.active = false;
-                    // If no actual drag (anchor == end), clear selection
+                    // Defensive: if a selection somehow ended up at anchor==end
+                    // (e.g., legacy state, future code path), clear it.
                     if sel.anchor == sel.end && sel.mode == SelectionMode::Cell {
                         m.selection = None;
                     }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -175,6 +175,12 @@ struct AmuxApp {
     last_click_time: Instant,
     last_click_pos: egui::Pos2,
     click_count: u32,
+    /// Single-click press info captured but not yet promoted to a SelectionState.
+    /// Held until the mouse moves past the press cell (then we paint the
+    /// selection) or the button releases without moving (then we discard it,
+    /// avoiding the "click leaves a square on the terminal" bug).
+    /// Stores (pane_id, col, stable_row).
+    pending_selection_start: Option<(PaneId, usize, usize)>,
     wants_exit: bool,
     font_size: f32,
     find_state: Option<FindState>,

--- a/crates/amux-app/src/notifications_ui.rs
+++ b/crates/amux-app/src/notifications_ui.rs
@@ -491,7 +491,7 @@ impl AmuxApp {
         let min_left = horizontal_margin.min(max_left);
         let panel_left = (bell_center_x - panel_width / 2.0).clamp(min_left, max_left);
 
-        egui::Window::new("Notifications")
+        let window_response = egui::Window::new("Notifications")
             .title_bar(false)
             .movable(false)
             .collapsible(false)
@@ -612,6 +612,22 @@ impl AmuxApp {
             }
             self.set_focus(pane_id as PaneId);
         }
+        // Click outside the panel dismisses it. Use interact_pos at press time
+        // and check it's outside the window rect. Skip when egui itself is using
+        // the pointer (e.g., dragging the scrollbar inside the panel).
+        if let Some(resp) = window_response {
+            let panel_rect = resp.response.rect;
+            let pressed_outside = ctx.input(|i| {
+                i.pointer.primary_pressed()
+                    && i.pointer
+                        .interact_pos()
+                        .is_some_and(|p| !panel_rect.contains(p))
+            });
+            if pressed_outside && !ctx.is_using_pointer() {
+                close_panel = true;
+            }
+        }
+
         if close_panel {
             self.show_notification_panel = false;
         }

--- a/crates/amux-app/src/pane_render.rs
+++ b/crates/amux-app/src/pane_render.rs
@@ -61,6 +61,7 @@ impl AmuxApp {
         // TODO: replace with screenshot+hide for smoother UX.
         let overlay_open = self.show_notification_panel
             || self.rename_modal.is_some()
+            || self.settings_modal.is_some()
             || self.find_state.is_some();
         for &bid in &browser_pane_ids {
             if let Some(PaneEntry::Browser(b)) = self.panes.get(&bid) {

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -524,6 +524,7 @@ pub(crate) fn run() -> anyhow::Result<()> {
                 tab_drag: None,
                 rename_modal: None,
                 settings_modal: None,
+                pending_selection_start: None,
                 app_focused: true,
                 app_config,
                 keybindings,


### PR DESCRIPTION
## Summary

Four related mouse-handling fixes in the terminal pane:

1. **Modal mouse passthrough**: clicking/dragging inside a settings modal, rename modal, or notification panel no longer starts a text selection in the terminal pane behind it. Uses `ctx.is_pointer_over_area()` to detect overlay coverage.

2. **Notification panel click-out dismiss**: clicking outside the open notification panel now closes it, matching standard popup UX. Skips dismiss while egui is using the pointer (e.g., scrollbar drag inside the panel).

3. **Deferred cell selection on click**: a single-click no longer paints a 1×1 selection square on the terminal. The press location is stashed in \`pending_selection_start\`; the selection only materializes if/when the mouse drags to a different cell. Word/line selections (double/triple click) still paint immediately. Fixes the visual noise from event coalescing where press+release in the same frame left the press's transient selection visible.

4. **Click-clears-selection**: any single left-click now clears the existing selection, matching standard terminal behavior (Terminal.app, iTerm, GNOME Terminal). Double/triple-click replace the selection with word/line selection as before.

Also: add \`settings_modal\` to the \`overlay_open\` check that hides browser webviews when overlays are active (was missing).

## Test plan
- [ ] Open Settings → drag inside modal → terminal behind doesn't start selection
- [ ] Click into a settings text field → focused pane behind doesn't change
- [ ] Open notification panel → click outside → panel dismisses
- [ ] Single fast click on terminal → no square painted
- [ ] Double-click on terminal → word selected
- [ ] Triple-click on terminal → line selected
- [ ] Drag → cell selection appears
- [ ] Selection exists → single click anywhere → selection clears
- [ ] Open Settings while a browser tab is active → webview hides

🤖 Generated with [Claude Code](https://claude.com/claude-code)