### PR TITLE
G3: 40ms debounce pipeline for sidebar status

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -197,6 +197,23 @@ impl eframe::App for AmuxApp {
         // Drain notification events from all surfaces
         self.drain_notifications();
 
+        // G3: promote stable status writes into the debounced `displayed`
+        // snapshot the sidebar renders from. Runs every frame so that
+        // (a) writes older than DEBOUNCE_WINDOW surface on the next paint
+        // and (b) rapid bursts within the window collapse to just the
+        // last value. `next_commit_at` tells us when the next pending
+        // write becomes eligible, so we schedule a repaint for that
+        // moment instead of waking every frame for no reason.
+        let now = std::time::Instant::now();
+        self.notifications
+            .commit_displayed_at(now, amux_notify::NotificationStore::DEBOUNCE_WINDOW);
+        if let Some(wake) = self
+            .notifications
+            .next_commit_at(amux_notify::NotificationStore::DEBOUNCE_WINDOW)
+        {
+            ctx.request_repaint_after(wake.saturating_duration_since(now));
+        }
+
         // Hot-reload config file if it changed on disk. Runs before
         // the badge update so toggling dock_badge takes effect on
         // the same frame (otherwise a true→false flip leaves a stale

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -317,9 +317,11 @@ fn render_workspace_row(
     let has_progress = status.as_ref().and_then(|s| s.progress).is_some();
     // Filter empty-string entries: upsert_entry lets publishers write empty
     // text, and we shouldn't reserve a subtitle line for a blank message.
+    // G3: render from the debounced `displayed` projection so rapid bursts
+    // of hook writes don't flash intermediate values through the sidebar.
     let agent_message = status
         .as_ref()
-        .and_then(|s| s.message())
+        .and_then(|s| s.displayed_message())
         .filter(|m| !m.is_empty());
     let has_agent_message = agent_message.is_some();
     let latest_notif = notifications.latest_for_workspace(ws.id);
@@ -336,7 +338,7 @@ fn render_workspace_row(
     // overwritten by agent status or auto-detected titles.
     let display_title = if let Some(ref ut) = ws.user_title {
         ut.clone()
-    } else if let Some(task) = status.as_ref().and_then(|s| s.task()) {
+    } else if let Some(task) = status.as_ref().and_then(|s| s.displayed_task()) {
         format!("\u{2731} {task}")
     } else if let Some(st) = metadata.and_then(|m| m.surface_title.as_ref()) {
         st.clone()
@@ -597,7 +599,7 @@ fn render_workspace_row(
             amux_notify::AgentState::Waiting => ("\u{1F514}", "Needs input"), // 🔔
             amux_notify::AgentState::Idle => ("\u{23F8}", "Idle"), // ⏸ (no variation selector — FE0E renders as box on Windows)
         };
-        let label = status.label().unwrap_or(default_text);
+        let label = status.displayed_label().unwrap_or(default_text);
         content_bottom += 4.0;
         let status_x = rect.min.x + content_left;
         let max_w = avail_w - content_left - ROW_H_PAD;

--- a/crates/amux-notify/src/store.rs
+++ b/crates/amux-notify/src/store.rs
@@ -28,11 +28,10 @@ fn apply_legacy_field(
 ) {
     match value {
         None => {}
-        Some(s) if s.is_empty() => {
-            if entries.remove(key).is_some() {
-                pending_removals.insert(key.to_string(), now);
-            }
+        Some(s) if s.is_empty() && entries.remove(key).is_some() => {
+            pending_removals.insert(key.to_string(), now);
         }
+        Some(s) if s.is_empty() => {}
         Some(s) => {
             entries.insert(
                 key.to_string(),

--- a/crates/amux-notify/src/store.rs
+++ b/crates/amux-notify/src/store.rs
@@ -14,9 +14,13 @@ use crate::types::*;
 ///
 /// Interprets the legacy `Some("")` / `Some(value)` / `None` convention:
 /// empty string expires the entry, non-empty upserts it, `None` leaves the
-/// existing entry untouched.
+/// existing entry untouched. Operates on both `entries` (authoritative)
+/// and `pending_removals` (G3 debounce tombstones) so a removal survives
+/// the debounce window and an upsert cancels any prior pending removal
+/// for the same key.
 fn apply_legacy_field(
     entries: &mut BTreeMap<String, StatusEntry>,
+    pending_removals: &mut BTreeMap<String, Instant>,
     key: &str,
     priority: i32,
     value: Option<String>,
@@ -25,7 +29,9 @@ fn apply_legacy_field(
     match value {
         None => {}
         Some(s) if s.is_empty() => {
-            entries.remove(key);
+            if entries.remove(key).is_some() {
+                pending_removals.insert(key.to_string(), now);
+            }
         }
         Some(s) => {
             entries.insert(
@@ -42,8 +48,75 @@ fn apply_legacy_field(
                     expires_at: None,
                 },
             );
+            // Re-insertion cancels any pending removal for the same key —
+            // otherwise a later `commit_displayed_at` could drop the
+            // just-re-inserted entry once the old tombstone window elapses.
+            pending_removals.remove(key);
         }
     }
+}
+
+/// Returns `true` when two entries carry the same user-visible value —
+/// ignores `updated_at` (commit timing, not content) and `expires_at`
+/// (a TTL bump alone shouldn't trigger a re-render).
+fn status_entry_eq(a: &StatusEntry, b: &StatusEntry) -> bool {
+    a.text == b.text && a.priority == b.priority && a.icon == b.icon && a.color == b.color
+}
+
+/// Apply G3 debounce to a single workspace's status in-place. Shared by
+/// [`NotificationStore::commit_displayed_at`] and the per-workspace test
+/// entry point. Returns `true` if anything about `displayed` actually
+/// changed (insert, update, or remove) so callers can track whether a
+/// repaint is warranted.
+fn commit_workspace_displayed(
+    status: &mut WorkspaceStatus,
+    now: Instant,
+    debounce: Duration,
+) -> bool {
+    let mut changed = false;
+    // Promote writes that have been stable for at least `debounce`.
+    for (key, entry) in &status.entries {
+        if now.saturating_duration_since(entry.updated_at) < debounce {
+            continue;
+        }
+        let existing = status.displayed.get(key);
+        if existing.is_some_and(|d| status_entry_eq(d, entry)) {
+            continue;
+        }
+        status.displayed.insert(key.clone(), entry.clone());
+        changed = true;
+    }
+    // Drop tombstones whose debounce window has expired.
+    let ready: Vec<String> = status
+        .pending_removals
+        .iter()
+        .filter(|(_, &t)| now.saturating_duration_since(t) >= debounce)
+        .map(|(k, _)| k.clone())
+        .collect();
+    for key in ready {
+        status.pending_removals.remove(&key);
+        // Only mark `changed` when `displayed` actually loses something.
+        if status.displayed.remove(&key).is_some() {
+            changed = true;
+        }
+    }
+    // Defensive cleanup: a key that vanished from `entries` without a
+    // tombstone (possible if `entries` was mutated directly in tests)
+    // shouldn't linger in `displayed` forever. Only purges after a full
+    // debounce window to keep the semantics of removals consistent.
+    let orphans: Vec<String> = status
+        .displayed
+        .iter()
+        .filter(|(k, _)| {
+            !status.entries.contains_key(*k) && !status.pending_removals.contains_key(*k)
+        })
+        .map(|(k, _)| k.clone())
+        .collect();
+    for key in orphans {
+        status.displayed.remove(&key);
+        changed = true;
+    }
+    changed
 }
 
 // ---------------------------------------------------------------------------
@@ -59,6 +132,13 @@ pub struct NotificationStore {
 }
 
 impl NotificationStore {
+    /// Default debounce window for the `displayed` snapshot promotion
+    /// pass (parity plan G3). Matches cmux's 40ms trailing debounce —
+    /// the interval is small enough that intentional status changes still
+    /// feel instant, but long enough that a burst of tool-call writes
+    /// doesn't flash through values the user can't read.
+    pub const DEBOUNCE_WINDOW: Duration = Duration::from_millis(40);
+
     pub fn new() -> Self {
         Self {
             notifications: Vec::new(),
@@ -360,7 +440,21 @@ impl NotificationStore {
         task: Option<String>,
         message: Option<String>,
     ) {
-        let now = Instant::now();
+        self.set_status_at(workspace_id, state, label, task, message, Instant::now());
+    }
+
+    /// Same as [`Self::set_status`] but takes the current time explicitly —
+    /// used by tests that need deterministic debounce behaviour without
+    /// racing `Instant::now()` inside the store.
+    pub fn set_status_at(
+        &mut self,
+        workspace_id: u64,
+        state: AgentState,
+        label: Option<String>,
+        task: Option<String>,
+        message: Option<String>,
+        now: Instant,
+    ) {
         let entry = self
             .workspace_statuses
             .entry(workspace_id)
@@ -369,6 +463,8 @@ impl NotificationStore {
                 updated_at: now,
                 progress: None,
                 entries: BTreeMap::new(),
+                displayed: BTreeMap::new(),
+                pending_removals: BTreeMap::new(),
             });
         entry.state = state;
         entry.updated_at = now;
@@ -377,6 +473,7 @@ impl NotificationStore {
 
         apply_legacy_field(
             &mut entry.entries,
+            &mut entry.pending_removals,
             KEY_AGENT_LABEL,
             priority::LABEL,
             label,
@@ -384,6 +481,7 @@ impl NotificationStore {
         );
         apply_legacy_field(
             &mut entry.entries,
+            &mut entry.pending_removals,
             KEY_AGENT_TASK,
             priority::TASK,
             task,
@@ -391,6 +489,7 @@ impl NotificationStore {
         );
         apply_legacy_field(
             &mut entry.entries,
+            &mut entry.pending_removals,
             KEY_AGENT_MESSAGE,
             priority::MESSAGE,
             message,
@@ -424,6 +523,32 @@ impl NotificationStore {
         color: Option<[u8; 4]>,
         ttl: Option<Duration>,
     ) {
+        self.upsert_entry_at(
+            workspace_id,
+            key,
+            text,
+            priority,
+            icon,
+            color,
+            ttl,
+            Instant::now(),
+        );
+    }
+
+    /// Same as [`Self::upsert_entry`] but takes the current time explicitly —
+    /// used by tests that need deterministic debounce behaviour.
+    #[allow(clippy::too_many_arguments)]
+    pub fn upsert_entry_at(
+        &mut self,
+        workspace_id: u64,
+        key: impl Into<String>,
+        text: impl Into<String>,
+        priority: i32,
+        icon: Option<String>,
+        color: Option<[u8; 4]>,
+        ttl: Option<Duration>,
+        now: Instant,
+    ) {
         let key = key.into();
         if key.starts_with(AGENT_KEY_PREFIX) {
             tracing::warn!(
@@ -432,7 +557,6 @@ impl NotificationStore {
             return;
         }
         let text = text.into();
-        let now = Instant::now();
         let expires_at = StatusEntry::ttl_to_expires_at(now, ttl);
         let status = self
             .workspace_statuses
@@ -442,8 +566,13 @@ impl NotificationStore {
                 updated_at: now,
                 progress: None,
                 entries: BTreeMap::new(),
+                displayed: BTreeMap::new(),
+                pending_removals: BTreeMap::new(),
             });
         status.updated_at = now;
+        // Re-insertion supersedes any tombstone for the same key — see
+        // the commentary on `apply_legacy_field` for why this matters.
+        status.pending_removals.remove(&key);
         status.entries.insert(
             key,
             StatusEntry {
@@ -490,11 +619,29 @@ impl NotificationStore {
     ///
     /// Used by tool-end hooks (G2) to expire just the tool's entry without
     /// disturbing other publishers. Safe to call on a missing workspace.
+    ///
+    /// G3: if the removed key was already visible in `displayed`, a
+    /// tombstone is recorded on `pending_removals` so the displayed
+    /// snapshot holds the value for the debounce window before dropping
+    /// it — avoids flashing the sidebar empty on a rapid tool-end.
     pub fn remove_entry(&mut self, workspace_id: u64, key: &str) -> bool {
+        self.remove_entry_at(workspace_id, key, Instant::now())
+    }
+
+    /// Same as [`Self::remove_entry`] but takes the current time
+    /// explicitly — used by tests that need deterministic tombstone
+    /// behaviour without `std::thread::sleep`.
+    pub fn remove_entry_at(&mut self, workspace_id: u64, key: &str, now: Instant) -> bool {
         if let Some(status) = self.workspace_statuses.get_mut(&workspace_id) {
             let removed = status.entries.remove(key).is_some();
             if removed {
-                status.updated_at = Instant::now();
+                status.updated_at = now;
+                // Only tombstone if the key is actually in the displayed
+                // snapshot; otherwise the removal has no visible effect
+                // and the tombstone would just bloat the map.
+                if status.displayed.contains_key(key) {
+                    status.pending_removals.insert(key.to_string(), now);
+                }
             }
             removed
         } else {
@@ -513,6 +660,65 @@ impl NotificationStore {
     /// Get workspace agent status.
     pub fn workspace_status(&self, workspace_id: u64) -> Option<&WorkspaceStatus> {
         self.workspace_statuses.get(&workspace_id)
+    }
+
+    /// Refresh the `displayed` debounced snapshot across all workspaces.
+    /// Call once per frame (or on each event tick) with `Instant::now()`
+    /// and [`Self::DEBOUNCE_WINDOW`].
+    ///
+    /// For each workspace:
+    /// - promote `entries[k]` into `displayed[k]` when
+    ///   `now - entry.updated_at >= debounce` (the write has been stable
+    ///   for long enough to display);
+    /// - drop keys from `displayed` when `pending_removals[k] + debounce
+    ///   <= now` (a removal has survived the debounce window);
+    /// - garbage-collect stale `displayed` entries that are neither in
+    ///   `entries` nor tombstoned — this is defensive cleanup and should
+    ///   never fire in normal operation.
+    ///
+    /// Returns the number of workspaces whose displayed state changed —
+    /// callers can use this to decide whether to request a repaint.
+    pub fn commit_displayed_at(&mut self, now: Instant, debounce: Duration) -> usize {
+        let mut changed = 0usize;
+        for status in self.workspace_statuses.values_mut() {
+            if commit_workspace_displayed(status, now, debounce) {
+                changed += 1;
+            }
+        }
+        changed
+    }
+
+    /// Earliest `Instant` at which a pending debounce transition will be
+    /// ready to apply. Returns `None` if nothing is pending. Callers use
+    /// this to wake the frame loop at the right moment rather than
+    /// polling blindly — e.g. `ctx.request_repaint_after(wakeup - now)`.
+    ///
+    /// Only entries that would actually change `displayed` on commit are
+    /// counted: an entry whose text already matches `displayed[k]`
+    /// contributes nothing (there's no pending work for it).
+    pub fn next_commit_at(&self, debounce: Duration) -> Option<Instant> {
+        let mut earliest: Option<Instant> = None;
+        let mut consider = |deadline: Instant| {
+            earliest = Some(match earliest {
+                Some(existing) if existing <= deadline => existing,
+                _ => deadline,
+            });
+        };
+        for status in self.workspace_statuses.values() {
+            for (key, entry) in &status.entries {
+                let already_shown = status
+                    .displayed
+                    .get(key)
+                    .is_some_and(|d| status_entry_eq(d, entry));
+                if !already_shown {
+                    consider(entry.updated_at + debounce);
+                }
+            }
+            for &ts in status.pending_removals.values() {
+                consider(ts + debounce);
+            }
+        }
+        earliest
     }
 
     /// Clean up all state for a closed pane.
@@ -1414,5 +1620,175 @@ mod tests {
         // pane_state (and thus no flash) is created by the restore path.
         assert_eq!(store.pane_unread(10), 0);
         assert!(store.pane_state(10).is_none());
+    }
+
+    // --- G3: debounced displayed snapshot ----------------------------------
+
+    const DEBOUNCE: Duration = Duration::from_millis(40);
+
+    fn new_ws(store: &mut NotificationStore, ws: u64) {
+        // Touch set_status to materialize the workspace entry.
+        store.set_status(ws, AgentState::Idle, None, None, None);
+    }
+
+    #[test]
+    fn fresh_upsert_is_held_until_debounce_elapses() {
+        let mut store = NotificationStore::new();
+        new_ws(&mut store, 1);
+        let t0 = Instant::now();
+        store.upsert_entry_at(1, "claude.tool", "Running cargo", 60, None, None, None, t0);
+        // Commit right at the write instant → still under debounce, hold.
+        store.commit_displayed_at(t0, DEBOUNCE);
+        let status = store.workspace_status(1).unwrap();
+        assert!(status.displayed.is_empty(), "must wait for debounce");
+
+        // Commit a tick after the window → now visible.
+        store.commit_displayed_at(t0 + DEBOUNCE, DEBOUNCE);
+        let status = store.workspace_status(1).unwrap();
+        assert_eq!(
+            status.displayed.get("claude.tool").map(|e| e.text.as_str()),
+            Some("Running cargo")
+        );
+    }
+
+    #[test]
+    fn transient_write_removed_within_debounce_is_never_shown() {
+        // Regression for the flicker bug class this whole feature targets:
+        // a rapid upsert → remove burst must NOT flash the value on screen.
+        let mut store = NotificationStore::new();
+        new_ws(&mut store, 1);
+        let t0 = Instant::now();
+        store.upsert_entry_at(1, "claude.tool", "Running test", 60, None, None, None, t0);
+        store.remove_entry_at(1, "claude.tool", t0 + Duration::from_millis(10));
+        store.commit_displayed_at(t0 + Duration::from_millis(50), DEBOUNCE);
+        let status = store.workspace_status(1).unwrap();
+        assert!(
+            status.displayed.is_empty(),
+            "upsert-then-remove inside the debounce window must not render"
+        );
+    }
+
+    #[test]
+    fn removal_after_display_holds_for_debounce_then_drops() {
+        let mut store = NotificationStore::new();
+        new_ws(&mut store, 1);
+        let t0 = Instant::now();
+        store.upsert_entry_at(1, "claude.tool", "Running test", 60, None, None, None, t0);
+        // Promote the value to displayed.
+        store.commit_displayed_at(t0 + DEBOUNCE, DEBOUNCE);
+        assert_eq!(
+            store.workspace_status(1).unwrap().displayed.len(),
+            1,
+            "precondition: value must be visible"
+        );
+
+        // Remove the entry; commit immediately — displayed must still hold.
+        let t_remove = t0 + DEBOUNCE + Duration::from_millis(5);
+        store.remove_entry_at(1, "claude.tool", t_remove);
+        store.commit_displayed_at(t_remove, DEBOUNCE);
+        assert_eq!(
+            store.workspace_status(1).unwrap().displayed.len(),
+            1,
+            "removal must not vanish the displayed value inside the window"
+        );
+
+        // After the full debounce window, displayed drops the entry.
+        store.commit_displayed_at(t_remove + DEBOUNCE, DEBOUNCE);
+        assert!(store.workspace_status(1).unwrap().displayed.is_empty());
+        assert!(store
+            .workspace_status(1)
+            .unwrap()
+            .pending_removals
+            .is_empty());
+    }
+
+    #[test]
+    fn reinsert_within_window_cancels_tombstone() {
+        // upsert → show → remove → reinsert within debounce: the final
+        // state must persist; we must not drop the re-inserted value when
+        // the old tombstone would otherwise have expired.
+        let mut store = NotificationStore::new();
+        new_ws(&mut store, 1);
+        let t0 = Instant::now();
+        store.upsert_entry_at(1, "claude.tool", "A", 60, None, None, None, t0);
+        store.commit_displayed_at(t0 + DEBOUNCE, DEBOUNCE);
+
+        let t1 = t0 + DEBOUNCE + Duration::from_millis(5);
+        store.remove_entry_at(1, "claude.tool", t1);
+        // Reinsert a few ms later, still inside the tombstone window.
+        let t2 = t1 + Duration::from_millis(5);
+        store.upsert_entry_at(1, "claude.tool", "B", 60, None, None, None, t2);
+
+        // Step far past both the original tombstone expiry and the new
+        // entry's debounce window. Displayed should now be "B".
+        store.commit_displayed_at(t2 + DEBOUNCE + Duration::from_millis(50), DEBOUNCE);
+        let status = store.workspace_status(1).unwrap();
+        assert_eq!(
+            status.displayed.get("claude.tool").map(|e| e.text.as_str()),
+            Some("B"),
+            "re-inserted value must win over the stale tombstone"
+        );
+        assert!(status.pending_removals.is_empty());
+    }
+
+    #[test]
+    fn next_commit_at_reports_earliest_deadline() {
+        let mut store = NotificationStore::new();
+        new_ws(&mut store, 1);
+        let t0 = Instant::now();
+        store.upsert_entry_at(1, "claude.tool", "first", 60, None, None, None, t0);
+        // Next commit = t0 + DEBOUNCE.
+        let wake = store.next_commit_at(DEBOUNCE).unwrap();
+        assert_eq!(
+            wake - t0,
+            DEBOUNCE,
+            "wake ({:?} after t0) should be exactly DEBOUNCE",
+            wake - t0
+        );
+
+        // After commit, same entry is now displayed. next_commit_at should
+        // stop reporting a deadline for it.
+        store.commit_displayed_at(wake, DEBOUNCE);
+        assert!(store.next_commit_at(DEBOUNCE).is_none());
+    }
+
+    #[test]
+    fn legacy_field_clear_tombstones_the_message_slot() {
+        // A set_status with Some("") used to be the flicker trigger —
+        // make sure the G3 tombstone path holds the displayed message for
+        // the debounce window on that path too.
+        let mut store = NotificationStore::new();
+        let t0 = Instant::now();
+        store.set_status_at(
+            1,
+            AgentState::Active,
+            None,
+            None,
+            Some("Running cargo".into()),
+            t0,
+        );
+        store.commit_displayed_at(t0 + DEBOUNCE, DEBOUNCE);
+        assert_eq!(
+            store.workspace_status(1).unwrap().displayed_message(),
+            Some("Running cargo")
+        );
+
+        // Clear via set_status(Some("")) and commit right away — displayed
+        // must still hold the old message for the debounce window.
+        let t_clear = t0 + DEBOUNCE + Duration::from_millis(5);
+        store.set_status_at(
+            1,
+            AgentState::Active,
+            None,
+            None,
+            Some(String::new()),
+            t_clear,
+        );
+        store.commit_displayed_at(t_clear, DEBOUNCE);
+        assert_eq!(
+            store.workspace_status(1).unwrap().displayed_message(),
+            Some("Running cargo"),
+            "displayed must not blank mid-debounce"
+        );
     }
 }

--- a/crates/amux-notify/src/types.rs
+++ b/crates/amux-notify/src/types.rs
@@ -119,16 +119,43 @@ impl StatusEntry {
 /// dictionary of [`StatusEntry`] rows. Legacy label/task/message are now
 /// looked up through the reserved keys in [`priority`]; see
 /// [`Self::label`], [`Self::task`], [`Self::message`].
+///
+/// ## Two-layer state (G3)
+///
+/// The authoritative state is `entries`: every write (`upsert_entry`,
+/// `remove_entry`, `set_status`) updates it immediately. A parallel
+/// `displayed` dictionary is the debounced projection the sidebar renders
+/// from — it trails `entries` by
+/// [`super::NotificationStore::DEBOUNCE_WINDOW`] (40ms) so a burst of rapid
+/// tool-call writes doesn't flash through intermediate values the user
+/// can't read. `displayed` is refreshed explicitly via
+/// [`super::NotificationStore::commit_displayed_at`], typically once per
+/// frame.
+///
+/// `pending_removals` carries keys that were dropped from `entries` but
+/// haven't aged out of `displayed` yet. Once `now - removed_at >=
+/// DEBOUNCE_WINDOW`, the commit pass drops them from both.
 #[derive(Debug, Clone)]
 pub struct WorkspaceStatus {
     pub state: AgentState,
     pub updated_at: Instant,
     /// Optional progress value (0.0–1.0) for progress bar display.
     pub progress: Option<f32>,
-    /// Keyed status entries. Use [`Self::entries_by_priority`] for the
-    /// ordered render list; [`Self::label`] / [`Self::task`] /
-    /// [`Self::message`] for the three legacy sidebar slots.
+    /// Keyed status entries — authoritative, written immediately by
+    /// `upsert_entry` / `set_status` / `remove_entry`. Use
+    /// [`Self::entries_by_priority`] for the ordered render list;
+    /// [`Self::label`] / [`Self::task`] / [`Self::message`] for the three
+    /// legacy sidebar slots.
     pub entries: BTreeMap<String, StatusEntry>,
+    /// Debounced snapshot of `entries` for rendering. See the type-level
+    /// docs; read via [`Self::displayed_by_priority`] /
+    /// [`Self::displayed_label`] / [`Self::displayed_task`] /
+    /// [`Self::displayed_message`].
+    pub displayed: BTreeMap<String, StatusEntry>,
+    /// Keys removed from `entries` that still linger in `displayed`
+    /// awaiting the debounce window to drop them. Maps to the removal
+    /// instant. Empty for most workspaces most of the time.
+    pub pending_removals: BTreeMap<String, Instant>,
 }
 
 /// Reserved entry keys used by the legacy sidebar view. Named here rather
@@ -184,8 +211,48 @@ impl WorkspaceStatus {
     /// Same as [`Self::entries_by_priority`] but takes the current time
     /// explicitly — used by tests that need deterministic TTL behaviour.
     pub fn entries_by_priority_at(&self, now: Instant) -> Vec<(&str, &StatusEntry)> {
-        let mut v: Vec<(&str, &StatusEntry)> = self
-            .entries
+        Self::sorted_by_priority(&self.entries, now)
+    }
+
+    // ---- Debounced / displayed-snapshot accessors (G3) --------------------
+
+    /// Debounced label — the displayed projection of [`KEY_AGENT_LABEL`].
+    pub fn displayed_label(&self) -> Option<&str> {
+        self.displayed.get(KEY_AGENT_LABEL).map(|e| e.text.as_str())
+    }
+
+    /// Debounced task.
+    pub fn displayed_task(&self) -> Option<&str> {
+        self.displayed.get(KEY_AGENT_TASK).map(|e| e.text.as_str())
+    }
+
+    /// Debounced message. This is the field the sidebar currently renders
+    /// as the per-workspace subtitle; using the displayed projection here
+    /// is what actually eliminates tool-boundary flicker for the user.
+    pub fn displayed_message(&self) -> Option<&str> {
+        self.displayed
+            .get(KEY_AGENT_MESSAGE)
+            .map(|e| e.text.as_str())
+    }
+
+    /// Priority-sorted list of entries from the debounced `displayed`
+    /// snapshot. Expired entries (those with `expires_at` in the past) are
+    /// filtered out, same as [`Self::entries_by_priority`].
+    pub fn displayed_by_priority(&self) -> Vec<(&str, &StatusEntry)> {
+        self.displayed_by_priority_at(Instant::now())
+    }
+
+    /// Same as [`Self::displayed_by_priority`] but takes the current time
+    /// explicitly.
+    pub fn displayed_by_priority_at(&self, now: Instant) -> Vec<(&str, &StatusEntry)> {
+        Self::sorted_by_priority(&self.displayed, now)
+    }
+
+    fn sorted_by_priority(
+        src: &BTreeMap<String, StatusEntry>,
+        now: Instant,
+    ) -> Vec<(&str, &StatusEntry)> {
+        let mut v: Vec<(&str, &StatusEntry)> = src
             .iter()
             .filter(|(_, e)| !e.is_expired(now))
             .map(|(k, e)| (k.as_str(), e))


### PR DESCRIPTION
## Summary

- Closes gap G3 in the sidebar-parity plan (#260): 40ms debounce between status writes and what the sidebar renders, so rapid bursts of hook writes collapse to their settled value instead of flashing through intermediate states.
- Store-side: parallel `displayed` map + `pending_removals` tombstone map on `WorkspaceStatus`, promoted via `commit_displayed_at(now, debounce)`. `next_commit_at(debounce)` exposes the earliest deadline at which `displayed` would change, so the app can schedule a single `request_repaint_after` instead of spinning.
- App-side: sidebar reads `displayed_label/task/message`; `frame_update` commits the snapshot once per frame after draining notifications.

## Design notes

amux is pull-based (egui requests a paint), not push-based like cmux — so the debounce lives in the store as a shadow snapshot, not in an event pipeline. Re-inserts within the tombstone window cancel the stale tombstone so a fresh value doesn't get dropped when the old removal expires. A defensive orphan purge keeps `displayed` from drifting if `entries` is mutated directly (e.g. in future code paths).

Tombstone cases:
- **upsert → remove inside window**: never rendered. Tombstone isn't created because `displayed` never held the value.
- **upsert → committed → remove**: tombstone holds `displayed` for one debounce window, then drops.

Six new unit tests exercise the pipeline with `Instant`-injected variants (`upsert_entry_at`, `set_status_at`, `remove_entry_at`) so they're deterministic without `thread::sleep`.

## Test plan

- [x] `cargo test -p amux-notify` — 35/35 pass including the new G3 tests
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --workspace` — clean
- [ ] Run amux locally, watch the sidebar during a burst of tool calls — verify no flicker on the `agent.message` row

Closes G3 in #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)