### PR TITLE
Fix cursor advancing one tab on every pane focus change

### DIFF
--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -891,6 +891,17 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
     }
 
     fn focus_changed(&mut self, focused: bool) {
+        // Focus reporting (DECSET 1004) is opt-in: only send the event when
+        // the application has enabled it. The encoded bytes are CSI I /
+        // CSI O, which the application reads from stdin via the PTY.
+        //
+        // Critical: write to PTY (write_bytes), NOT vt_write. CSI I as
+        // *output* to the VT engine is interpreted as CHT (Cursor Horizontal
+        // Tab — advance one tab stop), so vt_write here would creep the
+        // cursor forward each time focus changed.
+        if !self.terminal.mode(Mode::FOCUS_EVENT).unwrap_or(false) {
+            return;
+        }
         let event = if focused {
             libghostty_vt::focus::Event::Gained
         } else {
@@ -898,7 +909,8 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         };
         let mut buf = [0u8; 8];
         if let Ok(n) = event.encode(&mut buf) {
-            self.terminal.vt_write(&buf[..n]);
+            let mut writer = self.writer.lock().unwrap_or_else(|e| e.into_inner());
+            let _ = writer.write_all(&buf[..n]);
         }
     }
 

--- a/crates/amux-term/src/ghostty_pane.rs
+++ b/crates/amux-term/src/ghostty_pane.rs
@@ -909,8 +909,9 @@ impl TerminalBackend for GhosttyPane<'_, '_> {
         };
         let mut buf = [0u8; 8];
         if let Ok(n) = event.encode(&mut buf) {
-            let mut writer = self.writer.lock().unwrap_or_else(|e| e.into_inner());
-            let _ = writer.write_all(&buf[..n]);
+            if let Err(e) = self.write_bytes(&buf[..n]) {
+                tracing::warn!("failed to write focus event to PTY: {e}");
+            }
         }
     }
 

--- a/crates/amux-term/tests/ghostty_integration.rs
+++ b/crates/amux-term/tests/ghostty_integration.rs
@@ -402,3 +402,38 @@ fn seqno_increments_on_advance() {
         "expected seqno to increment: {before} -> {after}"
     );
 }
+
+/// Regression: focus_changed used to call terminal.vt_write(b"\x1b[I"), and
+/// since CSI I as VT *output* is interpreted as CHT (Cursor Horizontal Tab —
+/// advance one tab stop), every focus toggle moved the cursor forward 8
+/// columns. The fix routes the focus-report bytes through the PTY writer
+/// (so the application reads them from stdin), and only emits them when the
+/// app has enabled DECSET 1004. Either way, the cursor must not move.
+#[test]
+fn focus_changed_does_not_move_cursor() {
+    let cmd = CommandBuilder::new("true");
+    let mut pane = GhosttyPane::spawn(80, 24, cmd, 10_000).expect("spawn failed");
+
+    // Establish a known cursor position.
+    pane.feed_bytes(b"hello");
+    let before = pane.cursor();
+    assert!(before.x > 0, "cursor should have advanced past column 0");
+
+    // Toggle focus a few times. Pre-fix this would tab the cursor forward
+    // each call (mode 1004 not enabled, so post-fix it should be a no-op).
+    pane.focus_changed(false);
+    pane.focus_changed(true);
+    pane.focus_changed(false);
+    pane.focus_changed(true);
+
+    let after = pane.cursor();
+    assert_eq!(
+        before.x, after.x,
+        "cursor x must not change on focus toggle (1004 disabled): {} -> {}",
+        before.x, after.x
+    );
+    assert_eq!(
+        before.y, after.y,
+        "cursor y must not change on focus toggle"
+    );
+}


### PR DESCRIPTION
## The bug

When clicking between two split panes, the cursor in the newly-focused pane advanced one tab stop on every focus change. Click pane A → A's cursor jumps forward 8 columns. Click pane B → B's cursor jumps forward 8 columns. Repeat indefinitely.

## Root cause

\`GhosttyPane::focus_changed()\` was calling \`self.terminal.vt_write(&buf[..n])\` to deliver the focus-report bytes. \`vt_write\` feeds bytes INTO the VT engine as if they came from the application's stdout. The encoded focus-in sequence is \`\\x1b[I\` (CSI I), which the VT engine interprets as **CHT (Cursor Horizontal Tab — advance N tab stops, default 1)**.

So every focus change was effectively printing a tab character into the focused pane.

## What focus reporting is supposed to do

Focus reporting (DECSET mode 1004) is communication FROM the terminal TO the application:

- Application sets mode 1004 → tells the terminal \"please tell me when you gain/lose focus\"
- Terminal gains focus → terminal writes \`\\x1b[I\` to the application's stdin (via the PTY)
- Terminal loses focus → terminal writes \`\\x1b[O\`

The application reads these from its input stream. They should never go into the VT engine itself.

## Fix

1. Write focus-report bytes through the PTY writer (\`writer.write_all\`), not \`vt_write\`. Bytes go to the application's stdin where they belong.
2. Only send focus events when the application has enabled mode 1004. This matches standard terminal behavior — no point dumping unsolicited bytes into shells/apps that didn't ask for them (most shells don't, but TUIs like vim, htop, Claude Code do).

## Test plan
- [ ] Split pane vertically. Click between panes — cursor should NOT advance in either pane.
- [ ] Open vim or htop in a pane. Click away and back — focus reporting should still work (those apps enable mode 1004).
- [ ] Open a regular shell. Click between panes — no extraneous output anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)