### PR TITLE
G1: keyed StatusEntry dict on WorkspaceStatus (parity plan #260)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ name = "amux-notify"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -315,7 +315,7 @@ fn render_workspace_row(
     let status = notifications.workspace_status(ws.id);
     let has_status = status.is_some();
     let has_progress = status.as_ref().and_then(|s| s.progress).is_some();
-    let has_agent_message = status.as_ref().and_then(|s| s.message.as_ref()).is_some();
+    let has_agent_message = status.as_ref().and_then(|s| s.message()).is_some();
     let latest_notif = notifications.latest_for_workspace(ws.id);
     let has_notif_text = !has_agent_message && latest_notif.is_some_and(|n| !n.body.is_empty());
     let has_color = ws.color.is_some();
@@ -330,7 +330,7 @@ fn render_workspace_row(
     // overwritten by agent status or auto-detected titles.
     let display_title = if let Some(ref ut) = ws.user_title {
         ut.clone()
-    } else if let Some(task) = status.as_ref().and_then(|s| s.task.as_ref()) {
+    } else if let Some(task) = status.as_ref().and_then(|s| s.task()) {
         format!("\u{2731} {task}")
     } else if let Some(st) = metadata.and_then(|m| m.surface_title.as_ref()) {
         st.clone()
@@ -591,7 +591,7 @@ fn render_workspace_row(
             amux_notify::AgentState::Waiting => ("\u{1F514}", "Needs input"), // 🔔
             amux_notify::AgentState::Idle => ("\u{23F8}", "Idle"), // ⏸ (no variation selector — FE0E renders as box on Windows)
         };
-        let label = status.label.as_deref().unwrap_or(default_text);
+        let label = status.label().unwrap_or(default_text);
         content_bottom += 4.0;
         let status_x = rect.min.x + content_left;
         let max_w = avail_w - content_left - ROW_H_PAD;
@@ -609,7 +609,7 @@ fn render_workspace_row(
     }
 
     // --- Agent message (subtitle) ---
-    if let Some(message) = status.as_ref().and_then(|s| s.message.as_ref()) {
+    if let Some(message) = status.as_ref().and_then(|s| s.message()) {
         let msg_color = meta_color;
         content_bottom += 2.0;
         let msg_x = rect.min.x + content_left;
@@ -617,7 +617,7 @@ fn render_workspace_row(
         let msg_font = egui::FontId::proportional(METADATA_FONT_SIZE);
         let galley = ui
             .painter()
-            .layout(message.clone(), msg_font, msg_color, max_w);
+            .layout(message.to_string(), msg_font, msg_color, max_w);
         let clip_rect = egui::Rect::from_min_size(
             egui::pos2(msg_x, content_bottom),
             egui::vec2(max_w, METADATA_LINE_HEIGHT),

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -315,7 +315,13 @@ fn render_workspace_row(
     let status = notifications.workspace_status(ws.id);
     let has_status = status.is_some();
     let has_progress = status.as_ref().and_then(|s| s.progress).is_some();
-    let has_agent_message = status.as_ref().and_then(|s| s.message()).is_some();
+    // Filter empty-string entries: upsert_entry lets publishers write empty
+    // text, and we shouldn't reserve a subtitle line for a blank message.
+    let agent_message = status
+        .as_ref()
+        .and_then(|s| s.message())
+        .filter(|m| !m.is_empty());
+    let has_agent_message = agent_message.is_some();
     let latest_notif = notifications.latest_for_workspace(ws.id);
     let has_notif_text = !has_agent_message && latest_notif.is_some_and(|n| !n.body.is_empty());
     let has_color = ws.color.is_some();
@@ -609,7 +615,7 @@ fn render_workspace_row(
     }
 
     // --- Agent message (subtitle) ---
-    if let Some(message) = status.as_ref().and_then(|s| s.message()) {
+    if let Some(message) = agent_message {
         let msg_color = meta_color;
         content_bottom += 2.0;
         let msg_x = rect.min.x + content_left;

--- a/crates/amux-notify/Cargo.toml
+++ b/crates/amux-notify/Cargo.toml
@@ -7,3 +7,4 @@ description = "amux OSC notification parsing + in-app store"
 
 [dependencies]
 serde = { workspace = true }
+tracing = { workspace = true }

--- a/crates/amux-notify/src/store.rs
+++ b/crates/amux-notify/src/store.rs
@@ -31,7 +31,6 @@ fn apply_legacy_field(
             entries.insert(
                 key.to_string(),
                 StatusEntry {
-                    key: key.to_string(),
                     text: s,
                     priority,
                     icon: None,
@@ -343,6 +342,12 @@ impl NotificationStore {
     /// `Some("")` expires the entry and `None` leaves it untouched, so
     /// callers driven by the `status.set` IPC can continue to publish just
     /// the fields they want to change.
+    ///
+    /// `state` is **always** authoritative and replaces the existing agent
+    /// state on every call — the `None`-preserves convention applies only to
+    /// the three text fields handled via the shim. Callers that want to
+    /// publish text under their own key without mutating agent state should
+    /// use [`Self::upsert_entry`] instead.
     pub fn set_status(
         &mut self,
         workspace_id: u64,
@@ -397,6 +402,10 @@ impl NotificationStore {
     /// another source's content. Creates the workspace-status record with
     /// [`AgentState::Idle`] if it didn't already exist — callers that need a
     /// specific state should also call [`Self::set_status`].
+    ///
+    /// Keys beginning with [`AGENT_KEY_PREFIX`] (`"agent."`) are reserved for
+    /// the legacy sidebar slots written by [`Self::set_status`] and are
+    /// rejected here with a warning log; use `set_status` to write those.
     pub fn upsert_entry(
         &mut self,
         workspace_id: u64,
@@ -407,6 +416,12 @@ impl NotificationStore {
         color: Option<[u8; 4]>,
     ) {
         let key = key.into();
+        if key.starts_with(AGENT_KEY_PREFIX) {
+            tracing::warn!(
+                "upsert_entry rejected reserved key '{key}' (use set_status for agent.* slots)"
+            );
+            return;
+        }
         let text = text.into();
         let now = Instant::now();
         let status = self
@@ -420,9 +435,8 @@ impl NotificationStore {
             });
         status.updated_at = now;
         status.entries.insert(
-            key.clone(),
+            key,
             StatusEntry {
-                key,
                 text,
                 priority,
                 icon,
@@ -789,9 +803,9 @@ mod tests {
 
         // Entries surface with the expected priorities.
         let by_pri = status.entries_by_priority();
-        assert_eq!(by_pri[0].key, KEY_AGENT_LABEL);
-        assert_eq!(by_pri[1].key, KEY_AGENT_TASK);
-        assert_eq!(by_pri[2].key, KEY_AGENT_MESSAGE);
+        assert_eq!(by_pri[0].0, KEY_AGENT_LABEL);
+        assert_eq!(by_pri[1].0, KEY_AGENT_TASK);
+        assert_eq!(by_pri[2].0, KEY_AGENT_MESSAGE);
     }
 
     #[test]
@@ -870,9 +884,49 @@ mod tests {
         let ordered: Vec<&str> = status
             .entries_by_priority()
             .iter()
-            .map(|e| e.key.as_str())
+            .map(|(k, _)| *k)
             .collect();
         assert_eq!(ordered, vec!["b.high", "a.tie", "c.mid", "a.low"]);
+    }
+
+    #[test]
+    fn upsert_entry_rejects_reserved_agent_prefix() {
+        let mut store = NotificationStore::new();
+        // External publishers must not be able to write the legacy sidebar
+        // slots — set_status is the only legitimate writer for "agent.*".
+        store.upsert_entry(
+            1,
+            KEY_AGENT_MESSAGE,
+            "should not appear",
+            priority::MESSAGE,
+            None,
+            None,
+        );
+        // No workspace status record is created because the write was
+        // rejected before reaching the map.
+        assert!(store.workspace_status(1).is_none());
+
+        // With a pre-existing status from set_status, the agent.* entry
+        // written by set_status survives an external upsert_entry attempt.
+        store.set_status(
+            2,
+            AgentState::Active,
+            None,
+            None,
+            Some("real message".into()),
+        );
+        store.upsert_entry(
+            2,
+            KEY_AGENT_MESSAGE,
+            "should be rejected",
+            priority::MESSAGE,
+            None,
+            None,
+        );
+        assert_eq!(
+            store.workspace_status(2).unwrap().message(),
+            Some("real message")
+        );
     }
 
     #[test]

--- a/crates/amux-notify/src/store.rs
+++ b/crates/amux-notify/src/store.rs
@@ -5,10 +5,43 @@
 //! unread counting, workspace status updates, flash animation triggering,
 //! and per-pane notification state.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Instant;
 
 use crate::types::*;
+
+/// Helper for the [`NotificationStore::set_status`] back-compat shim.
+///
+/// Interprets the legacy `Some("")` / `Some(value)` / `None` convention:
+/// empty string expires the entry, non-empty upserts it, `None` leaves the
+/// existing entry untouched.
+fn apply_legacy_field(
+    entries: &mut BTreeMap<String, StatusEntry>,
+    key: &str,
+    priority: i32,
+    value: Option<String>,
+    now: Instant,
+) {
+    match value {
+        None => {}
+        Some(s) if s.is_empty() => {
+            entries.remove(key);
+        }
+        Some(s) => {
+            entries.insert(
+                key.to_string(),
+                StatusEntry {
+                    key: key.to_string(),
+                    text: s,
+                    priority,
+                    icon: None,
+                    color: None,
+                    updated_at: now,
+                },
+            );
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // NotificationStore
@@ -303,6 +336,13 @@ impl NotificationStore {
     }
 
     /// Set workspace agent status. Clears any existing progress bar.
+    ///
+    /// Back-compat shim over the keyed-entry model: `label`/`task`/`message`
+    /// map to the reserved [`KEY_AGENT_LABEL`] / [`KEY_AGENT_TASK`] /
+    /// [`KEY_AGENT_MESSAGE`] keys. Preserves the historical convention where
+    /// `Some("")` expires the entry and `None` leaves it untouched, so
+    /// callers driven by the `status.set` IPC can continue to publish just
+    /// the fields they want to change.
     pub fn set_status(
         &mut self,
         workspace_id: u64,
@@ -311,30 +351,101 @@ impl NotificationStore {
         task: Option<String>,
         message: Option<String>,
     ) {
-        let existing = self.workspace_statuses.get(&workspace_id);
-        // Normalize empty strings to None, then preserve existing if not provided.
-        // Some("") means "clear", None means "keep previous".
-        let task = match task {
-            Some(s) if s.is_empty() => None,
-            Some(s) => Some(s),
-            None => existing.and_then(|s| s.task.clone()),
-        };
-        let message = match message {
-            Some(s) if s.is_empty() => None,
-            Some(s) => Some(s),
-            None => existing.and_then(|s| s.message.clone()),
-        };
-        self.workspace_statuses.insert(
-            workspace_id,
-            WorkspaceStatus {
+        let now = Instant::now();
+        let entry = self
+            .workspace_statuses
+            .entry(workspace_id)
+            .or_insert_with(|| WorkspaceStatus {
                 state,
-                label,
-                updated_at: Instant::now(),
+                updated_at: now,
                 progress: None,
-                task,
-                message,
+                entries: BTreeMap::new(),
+            });
+        entry.state = state;
+        entry.updated_at = now;
+        // set_status is a "coarse" update: clears any existing progress.
+        entry.progress = None;
+
+        apply_legacy_field(
+            &mut entry.entries,
+            KEY_AGENT_LABEL,
+            priority::LABEL,
+            label,
+            now,
+        );
+        apply_legacy_field(
+            &mut entry.entries,
+            KEY_AGENT_TASK,
+            priority::TASK,
+            task,
+            now,
+        );
+        apply_legacy_field(
+            &mut entry.entries,
+            KEY_AGENT_MESSAGE,
+            priority::MESSAGE,
+            message,
+            now,
+        );
+    }
+
+    /// Publish / replace a keyed status entry for a workspace.
+    ///
+    /// Primary API for [#260](https://github.com/daveowenatl/amux/issues/260)
+    /// parity work: hooks, CLI, and integrations publish under their own key
+    /// so that one source expiring (e.g. a tool completing) doesn't blank
+    /// another source's content. Creates the workspace-status record with
+    /// [`AgentState::Idle`] if it didn't already exist — callers that need a
+    /// specific state should also call [`Self::set_status`].
+    pub fn upsert_entry(
+        &mut self,
+        workspace_id: u64,
+        key: impl Into<String>,
+        text: impl Into<String>,
+        priority: i32,
+        icon: Option<String>,
+        color: Option<[u8; 4]>,
+    ) {
+        let key = key.into();
+        let text = text.into();
+        let now = Instant::now();
+        let status = self
+            .workspace_statuses
+            .entry(workspace_id)
+            .or_insert_with(|| WorkspaceStatus {
+                state: AgentState::Idle,
+                updated_at: now,
+                progress: None,
+                entries: BTreeMap::new(),
+            });
+        status.updated_at = now;
+        status.entries.insert(
+            key.clone(),
+            StatusEntry {
+                key,
+                text,
+                priority,
+                icon,
+                color,
+                updated_at: now,
             },
         );
+    }
+
+    /// Remove a keyed status entry. Returns `true` if an entry was removed.
+    ///
+    /// Used by tool-end hooks (G2) to expire just the tool's entry without
+    /// disturbing other publishers. Safe to call on a missing workspace.
+    pub fn remove_entry(&mut self, workspace_id: u64, key: &str) -> bool {
+        if let Some(status) = self.workspace_statuses.get_mut(&workspace_id) {
+            let removed = status.entries.remove(key).is_some();
+            if removed {
+                status.updated_at = Instant::now();
+            }
+            removed
+        } else {
+            false
+        }
     }
 
     /// Set workspace progress (0.0–1.0). Pass `None` to clear.
@@ -646,12 +757,122 @@ mod tests {
         );
         let status = store.workspace_status(1).unwrap();
         assert_eq!(status.state, AgentState::Active);
-        assert_eq!(status.label.as_deref(), Some("Running tests"));
+        assert_eq!(status.label(), Some("Running tests"));
 
+        // None preserves label under the legacy shim.
         store.set_status(1, AgentState::Idle, None, None, None);
         let status = store.workspace_status(1).unwrap();
         assert_eq!(status.state, AgentState::Idle);
-        assert!(status.label.is_none());
+        assert_eq!(status.label(), Some("Running tests"));
+
+        // Some("") expires the entry.
+        store.set_status(1, AgentState::Idle, Some(String::new()), None, None);
+        let status = store.workspace_status(1).unwrap();
+        assert!(status.label().is_none());
+    }
+
+    #[test]
+    fn set_status_maps_to_reserved_keys() {
+        let mut store = NotificationStore::new();
+        store.set_status(
+            1,
+            AgentState::Active,
+            Some("Working".into()),
+            Some("Refactor foo".into()),
+            Some("reading bar.rs".into()),
+        );
+        let status = store.workspace_status(1).unwrap();
+        assert_eq!(status.label(), Some("Working"));
+        assert_eq!(status.task(), Some("Refactor foo"));
+        assert_eq!(status.message(), Some("reading bar.rs"));
+        assert_eq!(status.entries.len(), 3);
+
+        // Entries surface with the expected priorities.
+        let by_pri = status.entries_by_priority();
+        assert_eq!(by_pri[0].key, KEY_AGENT_LABEL);
+        assert_eq!(by_pri[1].key, KEY_AGENT_TASK);
+        assert_eq!(by_pri[2].key, KEY_AGENT_MESSAGE);
+    }
+
+    #[test]
+    fn upsert_entry_and_remove_entry() {
+        let mut store = NotificationStore::new();
+        store.upsert_entry(
+            1,
+            "claude.tool",
+            "Reading file",
+            priority::MESSAGE,
+            Some("\u{1F4C4}".into()),
+            None,
+        );
+        let status = store.workspace_status(1).unwrap();
+        let entry = status.entry("claude.tool").unwrap();
+        assert_eq!(entry.text, "Reading file");
+        assert_eq!(entry.priority, priority::MESSAGE);
+        assert_eq!(entry.icon.as_deref(), Some("\u{1F4C4}"));
+
+        // Upsert replaces in place.
+        store.upsert_entry(
+            1,
+            "claude.tool",
+            "Editing file",
+            priority::MESSAGE,
+            None,
+            None,
+        );
+        assert_eq!(
+            store
+                .workspace_status(1)
+                .unwrap()
+                .entry("claude.tool")
+                .unwrap()
+                .text,
+            "Editing file"
+        );
+
+        // Remove expires the key and leaves others alone.
+        store.upsert_entry(1, "git.branch", "main", priority::USER_GENERIC, None, None);
+        assert!(store.remove_entry(1, "claude.tool"));
+        let status = store.workspace_status(1).unwrap();
+        assert!(status.entry("claude.tool").is_none());
+        assert!(status.entry("git.branch").is_some());
+
+        // Double-remove returns false.
+        assert!(!store.remove_entry(1, "claude.tool"));
+    }
+
+    #[test]
+    fn upsert_entry_creates_status_if_missing() {
+        let mut store = NotificationStore::new();
+        assert!(store.workspace_status(1).is_none());
+        store.upsert_entry(
+            1,
+            "user.generic",
+            "hello",
+            priority::USER_GENERIC,
+            None,
+            None,
+        );
+        let status = store.workspace_status(1).unwrap();
+        assert_eq!(status.state, AgentState::Idle);
+        assert_eq!(status.entry("user.generic").unwrap().text, "hello");
+    }
+
+    #[test]
+    fn entries_by_priority_sorts_descending() {
+        let mut store = NotificationStore::new();
+        store.upsert_entry(1, "a.low", "low", 10, None, None);
+        store.upsert_entry(1, "b.high", "high", 100, None, None);
+        store.upsert_entry(1, "c.mid", "mid", 50, None, None);
+        // Ties break by key ascending: insert two at priority 50.
+        store.upsert_entry(1, "a.tie", "tie", 50, None, None);
+        let status = store.workspace_status(1).unwrap();
+        let ordered: Vec<&str> = status
+            .entries_by_priority()
+            .iter()
+            .map(|e| e.key.as_str())
+            .collect();
+        assert_eq!(ordered, vec!["b.high", "a.tie", "c.mid", "a.low"]);
     }
 
     #[test]

--- a/crates/amux-notify/src/types.rs
+++ b/crates/amux-notify/src/types.rs
@@ -70,9 +70,12 @@ pub mod priority {
 /// `"agent.message"`, `"claude.tool"`, `"git.branch"`). A fresh write to the
 /// same key replaces the prior entry; a call to
 /// [`super::NotificationStore::remove_entry`] expires it.
+///
+/// The key is carried on the `BTreeMap` — it's not duplicated here. Iterate
+/// via [`WorkspaceStatus::entries_by_priority`] to get `(&str, &StatusEntry)`
+/// pairs.
 #[derive(Debug, Clone)]
 pub struct StatusEntry {
-    pub key: String,
     pub text: String,
     pub priority: i32,
     pub icon: Option<String>,
@@ -100,9 +103,21 @@ pub struct WorkspaceStatus {
 
 /// Reserved entry keys used by the legacy sidebar view. Named here rather
 /// than inline so renames are a single edit.
+///
+/// The `"agent.*"` namespace is reserved for these three keys and is the only
+/// thing that [`NotificationStore::set_status`] writes. Integrations should
+/// pick their own namespace (`"claude.tool"`, `"gemini.state"`, …);
+/// [`NotificationStore::upsert_entry`] rejects writes whose key begins with
+/// `"agent."` so third-party publishers can't stomp the legacy sidebar slots.
+///
+/// [`NotificationStore::set_status`]: super::NotificationStore::set_status
+/// [`NotificationStore::upsert_entry`]: super::NotificationStore::upsert_entry
 pub const KEY_AGENT_LABEL: &str = "agent.label";
 pub const KEY_AGENT_TASK: &str = "agent.task";
 pub const KEY_AGENT_MESSAGE: &str = "agent.message";
+
+/// Reserved key namespace. See [`KEY_AGENT_LABEL`].
+pub const AGENT_KEY_PREFIX: &str = "agent.";
 
 impl WorkspaceStatus {
     /// Fetch an entry by key.
@@ -130,9 +145,10 @@ impl WorkspaceStatus {
 
     /// All entries sorted by descending priority, then by key for stable
     /// output on ties. The sidebar will iterate this once G20 lands.
-    pub fn entries_by_priority(&self) -> Vec<&StatusEntry> {
-        let mut v: Vec<&StatusEntry> = self.entries.values().collect();
-        v.sort_by(|a, b| b.priority.cmp(&a.priority).then_with(|| a.key.cmp(&b.key)));
+    pub fn entries_by_priority(&self) -> Vec<(&str, &StatusEntry)> {
+        let mut v: Vec<(&str, &StatusEntry)> =
+            self.entries.iter().map(|(k, e)| (k.as_str(), e)).collect();
+        v.sort_by(|a, b| b.1.priority.cmp(&a.1.priority).then_with(|| a.0.cmp(b.0)));
         v
     }
 }

--- a/crates/amux-notify/src/types.rs
+++ b/crates/amux-notify/src/types.rs
@@ -4,6 +4,7 @@
 //! agent state, notification source, flash reason, workspace status,
 //! notification payload, and per-pane notification state.
 
+use std::collections::BTreeMap;
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
@@ -45,18 +46,95 @@ pub enum FlashReason {
     NotificationDismiss,
 }
 
+/// Priority tiers for status entries. Higher values sort first in the sidebar.
+///
+/// Reserved keys under `agent.*` feed the existing sidebar fields (label,
+/// task, message) so that legacy callers of [`super::NotificationStore::set_status`]
+/// keep working bit-identically. Integrations (Claude hooks, Gemini, Codex,
+/// user CLI) publish under their own namespaced keys with their own priority.
+pub mod priority {
+    /// Agent state label (e.g. "Running", "Needs input"). Always renders in
+    /// the status row just below the title.
+    pub const LABEL: i32 = 100;
+    /// Agent's current task description (renders in the title line).
+    pub const TASK: i32 = 80;
+    /// Agent's latest message (renders as the subtitle under the status row).
+    pub const MESSAGE: i32 = 60;
+    /// User-published status without an explicit priority.
+    pub const USER_GENERIC: i32 = 50;
+}
+
+/// A single keyed status entry published by a hook, integration, or CLI call.
+///
+/// Entries live on [`WorkspaceStatus::entries`] keyed by publisher (e.g.
+/// `"agent.message"`, `"claude.tool"`, `"git.branch"`). A fresh write to the
+/// same key replaces the prior entry; a call to
+/// [`super::NotificationStore::remove_entry`] expires it.
+#[derive(Debug, Clone)]
+pub struct StatusEntry {
+    pub key: String,
+    pub text: String,
+    pub priority: i32,
+    pub icon: Option<String>,
+    pub color: Option<[u8; 4]>,
+    pub updated_at: Instant,
+}
+
 /// Per-workspace agent status displayed as a pill in the sidebar.
+///
+/// Stores agent state + progress as first-class meta fields, and a keyed
+/// dictionary of [`StatusEntry`] rows. Legacy label/task/message are now
+/// looked up through the reserved keys in [`priority`]; see
+/// [`Self::label`], [`Self::task`], [`Self::message`].
 #[derive(Debug, Clone)]
 pub struct WorkspaceStatus {
     pub state: AgentState,
-    pub label: Option<String>,
     pub updated_at: Instant,
     /// Optional progress value (0.0–1.0) for progress bar display.
     pub progress: Option<f32>,
-    /// Agent's current task description (shown as title line in sidebar).
-    pub task: Option<String>,
-    /// Agent's latest message (shown as subtitle in sidebar).
-    pub message: Option<String>,
+    /// Keyed status entries. Use [`Self::entries_by_priority`] for the
+    /// ordered render list; [`Self::label`] / [`Self::task`] /
+    /// [`Self::message`] for the three legacy sidebar slots.
+    pub entries: BTreeMap<String, StatusEntry>,
+}
+
+/// Reserved entry keys used by the legacy sidebar view. Named here rather
+/// than inline so renames are a single edit.
+pub const KEY_AGENT_LABEL: &str = "agent.label";
+pub const KEY_AGENT_TASK: &str = "agent.task";
+pub const KEY_AGENT_MESSAGE: &str = "agent.message";
+
+impl WorkspaceStatus {
+    /// Fetch an entry by key.
+    pub fn entry(&self, key: &str) -> Option<&StatusEntry> {
+        self.entries.get(key)
+    }
+
+    /// Legacy: agent state label (e.g. "Running"). Backed by
+    /// [`KEY_AGENT_LABEL`].
+    pub fn label(&self) -> Option<&str> {
+        self.entries.get(KEY_AGENT_LABEL).map(|e| e.text.as_str())
+    }
+
+    /// Legacy: agent task (rendered with ★ prefix in the title). Backed by
+    /// [`KEY_AGENT_TASK`].
+    pub fn task(&self) -> Option<&str> {
+        self.entries.get(KEY_AGENT_TASK).map(|e| e.text.as_str())
+    }
+
+    /// Legacy: agent's latest message (sidebar subtitle). Backed by
+    /// [`KEY_AGENT_MESSAGE`].
+    pub fn message(&self) -> Option<&str> {
+        self.entries.get(KEY_AGENT_MESSAGE).map(|e| e.text.as_str())
+    }
+
+    /// All entries sorted by descending priority, then by key for stable
+    /// output on ties. The sidebar will iterate this once G20 lands.
+    pub fn entries_by_priority(&self) -> Vec<&StatusEntry> {
+        let mut v: Vec<&StatusEntry> = self.entries.values().collect();
+        v.sort_by(|a, b| b.priority.cmp(&a.priority).then_with(|| a.key.cmp(&b.key)));
+        v
+    }
 }
 
 /// A single notification entry.


### PR DESCRIPTION
First PR in the #260 parity plan stack. Data-model only — no behavior changes in the sidebar.

## What

Replaces `WorkspaceStatus`'s single `label` / `task` / `message` slots with a `BTreeMap<String, StatusEntry>` so each publisher (hooks, integrations, CLI) can attach status under its own key and expire it independently. This is the foundation that the rest of the plan depends on:

- **G2** (sticky status): \`PostToolUse\` will call \`remove_entry(ws, \"claude.tool\")\` instead of \`set_status(message=\"\")\` — no more blanking shared message between tool calls.
- **G21** (\`amux set-status --key\`): maps directly onto the new \`upsert_entry\` API.
- **G22** (session persistence): serializes the \`entries\` dict.
- **G23** (hook conversion): each hook event writes/removes its own key.

## Back-compat

\`set_status(state, label, task, message)\` stays with the same signature. Internally it maps label/task/message onto the reserved keys \`agent.label\` / \`agent.task\` / \`agent.message\` using priority constants. The \`Some(\"\")\` = clear / \`None\` = preserve convention is preserved so existing IPC callers (\`status.set\` driven by hooks and \`amux set-status\`) keep working bit-identically.

Sidebar now reads through \`.label()\` / \`.task()\` / \`.message()\` accessors instead of field access. No visible rendering change.

## New APIs

\`\`\`rust
store.upsert_entry(ws_id, key, text, priority, icon, color);
store.remove_entry(ws_id, key) -> bool;
status.entry(key) -> Option<&StatusEntry>;
status.entries_by_priority() -> Vec<&StatusEntry>;
\`\`\`

Priority constants in \`amux_notify::priority\` (LABEL=100, TASK=80, MESSAGE=60, USER_GENERIC=50).

## Test plan

- [x] \`cargo test --workspace\` — all tests pass
- [x] \`cargo clippy --workspace -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] New tests: \`set_status_maps_to_reserved_keys\`, \`upsert_entry_and_remove_entry\`, \`upsert_entry_creates_status_if_missing\`, \`entries_by_priority_sorts_descending\`
- [x] Existing \`workspace_status_roundtrip\` + \`progress_lifecycle\` still pass (field-access swapped for method calls)

## Stack

This is the base of a manual stacked-branch chain for the #260 parity plan:

\`\`\`
main
└── parity/g1-keyed-entries           (this PR)
    ├── parity/g2-sticky-status
    ├── parity/g21-cli-keys
    ├── parity/g22-session-persist
    └── parity/g23-hook-conversion    (via g2)
\`\`\`

Refs #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored status management system to support flexible, prioritized status entries with full backward compatibility.
  * Status items now support custom priority ordering and metadata (icons, colors).
  * Improved internal data structure for better scalability and extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->