### PR TITLE
G2: TTL-based expiry for keyed status entries

### DIFF
--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -954,6 +954,7 @@ impl AmuxApp {
                             let priority = params
                                 .priority
                                 .unwrap_or(amux_notify::priority::USER_GENERIC);
+                            let ttl = params.ttl_ms.map(std::time::Duration::from_millis);
                             self.notifications.upsert_entry(
                                 ws_id,
                                 params.key,
@@ -961,6 +962,7 @@ impl AmuxApp {
                                 priority,
                                 params.icon,
                                 params.color,
+                                ttl,
                             );
                             Response::ok(req.id.clone(), serde_json::json!({}))
                         }

--- a/crates/amux-cli/src/cli.rs
+++ b/crates/amux-cli/src/cli.rs
@@ -311,6 +311,12 @@ pub(crate) enum Command {
         /// Optional RGB/RGBA color, e.g. "#ff8800" or "#ff8800aa"
         #[arg(long)]
         color: Option<String>,
+        /// Auto-expire the entry after this many seconds. Useful as a
+        /// safety net for scripts that may not get a chance to run
+        /// `remove-entry` on exit. Fractional values are rounded to the
+        /// nearest millisecond.
+        #[arg(long)]
+        ttl: Option<f64>,
         /// Target workspace ID (defaults to AMUX_WORKSPACE_ID)
         #[arg(long)]
         workspace: Option<String>,

--- a/crates/amux-cli/src/cli.rs
+++ b/crates/amux-cli/src/cli.rs
@@ -313,8 +313,9 @@ pub(crate) enum Command {
         color: Option<String>,
         /// Auto-expire the entry after this many seconds. Useful as a
         /// safety net for scripts that may not get a chance to run
-        /// `remove-entry` on exit. Fractional values are rounded to the
-        /// nearest millisecond.
+        /// `remove-entry` on exit. Fractional values are rounded up to
+        /// the next millisecond (a sub-ms `--ttl` becomes 1ms, so the
+        /// entry never expires instantly).
         #[arg(long)]
         ttl: Option<f64>,
         /// Target workspace ID (defaults to AMUX_WORKSPACE_ID)

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -734,6 +734,7 @@ async fn main() -> anyhow::Result<()> {
             priority,
             icon,
             color,
+            ttl,
             workspace,
         } => {
             if key.starts_with("agent.") {
@@ -760,6 +761,13 @@ async fn main() -> anyhow::Result<()> {
                     anyhow::anyhow!("invalid color '{c}' (expected #RRGGBB or #RRGGBBAA)")
                 })?;
                 params["color"] = serde_json::json!(rgba);
+            }
+            if let Some(secs) = ttl {
+                if !secs.is_finite() || secs <= 0.0 {
+                    anyhow::bail!("--ttl must be a positive number of seconds (got {secs})");
+                }
+                let ttl_ms = (secs * 1000.0).round() as u64;
+                params["ttl_ms"] = serde_json::json!(ttl_ms);
             }
             let resp = client.call("status.upsert_entry", params).await?;
             if cli.json {

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -766,7 +766,15 @@ async fn main() -> anyhow::Result<()> {
                 if !secs.is_finite() || secs <= 0.0 {
                     anyhow::bail!("--ttl must be a positive number of seconds (got {secs})");
                 }
-                let ttl_ms = (secs * 1000.0).round() as u64;
+                // ceil (not round) so that a tiny positive --ttl can never
+                // become 0ms and fire an immediate expiry.
+                let ttl_ms_f64 = (secs * 1000.0).ceil();
+                if ttl_ms_f64 > u64::MAX as f64 {
+                    anyhow::bail!(
+                        "--ttl is too large to represent in milliseconds (got {secs} seconds)"
+                    );
+                }
+                let ttl_ms = ttl_ms_f64 as u64;
                 params["ttl_ms"] = serde_json::json!(ttl_ms);
             }
             let resp = client.call("status.upsert_entry", params).await?;

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -143,6 +143,12 @@ pub struct UpsertEntryParams {
     /// RGBA tuple. Wire format is a 4-element array of bytes.
     #[serde(default)]
     pub color: Option<[u8; 4]>,
+    /// Optional TTL in milliseconds. When set, the entry is filtered out of
+    /// the render list once its deadline has passed — a safety net for
+    /// integrations that publish transient entries (e.g. "running tool X")
+    /// but might not survive to clean them up explicitly.
+    #[serde(default)]
+    pub ttl_ms: Option<u64>,
 }
 
 /// Parameters for `status.remove_entry`: expire a previously-published

--- a/crates/amux-notify/src/store.rs
+++ b/crates/amux-notify/src/store.rs
@@ -467,10 +467,16 @@ impl NotificationStore {
     /// [`WorkspaceStatus::entries_by_priority`] at render time, so the only
     /// cost of *not* pruning is the memory footprint of a dangling entry.
     pub fn prune_expired_entries(&mut self, workspace_id: u64) -> usize {
+        self.prune_expired_entries_at(workspace_id, Instant::now())
+    }
+
+    /// Same as [`Self::prune_expired_entries`] but takes the current time
+    /// explicitly — used by tests that need deterministic TTL behaviour
+    /// without `std::thread::sleep`.
+    pub fn prune_expired_entries_at(&mut self, workspace_id: u64, now: Instant) -> usize {
         let Some(status) = self.workspace_statuses.get_mut(&workspace_id) else {
             return 0;
         };
-        let now = Instant::now();
         let before = status.entries.len();
         status.entries.retain(|_, e| !e.is_expired(now));
         let removed = before - status.entries.len();
@@ -1026,15 +1032,16 @@ mod tests {
         assert!(status.entries.contains_key("claude.tool"));
 
         // Prune reclaims the expired slot. Sticky entry is left alone.
-        std::thread::sleep(Duration::from_millis(60));
-        let removed = store.prune_expired_entries(1);
+        // Uses the `_at` variant so the test is deterministic rather than
+        // racing a real sleep.
+        let removed = store.prune_expired_entries_at(1, after);
         assert_eq!(removed, 1);
         let status = store.workspace_status(1).unwrap();
         assert!(!status.entries.contains_key("claude.tool"));
         assert!(status.entries.contains_key("git.branch"));
 
         // Prune on an unknown workspace is a no-op.
-        assert_eq!(store.prune_expired_entries(999), 0);
+        assert_eq!(store.prune_expired_entries_at(999, after), 0);
     }
 
     #[test]

--- a/crates/amux-notify/src/store.rs
+++ b/crates/amux-notify/src/store.rs
@@ -6,7 +6,7 @@
 //! and per-pane notification state.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::types::*;
 
@@ -36,6 +36,10 @@ fn apply_legacy_field(
                     icon: None,
                     color: None,
                     updated_at: now,
+                    // Legacy sidebar slots are sticky: they live until the
+                    // next set_status overwrites or clears them. TTL is only
+                    // ever attached by upsert_entry callers.
+                    expires_at: None,
                 },
             );
         }
@@ -406,6 +410,10 @@ impl NotificationStore {
     /// Keys beginning with [`AGENT_KEY_PREFIX`] (`"agent."`) are reserved for
     /// the legacy sidebar slots written by [`Self::set_status`] and are
     /// rejected here with a warning log; use `set_status` to write those.
+    // TODO(parity/followup): collapse (icon, color, ttl) into a small
+    // `EntryOptions { .. }` builder struct to tame the arg count. Kept as
+    // positional for now so G1→G2 stays a minimal additive change.
+    #[allow(clippy::too_many_arguments)]
     pub fn upsert_entry(
         &mut self,
         workspace_id: u64,
@@ -414,6 +422,7 @@ impl NotificationStore {
         priority: i32,
         icon: Option<String>,
         color: Option<[u8; 4]>,
+        ttl: Option<Duration>,
     ) {
         let key = key.into();
         if key.starts_with(AGENT_KEY_PREFIX) {
@@ -424,6 +433,7 @@ impl NotificationStore {
         }
         let text = text.into();
         let now = Instant::now();
+        let expires_at = StatusEntry::ttl_to_expires_at(now, ttl);
         let status = self
             .workspace_statuses
             .entry(workspace_id)
@@ -442,8 +452,32 @@ impl NotificationStore {
                 icon,
                 color,
                 updated_at: now,
+                expires_at,
             },
         );
+    }
+
+    /// Drop expired entries from a workspace's status. Returns the number of
+    /// entries removed — callers can use this to decide whether a redraw is
+    /// warranted.
+    ///
+    /// Safe to call on any interval; does nothing if the workspace has no
+    /// expired entries (or doesn't exist). A cheap opportunistic sweep is
+    /// enough — expired entries are already filtered out of
+    /// [`WorkspaceStatus::entries_by_priority`] at render time, so the only
+    /// cost of *not* pruning is the memory footprint of a dangling entry.
+    pub fn prune_expired_entries(&mut self, workspace_id: u64) -> usize {
+        let Some(status) = self.workspace_statuses.get_mut(&workspace_id) else {
+            return 0;
+        };
+        let now = Instant::now();
+        let before = status.entries.len();
+        status.entries.retain(|_, e| !e.is_expired(now));
+        let removed = before - status.entries.len();
+        if removed > 0 {
+            status.updated_at = now;
+        }
+        removed
     }
 
     /// Remove a keyed status entry. Returns `true` if an entry was removed.
@@ -818,6 +852,7 @@ mod tests {
             priority::MESSAGE,
             Some("\u{1F4C4}".into()),
             None,
+            None,
         );
         let status = store.workspace_status(1).unwrap();
         let entry = status.entry("claude.tool").unwrap();
@@ -833,6 +868,7 @@ mod tests {
             priority::MESSAGE,
             None,
             None,
+            None,
         );
         assert_eq!(
             store
@@ -845,7 +881,15 @@ mod tests {
         );
 
         // Remove expires the key and leaves others alone.
-        store.upsert_entry(1, "git.branch", "main", priority::USER_GENERIC, None, None);
+        store.upsert_entry(
+            1,
+            "git.branch",
+            "main",
+            priority::USER_GENERIC,
+            None,
+            None,
+            None,
+        );
         assert!(store.remove_entry(1, "claude.tool"));
         let status = store.workspace_status(1).unwrap();
         assert!(status.entry("claude.tool").is_none());
@@ -866,6 +910,7 @@ mod tests {
             priority::USER_GENERIC,
             None,
             None,
+            None,
         );
         let status = store.workspace_status(1).unwrap();
         assert_eq!(status.state, AgentState::Idle);
@@ -875,11 +920,11 @@ mod tests {
     #[test]
     fn entries_by_priority_sorts_descending() {
         let mut store = NotificationStore::new();
-        store.upsert_entry(1, "a.low", "low", 10, None, None);
-        store.upsert_entry(1, "b.high", "high", 100, None, None);
-        store.upsert_entry(1, "c.mid", "mid", 50, None, None);
+        store.upsert_entry(1, "a.low", "low", 10, None, None, None);
+        store.upsert_entry(1, "b.high", "high", 100, None, None, None);
+        store.upsert_entry(1, "c.mid", "mid", 50, None, None, None);
         // Ties break by key ascending: insert two at priority 50.
-        store.upsert_entry(1, "a.tie", "tie", 50, None, None);
+        store.upsert_entry(1, "a.tie", "tie", 50, None, None, None);
         let status = store.workspace_status(1).unwrap();
         let ordered: Vec<&str> = status
             .entries_by_priority()
@@ -899,6 +944,7 @@ mod tests {
             KEY_AGENT_MESSAGE,
             "should not appear",
             priority::MESSAGE,
+            None,
             None,
             None,
         );
@@ -922,11 +968,98 @@ mod tests {
             priority::MESSAGE,
             None,
             None,
+            None,
         );
         assert_eq!(
             store.workspace_status(2).unwrap().message(),
             Some("real message")
         );
+    }
+
+    #[test]
+    fn upsert_entry_with_ttl_filters_and_prunes() {
+        let mut store = NotificationStore::new();
+        store.upsert_entry(
+            1,
+            "claude.tool",
+            "Running tool",
+            priority::MESSAGE,
+            None,
+            None,
+            Some(Duration::from_millis(50)),
+        );
+        store.upsert_entry(
+            1,
+            "git.branch",
+            "main",
+            priority::USER_GENERIC,
+            None,
+            None,
+            None,
+        );
+
+        let status = store.workspace_status(1).unwrap();
+        let entry = status.entry("claude.tool").unwrap();
+        let entry_expires_at = entry
+            .expires_at
+            .expect("TTL should be translated to expires_at");
+
+        // Before the deadline both entries are visible.
+        let before = entry_expires_at - Duration::from_millis(10);
+        let ordered: Vec<&str> = status
+            .entries_by_priority_at(before)
+            .iter()
+            .map(|(k, _)| *k)
+            .collect();
+        assert_eq!(ordered, vec!["claude.tool", "git.branch"]);
+
+        // After the deadline the TTL-bound entry is filtered from the render
+        // list, but the sticky one stays. The raw map is untouched until
+        // prune runs.
+        let after = entry_expires_at + Duration::from_millis(10);
+        let ordered_after: Vec<&str> = status
+            .entries_by_priority_at(after)
+            .iter()
+            .map(|(k, _)| *k)
+            .collect();
+        assert_eq!(ordered_after, vec!["git.branch"]);
+        assert!(status.entries.contains_key("claude.tool"));
+
+        // Prune reclaims the expired slot. Sticky entry is left alone.
+        std::thread::sleep(Duration::from_millis(60));
+        let removed = store.prune_expired_entries(1);
+        assert_eq!(removed, 1);
+        let status = store.workspace_status(1).unwrap();
+        assert!(!status.entries.contains_key("claude.tool"));
+        assert!(status.entries.contains_key("git.branch"));
+
+        // Prune on an unknown workspace is a no-op.
+        assert_eq!(store.prune_expired_entries(999), 0);
+    }
+
+    #[test]
+    fn legacy_slots_are_sticky_not_ttl() {
+        // set_status never attaches a TTL — the legacy sidebar slots must
+        // live until overwritten.
+        let mut store = NotificationStore::new();
+        store.set_status(
+            1,
+            AgentState::Active,
+            Some("Running".into()),
+            None,
+            Some("latest message".into()),
+        );
+        let status = store.workspace_status(1).unwrap();
+        assert!(status
+            .entry(KEY_AGENT_LABEL)
+            .expect("label entry")
+            .expires_at
+            .is_none());
+        assert!(status
+            .entry(KEY_AGENT_MESSAGE)
+            .expect("message entry")
+            .expires_at
+            .is_none());
     }
 
     #[test]

--- a/crates/amux-notify/src/types.rs
+++ b/crates/amux-notify/src/types.rs
@@ -82,8 +82,10 @@ pub struct StatusEntry {
     pub color: Option<[u8; 4]>,
     pub updated_at: Instant,
     /// Absolute deadline after which the entry is considered expired and is
-    /// filtered out of the render list. `None` means sticky until an explicit
-    /// [`super::NotificationStore::remove_entry`] call.
+    /// filtered out of the render list. `None` means there is no automatic
+    /// expiry — the entry persists until removed via
+    /// [`super::NotificationStore::remove_entry`] or overwritten by a later
+    /// [`super::NotificationStore::upsert_entry`] call for the same key.
     ///
     /// TTL acts as a safety net for integrations that publish a transient
     /// entry (e.g. "running tool X") but might not survive to clean it up

--- a/crates/amux-notify/src/types.rs
+++ b/crates/amux-notify/src/types.rs
@@ -101,8 +101,13 @@ impl StatusEntry {
 
     /// Convert a duration into an absolute `expires_at` anchored at `now`.
     /// Helper for callers composing their own `StatusEntry` values.
+    ///
+    /// Uses `checked_add` so that a pathologically large `ttl` (e.g. a
+    /// malicious IPC client sending `ttl_ms = u64::MAX`) collapses to
+    /// `None` — semantically equivalent to "sticky, no expiry" — instead
+    /// of panicking on `Instant` overflow.
     pub fn ttl_to_expires_at(now: Instant, ttl: Option<Duration>) -> Option<Instant> {
-        ttl.map(|d| now + d)
+        ttl.and_then(|d| now.checked_add(d))
     }
 }
 

--- a/crates/amux-notify/src/types.rs
+++ b/crates/amux-notify/src/types.rs
@@ -5,7 +5,7 @@
 //! notification payload, and per-pane notification state.
 
 use std::collections::BTreeMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
@@ -81,6 +81,29 @@ pub struct StatusEntry {
     pub icon: Option<String>,
     pub color: Option<[u8; 4]>,
     pub updated_at: Instant,
+    /// Absolute deadline after which the entry is considered expired and is
+    /// filtered out of the render list. `None` means sticky until an explicit
+    /// [`super::NotificationStore::remove_entry`] call.
+    ///
+    /// TTL acts as a safety net for integrations that publish a transient
+    /// entry (e.g. "running tool X") but might not survive to clean it up
+    /// (crashed hook, killed subprocess). Set to `None` for legacy sidebar
+    /// slots — those are owned by `set_status` and live until overwritten.
+    pub expires_at: Option<Instant>,
+}
+
+impl StatusEntry {
+    /// True if this entry's TTL has passed at `now`. Sticky (no-TTL)
+    /// entries always return false.
+    pub fn is_expired(&self, now: Instant) -> bool {
+        self.expires_at.is_some_and(|t| now >= t)
+    }
+
+    /// Convert a duration into an absolute `expires_at` anchored at `now`.
+    /// Helper for callers composing their own `StatusEntry` values.
+    pub fn ttl_to_expires_at(now: Instant, ttl: Option<Duration>) -> Option<Instant> {
+        ttl.map(|d| now + d)
+    }
 }
 
 /// Per-workspace agent status displayed as a pill in the sidebar.
@@ -143,11 +166,23 @@ impl WorkspaceStatus {
         self.entries.get(KEY_AGENT_MESSAGE).map(|e| e.text.as_str())
     }
 
-    /// All entries sorted by descending priority, then by key for stable
-    /// output on ties. The sidebar will iterate this once G20 lands.
+    /// Non-expired entries sorted by descending priority, then by key for
+    /// stable output on ties. Expired entries are filtered out silently —
+    /// call [`super::NotificationStore::prune_expired_entries`] periodically
+    /// to reclaim their memory. The sidebar will iterate this once G20 lands.
     pub fn entries_by_priority(&self) -> Vec<(&str, &StatusEntry)> {
-        let mut v: Vec<(&str, &StatusEntry)> =
-            self.entries.iter().map(|(k, e)| (k.as_str(), e)).collect();
+        self.entries_by_priority_at(Instant::now())
+    }
+
+    /// Same as [`Self::entries_by_priority`] but takes the current time
+    /// explicitly — used by tests that need deterministic TTL behaviour.
+    pub fn entries_by_priority_at(&self, now: Instant) -> Vec<(&str, &StatusEntry)> {
+        let mut v: Vec<(&str, &StatusEntry)> = self
+            .entries
+            .iter()
+            .filter(|(_, e)| !e.is_expired(now))
+            .map(|(k, e)| (k.as_str(), e))
+            .collect();
         v.sort_by(|a, b| b.1.priority.cmp(&a.1.priority).then_with(|| a.0.cmp(b.0)));
         v
     }


### PR DESCRIPTION
Part of #260 (parity plan, G2).

**Stacked on #282 (G21), which is stacked on #281 (G1).** Review bottom-up: #281 → #282 → this.

## Summary
- Adds `expires_at: Option<Instant>` to `StatusEntry` as a safety-net for transient publishers (e.g. Claude's tool-in-flight entry). Tool crashes before sending `remove-entry`? The entry ages out instead of sticking.
- `entries_by_priority` filters expired entries at render time; new `entries_by_priority_at(now)` variant for deterministic tests.
- `NotificationStore::upsert_entry` gains `ttl: Option<Duration>`. Legacy sidebar slots (`agent.*` via `set_status`) stay sticky — they never get a TTL.
- New `prune_expired_entries(ws)` for periodic memory hygiene (returns count removed; filter-at-read means pruning is never required for correctness).
- IPC `UpsertEntryParams` gains optional `ttl_ms` field.
- CLI `amux set-entry --ttl <SECONDS>` (fractional-second OK) with validation for non-positive / non-finite input.

## Test plan
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] `cargo test --workspace` — new tests: `upsert_entry_with_ttl_filters_and_prunes`, `legacy_slots_are_sticky_not_ttl`
- [ ] Manual: `amux set-entry claude.tool "Reading foo" --ttl 2` → sidebar shows entry, disappears after 2s
- [ ] Manual: `amux set-entry claude.tool "Reading foo"` (no TTL) → sidebar shows entry, stays until `remove-entry`

## Known follow-up (non-blocking)
`upsert_entry` now has 8 positional args. `#[allow(clippy::too_many_arguments)]` is applied with a TODO pointing at an `EntryOptions` builder refactor. Kept positional in this PR to keep G1→G2 additive.

## Rebase plan
Once #281 squash-lands on main, rebase the stack: #282 → new base = main, then #283 → new base = #282's new branch. I'll handle this when the landing order is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status entries now support automatic expiration with TTL (time-to-live)
  * New `--ttl` command-line option to set entry expiration time in seconds (supports fractional values)
  * Expired entries are automatically pruned from status displays; existing legacy entries remain sticky

<!-- end of auto-generated comment: release notes by coderabbit.ai -->