### PR TITLE
G21: set-entry / remove-entry CLI + IPC methods

### DIFF
--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -938,6 +938,48 @@ impl AmuxApp {
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
                 }
             }
+            "status.upsert_entry" => {
+                match serde_json::from_value::<amux_ipc::methods::UpsertEntryParams>(
+                    req.params.clone(),
+                ) {
+                    Ok(params) => {
+                        if params.key.starts_with(amux_notify::AGENT_KEY_PREFIX) {
+                            Response::err(
+                                req.id.clone(),
+                                "invalid_params",
+                                "keys starting with 'agent.' are reserved for status.set",
+                            )
+                        } else {
+                            let ws_id = params.workspace_id.parse::<u64>().unwrap_or(0);
+                            let priority = params
+                                .priority
+                                .unwrap_or(amux_notify::priority::USER_GENERIC);
+                            self.notifications.upsert_entry(
+                                ws_id,
+                                params.key,
+                                params.text,
+                                priority,
+                                params.icon,
+                                params.color,
+                            );
+                            Response::ok(req.id.clone(), serde_json::json!({}))
+                        }
+                    }
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
+            "status.remove_entry" => {
+                match serde_json::from_value::<amux_ipc::methods::RemoveEntryParams>(
+                    req.params.clone(),
+                ) {
+                    Ok(params) => {
+                        let ws_id = params.workspace_id.parse::<u64>().unwrap_or(0);
+                        let removed = self.notifications.remove_entry(ws_id, &params.key);
+                        Response::ok(req.id.clone(), serde_json::json!({ "removed": removed }))
+                    }
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
             "notify.send" => {
                 match serde_json::from_value::<amux_ipc::methods::NotifySendParams>(
                     req.params.clone(),

--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -973,9 +973,17 @@ impl AmuxApp {
                     req.params.clone(),
                 ) {
                     Ok(params) => {
-                        let ws_id = params.workspace_id.parse::<u64>().unwrap_or(0);
-                        let removed = self.notifications.remove_entry(ws_id, &params.key);
-                        Response::ok(req.id.clone(), serde_json::json!({ "removed": removed }))
+                        if params.key.starts_with(amux_notify::AGENT_KEY_PREFIX) {
+                            Response::err(
+                                req.id.clone(),
+                                "invalid_params",
+                                "keys starting with 'agent.' are reserved for status.set",
+                            )
+                        } else {
+                            let ws_id = params.workspace_id.parse::<u64>().unwrap_or(0);
+                            let removed = self.notifications.remove_entry(ws_id, &params.key);
+                            Response::ok(req.id.clone(), serde_json::json!({ "removed": removed }))
+                        }
                     }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
                 }

--- a/crates/amux-cli/src/cli.rs
+++ b/crates/amux-cli/src/cli.rs
@@ -291,10 +291,10 @@ pub(crate) enum Command {
     /// Publish or replace a keyed status entry.
     ///
     /// Each call writes under its own key (e.g. "claude.tool",
-    /// "git.branch"). Re-using a key replaces the prior entry; pass
-    /// --remove (or use `remove-entry`) to expire it. Keys starting
-    /// with "agent." are reserved for the legacy sidebar slots owned
-    /// by `set-status` and will be rejected.
+    /// "git.branch"). Re-using a key replaces the prior entry; use
+    /// `remove-entry` to expire it. Keys starting with "agent." are
+    /// reserved for the legacy sidebar slots owned by `set-status`
+    /// and will be rejected.
     #[command(name = "set-entry")]
     SetEntry {
         /// Entry key (e.g. "claude.tool", "git.branch"). Must not

--- a/crates/amux-cli/src/cli.rs
+++ b/crates/amux-cli/src/cli.rs
@@ -288,6 +288,42 @@ pub(crate) enum Command {
         #[arg(long)]
         workspace: Option<String>,
     },
+    /// Publish or replace a keyed status entry.
+    ///
+    /// Each call writes under its own key (e.g. "claude.tool",
+    /// "git.branch"). Re-using a key replaces the prior entry; pass
+    /// --remove (or use `remove-entry`) to expire it. Keys starting
+    /// with "agent." are reserved for the legacy sidebar slots owned
+    /// by `set-status` and will be rejected.
+    #[command(name = "set-entry")]
+    SetEntry {
+        /// Entry key (e.g. "claude.tool", "git.branch"). Must not
+        /// start with "agent." — that namespace is reserved.
+        key: String,
+        /// Display text
+        text: String,
+        /// Render priority. Higher sorts first (default 50).
+        #[arg(long)]
+        priority: Option<i32>,
+        /// Optional icon name / emoji (renderer-defined)
+        #[arg(long)]
+        icon: Option<String>,
+        /// Optional RGB/RGBA color, e.g. "#ff8800" or "#ff8800aa"
+        #[arg(long)]
+        color: Option<String>,
+        /// Target workspace ID (defaults to AMUX_WORKSPACE_ID)
+        #[arg(long)]
+        workspace: Option<String>,
+    },
+    /// Remove a previously-published keyed status entry.
+    #[command(name = "remove-entry")]
+    RemoveEntry {
+        /// Entry key to remove
+        key: String,
+        /// Target workspace ID (defaults to AMUX_WORKSPACE_ID)
+        #[arg(long)]
+        workspace: Option<String>,
+    },
     /// Send a notification
     Notify {
         /// Notification body

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -771,20 +771,38 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Command::RemoveEntry { key, workspace } => {
+            if key.starts_with("agent.") {
+                anyhow::bail!(
+                    "keys starting with 'agent.' are reserved for set-status (got '{key}')"
+                );
+            }
             let ws_id = workspace
                 .or_else(|| std::env::var("AMUX_WORKSPACE_ID").ok())
                 .unwrap_or_else(|| "0".to_string());
             let params = serde_json::json!({
                 "workspace_id": ws_id,
-                "key": key,
+                "key": &key,
             });
             let resp = client.call("status.remove_entry", params).await?;
             if cli.json {
                 print_response(&resp, true);
-            } else if resp.ok {
-                println!("Entry removed");
-            } else {
+            } else if !resp.ok {
                 print_response(&resp, false);
+            } else {
+                // The server reports `removed: true` when the key existed,
+                // `false` when it didn't. Print distinct messages and exit
+                // non-zero on the no-op so scripts can tell them apart.
+                let removed = resp
+                    .result
+                    .as_ref()
+                    .and_then(|v| v.get("removed"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if removed {
+                    println!("Entry removed");
+                } else {
+                    anyhow::bail!("no entry to remove for key '{key}'");
+                }
             }
         }
         Command::Notify {

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -728,6 +728,65 @@ async fn main() -> anyhow::Result<()> {
                 print_response(&resp, false);
             }
         }
+        Command::SetEntry {
+            key,
+            text,
+            priority,
+            icon,
+            color,
+            workspace,
+        } => {
+            if key.starts_with("agent.") {
+                anyhow::bail!(
+                    "keys starting with 'agent.' are reserved for set-status (got '{key}')"
+                );
+            }
+            let ws_id = workspace
+                .or_else(|| std::env::var("AMUX_WORKSPACE_ID").ok())
+                .unwrap_or_else(|| "0".to_string());
+            let mut params = serde_json::json!({
+                "workspace_id": ws_id,
+                "key": key,
+                "text": text,
+            });
+            if let Some(p) = priority {
+                params["priority"] = serde_json::json!(p);
+            }
+            if let Some(i) = icon {
+                params["icon"] = serde_json::json!(i);
+            }
+            if let Some(c) = color {
+                let rgba = parse_hex_rgba(&c).ok_or_else(|| {
+                    anyhow::anyhow!("invalid color '{c}' (expected #RRGGBB or #RRGGBBAA)")
+                })?;
+                params["color"] = serde_json::json!(rgba);
+            }
+            let resp = client.call("status.upsert_entry", params).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                println!("Entry set");
+            } else {
+                print_response(&resp, false);
+            }
+        }
+        Command::RemoveEntry { key, workspace } => {
+            let ws_id = workspace
+                .or_else(|| std::env::var("AMUX_WORKSPACE_ID").ok())
+                .unwrap_or_else(|| "0".to_string());
+            let params = serde_json::json!({
+                "workspace_id": ws_id,
+                "key": key,
+            });
+            let resp = client.call("status.remove_entry", params).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                println!("Entry removed");
+            } else {
+                print_response(&resp, false);
+            }
+        }
         Command::Notify {
             body,
             title,
@@ -907,6 +966,46 @@ async fn poll_eval_result(
         }
     }
     Ok(last)
+}
+
+/// Parse `#RRGGBB` or `#RRGGBBAA` hex into RGBA bytes.
+///
+/// The leading `#` is optional. RGB form defaults alpha to 255.
+fn parse_hex_rgba(s: &str) -> Option<[u8; 4]> {
+    let hex = s.strip_prefix('#').unwrap_or(s);
+    let (rgb, a) = match hex.len() {
+        6 => (hex, 0xFF),
+        8 => (&hex[..6], u8::from_str_radix(&hex[6..8], 16).ok()?),
+        _ => return None,
+    };
+    let r = u8::from_str_radix(&rgb[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&rgb[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&rgb[4..6], 16).ok()?;
+    Some([r, g, b, a])
+}
+
+#[cfg(test)]
+mod parse_hex_rgba_tests {
+    use super::parse_hex_rgba;
+
+    #[test]
+    fn accepts_rgb_form_with_full_alpha() {
+        assert_eq!(parse_hex_rgba("#ff8800"), Some([0xFF, 0x88, 0x00, 0xFF]));
+        assert_eq!(parse_hex_rgba("FF8800"), Some([0xFF, 0x88, 0x00, 0xFF]));
+    }
+
+    #[test]
+    fn accepts_rgba_form() {
+        assert_eq!(parse_hex_rgba("#ff880080"), Some([0xFF, 0x88, 0x00, 0x80]));
+    }
+
+    #[test]
+    fn rejects_bad_lengths_and_nonhex() {
+        assert_eq!(parse_hex_rgba("#fff"), None);
+        assert_eq!(parse_hex_rgba("#ff88000"), None);
+        assert_eq!(parse_hex_rgba("#gghhii"), None);
+        assert_eq!(parse_hex_rgba(""), None);
+    }
 }
 
 fn resolve_addr(cli: &Cli) -> anyhow::Result<IpcAddr> {

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -23,6 +23,8 @@ pub const METHODS: &[&str] = &[
     "pane.focus",
     "pane.list",
     "status.set",
+    "status.upsert_entry",
+    "status.remove_entry",
     "notify.send",
     "notify.list",
     "notify.clear",
@@ -122,6 +124,34 @@ pub struct StatusSetParams {
     pub task: Option<String>,
     #[serde(default)]
     pub message: Option<String>,
+}
+
+/// Parameters for `status.upsert_entry`: publish / replace a keyed status
+/// entry under a user-defined key. Must not begin with `agent.` — those
+/// slots are owned by `status.set`.
+#[derive(Debug, Deserialize)]
+pub struct UpsertEntryParams {
+    pub workspace_id: String,
+    pub key: String,
+    pub text: String,
+    /// Render priority. Higher sorts first. Defaults to
+    /// [`amux_notify::priority::USER_GENERIC`] server-side if omitted.
+    #[serde(default)]
+    pub priority: Option<i32>,
+    #[serde(default)]
+    pub icon: Option<String>,
+    /// RGBA tuple. Wire format is a 4-element array of bytes.
+    #[serde(default)]
+    pub color: Option<[u8; 4]>,
+}
+
+/// Parameters for `status.remove_entry`: expire a previously-published
+/// keyed entry. Returns `{ "removed": bool }` so callers can tell whether
+/// the key actually existed.
+#[derive(Debug, Deserialize)]
+pub struct RemoveEntryParams {
+    pub workspace_id: String,
+    pub key: String,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Part of #260 (parity plan, G21).

**Stacked on #281 (G1).** Review that one first; this PR's diff only shows its own commit when viewed against the stacked base branch.

## Summary
- New CLI commands `amux set-entry <KEY> <TEXT>` and `amux remove-entry <KEY>` — write into the keyed-entries dict introduced in G1 without touching the legacy `agent.*` sidebar slots.
- New IPC methods `status.upsert_entry` and `status.remove_entry`. Server enforces the `agent.*` namespace rule and returns a structured error; the CLI also rejects it locally so users get a fast, clear error.
- Hex color parser (`#RRGGBB` → alpha 255, `#RRGGBBAA` preserves supplied alpha) with unit tests.

## Test plan
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] `cargo test --workspace` — new tests: `parse_hex_rgba_tests::*` (3)
- [ ] Manual: run `amux set-entry claude.tool "Reading foo.rs"`, confirm it appears in sidebar
- [ ] Manual: run `amux set-entry agent.label "nope"` — should error locally before IPC
- [ ] Manual: run `amux remove-entry claude.tool` — confirm sidebar collapses

## Follow-ups (separate PRs on the stack)
- G2 (#66): sticky-status semantics built on `remove_entry` so tool-end expires one key instead of blanking `message`
- G22 (#69): persist keyed entries across session restore
- G23 (#70): convert Claude/Gemini/Codex hooks to publish under their own keys

Rebase onto main after #281 squash-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)