### PR TITLE
G22: persist non-reserved keyed status entries across restart

### DIFF
--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -639,7 +639,7 @@ impl AmuxApp {
             // description). Reserved `agent.*` slots and the live
             // AgentState/progress describe process state that doesn't
             // survive a restart, so they're intentionally dropped.
-            let agent_status = self.notifications.workspace_status(ws.id).and_then(|s| {
+            let workspace_status = self.notifications.workspace_status(ws.id).and_then(|s| {
                 let entries: Vec<amux_session::SavedStatusEntry> = s
                     .entries
                     .iter()
@@ -668,7 +668,7 @@ impl AmuxApp {
                 zoomed: ws.zoomed,
                 panes: saved_panes,
                 color: ws.color,
-                agent_status,
+                workspace_status,
             });
         }
 

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -634,6 +634,31 @@ impl AmuxApp {
                     None => {}
                 }
             }
+            // G22: persist non-reserved keyed entries (user-published via
+            // `amux set-status`, e.g. `git.branch` or a workspace
+            // description). Reserved `agent.*` slots and the live
+            // AgentState/progress describe process state that doesn't
+            // survive a restart, so they're intentionally dropped.
+            let agent_status = self.notifications.workspace_status(ws.id).and_then(|s| {
+                let entries: Vec<amux_session::SavedStatusEntry> = s
+                    .entries
+                    .iter()
+                    .filter(|(k, _)| !k.starts_with(amux_notify::AGENT_KEY_PREFIX))
+                    .map(|(k, e)| amux_session::SavedStatusEntry {
+                        key: k.clone(),
+                        text: e.text.clone(),
+                        priority: e.priority,
+                        icon: e.icon.clone(),
+                        color: e.color,
+                    })
+                    .collect();
+                if entries.is_empty() {
+                    None
+                } else {
+                    Some(amux_session::SavedWorkspaceStatus { entries })
+                }
+            });
+
             saved_workspaces.push(amux_session::SavedWorkspace {
                 id: ws.id,
                 title: ws.title.clone(),
@@ -643,6 +668,7 @@ impl AmuxApp {
                 zoomed: ws.zoomed,
                 panes: saved_panes,
                 color: ws.color,
+                agent_status,
             });
         }
 

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -808,8 +808,18 @@ pub(crate) fn restore_session(
     // out `agent.*` before writing them, so agent-owned slots don't
     // resurrect after the agent died.
     let mut store = NotificationStore::new();
+    // Only reseed for workspaces that actually restored. The earlier
+    // restore loop can drop a saved workspace (unsupported panel type,
+    // tree referencing missing panes, every surface failing to spawn)
+    // and we'd otherwise leave orphan `WorkspaceStatus` records keyed
+    // by IDs with no matching `Workspace` — state no UI path could ever
+    // clear.
+    let restored_ids: std::collections::HashSet<u64> = workspaces.iter().map(|w| w.id).collect();
     for saved_ws in &session.workspaces {
-        let Some(saved_status) = saved_ws.agent_status.as_ref() else {
+        if !restored_ids.contains(&saved_ws.id) {
+            continue;
+        }
+        let Some(saved_status) = saved_ws.workspace_status.as_ref() else {
             continue;
         };
         for entry in &saved_status.entries {

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -794,13 +794,41 @@ pub(crate) fn restore_session(
         drag: None,
     };
 
-    // Don't restore notifications — they're from dead agent sessions
-    // that can't be reattached. Starting fresh avoids stale unread
-    // badges in the sidebar. See #244.
-    let store = NotificationStore::new();
-
-    // Don't restore workspace statuses — agent processes don't survive restart,
-    // so any Active/Waiting state would be stale. They start as Idle implicitly.
+    // Don't restore notifications (the pane-level unread ring) — they're
+    // from dead agent sessions that can't be reattached, and a stale
+    // unread badge would mislead the user. See #244.
+    //
+    // Don't restore workspace agent *state* (Active/Waiting) or progress
+    // either — agent processes don't survive restart, so any live state
+    // would be stale. They start as Idle implicitly.
+    //
+    // G22: we *do* restore non-reserved keyed entries (`git.branch`,
+    // user-set descriptions, etc.). Those are user publications via
+    // `amux set-status` and carry across restart; the save side filters
+    // out `agent.*` before writing them, so agent-owned slots don't
+    // resurrect after the agent died.
+    let mut store = NotificationStore::new();
+    for saved_ws in &session.workspaces {
+        let Some(saved_status) = saved_ws.agent_status.as_ref() else {
+            continue;
+        };
+        for entry in &saved_status.entries {
+            if entry.key.starts_with(amux_notify::AGENT_KEY_PREFIX) {
+                // Defensive — a future-build or hand-edited session file
+                // shouldn't be able to shove `agent.*` through this path.
+                continue;
+            }
+            store.upsert_entry(
+                saved_ws.id,
+                entry.key.clone(),
+                entry.text.clone(),
+                entry.priority,
+                entry.icon.clone(),
+                entry.color,
+                None,
+            );
+        }
+    }
 
     let active_idx = session
         .active_workspace_idx

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -80,6 +80,37 @@ pub struct SavedWorkspace {
     pub panes: HashMap<u64, SavedManagedPane>,
     #[serde(default)]
     pub color: Option<[u8; 4]>,
+    /// Non-reserved keyed status entries (user publications via
+    /// `amux set-status`, e.g. `git.branch` or a workspace description).
+    /// Reserved `agent.*` slots and the live `AgentState` / progress are
+    /// intentionally not persisted — those describe agent-process state
+    /// that doesn't survive a restart (see #260 G22 and the note in
+    /// `restore_session`). `None` when nothing worth saving is present,
+    /// so old session files without this field load unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_status: Option<SavedWorkspaceStatus>,
+}
+
+/// Serializable projection of `amux_notify::WorkspaceStatus` — carries only
+/// what's safe to restore across a restart. See [`SavedWorkspace::agent_status`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedWorkspaceStatus {
+    pub entries: Vec<SavedStatusEntry>,
+}
+
+/// Persistable form of `amux_notify::StatusEntry`. Timestamps (`updated_at`,
+/// `expires_at`) aren't carried: they're `Instant`-valued and have no
+/// cross-restart meaning, so restored entries come back sticky with a
+/// fresh `updated_at` at load time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedStatusEntry {
+    pub key: String,
+    pub text: String,
+    pub priority: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<[u8; 4]>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -301,6 +332,7 @@ mod tests {
                 zoomed: None,
                 panes,
                 color: None,
+                agent_status: None,
             }],
             active_workspace_idx: 0,
             next_pane_id: 1,
@@ -430,6 +462,65 @@ mod tests {
         }"#;
         let surface: SavedSurface = serde_json::from_str(json).unwrap();
         assert!(surface.user_title.is_none());
+    }
+
+    #[test]
+    fn deserialize_without_agent_status_defaults_to_none() {
+        // Older sessions predate G22's agent_status field — the
+        // `#[serde(default)]` shim must let them load unchanged.
+        // Generate a valid SavedWorkspace via serde, strip agent_status,
+        // and confirm it still parses.
+        let ws = &minimal_session().workspaces[0];
+        let mut v = serde_json::to_value(ws).unwrap();
+        v.as_object_mut().unwrap().remove("agent_status");
+        assert!(!v.as_object().unwrap().contains_key("agent_status"));
+        let restored: SavedWorkspace = serde_json::from_value(v).unwrap();
+        assert!(restored.agent_status.is_none());
+    }
+
+    #[test]
+    fn agent_status_round_trips_keyed_entries() {
+        let mut session = minimal_session();
+        session.workspaces[0].agent_status = Some(SavedWorkspaceStatus {
+            entries: vec![
+                SavedStatusEntry {
+                    key: "git.branch".to_string(),
+                    text: "main".to_string(),
+                    priority: 50,
+                    icon: Some("".to_string()),
+                    color: Some([255, 128, 0, 255]),
+                },
+                SavedStatusEntry {
+                    key: "workspace.description".to_string(),
+                    text: "parity sprint".to_string(),
+                    priority: 50,
+                    icon: None,
+                    color: None,
+                },
+            ],
+        });
+        let json = serde_json::to_string(&session).unwrap();
+        assert!(json.contains("agent_status"));
+        let restored: SessionData = serde_json::from_str(&json).unwrap();
+        let entries = restored.workspaces[0]
+            .agent_status
+            .as_ref()
+            .unwrap()
+            .entries
+            .as_slice();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].key, "git.branch");
+        assert_eq!(entries[0].color, Some([255, 128, 0, 255]));
+        assert_eq!(entries[1].key, "workspace.description");
+        assert!(entries[1].color.is_none());
+    }
+
+    #[test]
+    fn agent_status_none_is_omitted_from_json() {
+        // skip_serializing_if on the Option keeps the common case terse.
+        let session = minimal_session();
+        let json = serde_json::to_string(&session).unwrap();
+        assert!(!json.contains("agent_status"));
     }
 
     #[test]

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -87,14 +87,25 @@ pub struct SavedWorkspace {
     /// that doesn't survive a restart (see #260 G22 and the note in
     /// `restore_session`). `None` when nothing worth saving is present,
     /// so old session files without this field load unchanged.
+    ///
+    /// Named after the struct it carries, not after the `agent.*` keys —
+    /// those are exactly what this field *excludes*. An earlier revision
+    /// called this `agent_status`, which read as the inverse of the
+    /// intent; the rename happened before the PR landed, so there's no
+    /// on-disk compat burden.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub agent_status: Option<SavedWorkspaceStatus>,
+    pub workspace_status: Option<SavedWorkspaceStatus>,
 }
 
 /// Serializable projection of `amux_notify::WorkspaceStatus` — carries only
-/// what's safe to restore across a restart. See [`SavedWorkspace::agent_status`].
+/// what's safe to restore across a restart. See
+/// [`SavedWorkspace::workspace_status`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedWorkspaceStatus {
+    /// User-published keyed entries to restore on the next launch. The
+    /// save path filters reserved `agent.*` keys; the restore path also
+    /// filters defensively in case a hand-edited session file tries to
+    /// smuggle reserved keys through.
     pub entries: Vec<SavedStatusEntry>,
 }
 
@@ -104,11 +115,16 @@ pub struct SavedWorkspaceStatus {
 /// fresh `updated_at` at load time.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedStatusEntry {
+    /// Namespaced entry key (e.g. `git.branch`, `workspace.description`).
     pub key: String,
+    /// Rendered text for the entry — what appears in the sidebar row.
     pub text: String,
+    /// Sort priority; higher wins. See `amux_notify::types::priority`.
     pub priority: i32,
+    /// Optional icon (emoji or glyph) shown alongside `text`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icon: Option<String>,
+    /// Optional RGBA override for the text color.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<[u8; 4]>,
 }
@@ -332,7 +348,7 @@ mod tests {
                 zoomed: None,
                 panes,
                 color: None,
-                agent_status: None,
+                workspace_status: None,
             }],
             active_workspace_idx: 0,
             next_pane_id: 1,
@@ -465,23 +481,23 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_without_agent_status_defaults_to_none() {
-        // Older sessions predate G22's agent_status field — the
+    fn deserialize_without_workspace_status_defaults_to_none() {
+        // Older sessions predate G22's workspace_status field — the
         // `#[serde(default)]` shim must let them load unchanged.
-        // Generate a valid SavedWorkspace via serde, strip agent_status,
+        // Generate a valid SavedWorkspace via serde, strip the field,
         // and confirm it still parses.
         let ws = &minimal_session().workspaces[0];
         let mut v = serde_json::to_value(ws).unwrap();
-        v.as_object_mut().unwrap().remove("agent_status");
-        assert!(!v.as_object().unwrap().contains_key("agent_status"));
+        v.as_object_mut().unwrap().remove("workspace_status");
+        assert!(!v.as_object().unwrap().contains_key("workspace_status"));
         let restored: SavedWorkspace = serde_json::from_value(v).unwrap();
-        assert!(restored.agent_status.is_none());
+        assert!(restored.workspace_status.is_none());
     }
 
     #[test]
-    fn agent_status_round_trips_keyed_entries() {
+    fn workspace_status_round_trips_keyed_entries() {
         let mut session = minimal_session();
-        session.workspaces[0].agent_status = Some(SavedWorkspaceStatus {
+        session.workspaces[0].workspace_status = Some(SavedWorkspaceStatus {
             entries: vec![
                 SavedStatusEntry {
                     key: "git.branch".to_string(),
@@ -500,10 +516,10 @@ mod tests {
             ],
         });
         let json = serde_json::to_string(&session).unwrap();
-        assert!(json.contains("agent_status"));
+        assert!(json.contains("workspace_status"));
         let restored: SessionData = serde_json::from_str(&json).unwrap();
         let entries = restored.workspaces[0]
-            .agent_status
+            .workspace_status
             .as_ref()
             .unwrap()
             .entries
@@ -516,11 +532,11 @@ mod tests {
     }
 
     #[test]
-    fn agent_status_none_is_omitted_from_json() {
+    fn workspace_status_none_is_omitted_from_json() {
         // skip_serializing_if on the Option keeps the common case terse.
         let session = minimal_session();
         let json = serde_json::to_string(&session).unwrap();
-        assert!(!json.contains("agent_status"));
+        assert!(!json.contains("workspace_status"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Closes gap G22 in the sidebar-parity plan (#260), scoped to what's actually landed: keyed status entries published via `amux set-status` now survive a session restart.
- Reserved `agent.*` slots and the live `AgentState` / `progress` are **not** persisted — those describe process state that doesn't survive a restart, and restoring a stale "Running tests..." after the agent died would be worse than losing it. Existing comment at `startup.rs` already documented this rationale; G22 carves out the user-published subset.

## Schema changes

`SavedWorkspace` picks up an optional `agent_status`. Everything is behind `#[serde(default)]`, so **no schema-version bump** — old v1 session files load unchanged.

```rust
pub struct SavedWorkspace { ..., pub agent_status: Option<SavedWorkspaceStatus> }

pub struct SavedWorkspaceStatus { pub entries: Vec<SavedStatusEntry> }

pub struct SavedStatusEntry {
    pub key: String,
    pub text: String,
    pub priority: i32,
    pub icon: Option<String>,
    pub color: Option<[u8; 4]>,
}
```

Dropped fields (deliberate):
- **`state` / `progress`**: live-process fields. Restoring `Active` after the agent is dead would be a lie.
- **`updated_at` / `expires_at`**: `Instant`-valued, no cross-restart meaning. Restored entries come back sticky.

## App wiring

- `build_session_data` (`main.rs`): per workspace, filter `AGENT_KEY_PREFIX` keys out of `status.entries`, only attach `agent_status` when there's something to save.
- `restore_session` (`startup.rs`): re-seed the store via `upsert_entry` for each persisted entry. The agent-prefix filter runs defensively on the restore side too, in case a hand-edited session file tries to smuggle reserved keys through.
- Folded the redundant second `let store = NotificationStore::new()` into a single `let mut store` and expanded the comment to cover both the notification-ring rationale (#244) and the G22 decision.

## Test plan

- [x] `cargo test -p amux-session` — 19/19 pass, including 3 new tests (default-on-missing-field, round-trip, None-omitted-from-JSON)
- [x] `cargo test -p amux-notify` — 35/35 (regression check on the G3 pipeline)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --workspace` — clean
- [ ] Manual smoke: `amux set-status --workspace <id> git.branch main`, kill amux, restart, confirm the entry is back.

Closes G22 in #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom notification status entries are now saved with workspace sessions and automatically restored when sessions are reopened, with full backward compatibility for existing session files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->