### PR TITLE
Pin Zig to 0.15.2 in CI (unbreak all PR builds)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,13 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          # Pinned to match ghostty's minimum_zig_version in build.zig.zon.
-          # Bumping Zig without checking ghostty's requirement will break
-          # libghostty-vt-sys builds (refs amux <zig-pin-issue>).
+          # Pinned to match Ghostty's `minimum_zig_version` (currently
+          # "0.15.2") declared at:
+          #   https://github.com/ghostty-org/ghostty/blob/main/build.zig.zon
+          # Ghostty hasn't migrated to Zig 0.16 yet; bumping here without
+          # verifying upstream will break libghostty-vt-sys's zig build.
+          # When upstream bumps, bump libghostty-vt patch rev in Cargo.toml
+          # and this pin together.
           version: 0.15.2
 
       - uses: dtolnay/rust-toolchain@stable
@@ -59,9 +63,13 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          # Pinned to match ghostty's minimum_zig_version in build.zig.zon.
-          # Bumping Zig without checking ghostty's requirement will break
-          # libghostty-vt-sys builds (refs amux <zig-pin-issue>).
+          # Pinned to match Ghostty's `minimum_zig_version` (currently
+          # "0.15.2") declared at:
+          #   https://github.com/ghostty-org/ghostty/blob/main/build.zig.zon
+          # Ghostty hasn't migrated to Zig 0.16 yet; bumping here without
+          # verifying upstream will break libghostty-vt-sys's zig build.
+          # When upstream bumps, bump libghostty-vt patch rev in Cargo.toml
+          # and this pin together.
           version: 0.15.2
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: mlugg/setup-zig@v2
+        with:
+          # Pinned to match ghostty's minimum_zig_version in build.zig.zon.
+          # Bumping Zig without checking ghostty's requirement will break
+          # libghostty-vt-sys builds (refs amux <zig-pin-issue>).
+          version: 0.15.2
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -53,6 +58,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev
 
       - uses: mlugg/setup-zig@v2
+        with:
+          # Pinned to match ghostty's minimum_zig_version in build.zig.zon.
+          # Bumping Zig without checking ghostty's requirement will break
+          # libghostty-vt-sys builds (refs amux <zig-pin-issue>).
+          version: 0.15.2
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,10 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          # Pinned to ghostty's minimum_zig_version (build.zig.zon).
-          # See ci.yml for details.
+          # See ci.yml for the full rationale. TL;DR: pinned to match
+          # Ghostty's `minimum_zig_version` from
+          # https://github.com/ghostty-org/ghostty/blob/main/build.zig.zon
+          # so release builds don't fail when a new Zig drops.
           version: 0.15.2
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
             libsoup-3.0-dev
 
       - uses: mlugg/setup-zig@v2
+        with:
+          # Pinned to ghostty's minimum_zig_version (build.zig.zon).
+          # See ci.yml for details.
+          version: 0.15.2
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/crates/amux-browser/src/history.rs
+++ b/crates/amux-browser/src/history.rs
@@ -74,10 +74,11 @@ impl BrowserHistory {
             });
         }
 
-        // Cap at 5000 entries — remove oldest by last_visited_ms
+        // Cap at 5000 entries — remove oldest by last_visited_ms.
+        // sort_by_key + Reverse is clippy-preferred over manual b.cmp(a).
         if self.entries.len() > 5000 {
             self.entries
-                .sort_by(|a, b| b.last_visited_ms.cmp(&a.last_visited_ms));
+                .sort_by_key(|e| std::cmp::Reverse(e.last_visited_ms));
             self.entries.truncate(5000);
         }
 


### PR DESCRIPTION
## The problem

Zig 0.16.0 was released in the past couple days. \`mlugg/setup-zig@v2\` with no pin defaults to latest, so CI started pulling 0.16.0 for every job. Ghostty's \`build.zig.zon\` still requires \`minimum_zig_version = \"0.15.2\"\` and hard-fails the build with:

\`\`\`
src/build/zig.zig:13:9: error: Your Zig version v0.16.0
does not meet the required build version of v0.15.2
\`\`\`

This has been failing every PR CI since Zig 0.16 dropped. Main still shows green because it was merged pre-Zig-0.16.

## Why not upgrade libghostty-rs instead?

Investigated this path first since it was the preferred plan. Conclusion: upgrading wouldn't help.

- Our fork pins ghostty commit \`bebca84\`.
- Upstream libghostty-rs has advanced to ghostty commit \`a1e75da\` (8 commits ahead).
- But even ghostty \`main\` today still has \`minimum_zig_version = \"0.15.2\"\` in \`build.zig.zon\`.
- Ghostty hasn't migrated to Zig 0.16 yet (they usually wait several weeks after a Zig release).

So pinning our CI to 0.15.2 is the correct fix — we're not falling behind, we're matching what ghostty requires. When ghostty bumps its minimum, we can simultaneously update libghostty-rs and unpin Zig.

## Change

Pin \`mlugg/setup-zig@v2\` to \`version: 0.15.2\` in both:
- \`.github/workflows/ci.yml\` (PR check runs)
- \`.github/workflows/release.yml\` (MSIX release builds)

Added inline comments pointing at ghostty's \`build.zig.zon\` as the source of truth so future maintainers know why the pin exists.

## Test plan
- [ ] CI on this PR is green (validates the pin works)
- [ ] Future PRs no longer fail with the \"required build version of v0.15.2\" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)