### PR TITLE
G16: progress bar + optional label (parity plan #260)

### DIFF
--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -987,8 +987,7 @@ impl AmuxApp {
                                 Some(v.clamp(0.0, 1.0))
                             }
                         });
-                        self.notifications
-                            .set_progress(ws_id, value, params.label.clone());
+                        self.notifications.set_progress(ws_id, value, params.label);
                         Response::ok(req.id.clone(), serde_json::json!({}))
                     }
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),

--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -970,6 +970,30 @@ impl AmuxApp {
                     Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
                 }
             }
+            "status.progress" => {
+                match serde_json::from_value::<amux_ipc::methods::StatusProgressParams>(
+                    req.params.clone(),
+                ) {
+                    Ok(params) => {
+                        let ws_id = params.workspace_id.parse::<u64>().unwrap_or(0);
+                        // Clamp to [0.0, 1.0] so malformed callers (sending
+                        // raw counters or percentages) can't paint an
+                        // out-of-bounds bar. NaN collapses to `None` rather
+                        // than sticking as a poison value.
+                        let value = params.value.and_then(|v| {
+                            if v.is_nan() {
+                                None
+                            } else {
+                                Some(v.clamp(0.0, 1.0))
+                            }
+                        });
+                        self.notifications
+                            .set_progress(ws_id, value, params.label.clone());
+                        Response::ok(req.id.clone(), serde_json::json!({}))
+                    }
+                    Err(e) => Response::err(req.id.clone(), "invalid_params", &e.to_string()),
+                }
+            }
             "status.remove_entry" => {
                 match serde_json::from_value::<amux_ipc::methods::RemoveEntryParams>(
                     req.params.clone(),

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -315,6 +315,12 @@ fn render_workspace_row(
     let status = notifications.workspace_status(ws.id);
     let has_status = status.is_some();
     let has_progress = status.as_ref().and_then(|s| s.progress).is_some();
+    let progress_label = status
+        .as_ref()
+        .filter(|s| s.progress.is_some())
+        .and_then(|s| s.progress_label.as_deref())
+        .filter(|l| !l.is_empty());
+    let has_progress_label = progress_label.is_some();
     // Filter empty-string entries: upsert_entry lets publishers write empty
     // text, and we shouldn't reserve a subtitle line for a blank message.
     // G3: render from the debounced `displayed` projection so rapid bursts
@@ -379,6 +385,9 @@ fn render_workspace_row(
     }
     if has_progress {
         row_h += PROGRESS_BAR_HEIGHT + 4.0;
+    }
+    if has_progress_label {
+        row_h += METADATA_LINE_HEIGHT + 2.0;
     }
 
     let avail_w = ui.available_width();
@@ -715,8 +724,26 @@ fn render_workspace_row(
         content_bottom += NOTIF_PREVIEW_HEIGHT;
     }
 
-    // --- Progress bar ---
+    // --- Progress bar (optional label row + thin bar) ---
     if let Some(progress) = status.as_ref().and_then(|s| s.progress) {
+        // Label sits above the bar so the bar stays aligned with the
+        // same baseline whether or not there's a label; keeps the row
+        // visual rhythm consistent across workspaces.
+        if let Some(label) = progress_label {
+            content_bottom += 2.0;
+            let label_x = rect.min.x + content_left;
+            let max_w = avail_w - content_left - ROW_H_PAD;
+            let label_font = egui::FontId::proportional(METADATA_FONT_SIZE);
+            let truncated = truncate_text(ui, label, &label_font, max_w);
+            ui.painter().text(
+                egui::pos2(label_x, content_bottom),
+                egui::Align2::LEFT_TOP,
+                &truncated,
+                label_font,
+                meta_color,
+            );
+            content_bottom += METADATA_LINE_HEIGHT;
+        }
         content_bottom += 4.0;
         let bar_x = rect.min.x + content_left;
         let bar_w = avail_w - content_left - ROW_H_PAD;

--- a/crates/amux-cli/src/cli.rs
+++ b/crates/amux-cli/src/cli.rs
@@ -326,16 +326,20 @@ pub(crate) enum Command {
     /// sidebar row).
     ///
     /// `VALUE` is a fraction in `[0.0, 1.0]` — pass `--clear` instead
-    /// to drop the bar entirely. `--label` attaches a short caption
-    /// ("compiling 34/120"); it renders next to the bar and only while
-    /// a value is present.
+    /// to drop the bar entirely. Exactly one of `VALUE` or `--clear`
+    /// is required. `--label` attaches a short caption
+    /// ("compiling 34/120"); it renders above the bar and only while
+    /// a value is present, so it can't be combined with `--clear`.
     #[command(name = "set-progress")]
     SetProgress {
-        /// Progress value between 0.0 and 1.0. Conflicts with `--clear`.
+        /// Progress value between 0.0 and 1.0. Required unless
+        /// `--clear` is set; conflicts with `--clear`.
         #[arg(conflicts_with = "clear")]
         value: Option<f32>,
-        /// Optional short caption rendered beside the bar.
-        #[arg(long)]
+        /// Optional short caption rendered above the bar. Only
+        /// meaningful while a value is present, so it can't be
+        /// combined with `--clear`.
+        #[arg(long, conflicts_with = "clear")]
         label: Option<String>,
         /// Clear the progress bar (and its label).
         #[arg(long)]

--- a/crates/amux-cli/src/cli.rs
+++ b/crates/amux-cli/src/cli.rs
@@ -322,6 +322,28 @@ pub(crate) enum Command {
         #[arg(long)]
         workspace: Option<String>,
     },
+    /// Set or clear the workspace progress bar (decoration on the
+    /// sidebar row).
+    ///
+    /// `VALUE` is a fraction in `[0.0, 1.0]` — pass `--clear` instead
+    /// to drop the bar entirely. `--label` attaches a short caption
+    /// ("compiling 34/120"); it renders next to the bar and only while
+    /// a value is present.
+    #[command(name = "set-progress")]
+    SetProgress {
+        /// Progress value between 0.0 and 1.0. Conflicts with `--clear`.
+        #[arg(conflicts_with = "clear")]
+        value: Option<f32>,
+        /// Optional short caption rendered beside the bar.
+        #[arg(long)]
+        label: Option<String>,
+        /// Clear the progress bar (and its label).
+        #[arg(long)]
+        clear: bool,
+        /// Target workspace ID (defaults to AMUX_WORKSPACE_ID)
+        #[arg(long)]
+        workspace: Option<String>,
+    },
     /// Remove a previously-published keyed status entry.
     #[command(name = "remove-entry")]
     RemoveEntry {

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -787,6 +787,48 @@ async fn main() -> anyhow::Result<()> {
                 print_response(&resp, false);
             }
         }
+        Command::SetProgress {
+            value,
+            label,
+            clear,
+            workspace,
+        } => {
+            let ws_id = workspace
+                .or_else(|| std::env::var("AMUX_WORKSPACE_ID").ok())
+                .unwrap_or_else(|| "0".to_string());
+            let value = if clear { None } else { value };
+            if let Some(v) = value {
+                if !v.is_finite() {
+                    anyhow::bail!("progress value must be finite (got {v})");
+                }
+                if !(0.0..=1.0).contains(&v) {
+                    anyhow::bail!("progress value must be in [0.0, 1.0] (got {v})");
+                }
+            } else if !clear && label.is_some() {
+                // A label without a bar is meaningless — the server
+                // drops labels on a `None` value anyway. Surface this
+                // to the caller so a script bug doesn't silently no-op.
+                anyhow::bail!("--label requires a progress value or --clear");
+            }
+            let mut params = serde_json::json!({
+                "workspace_id": ws_id,
+                "value": value,
+            });
+            if let Some(ref l) = label {
+                params["label"] = serde_json::json!(l);
+            }
+            let resp = client.call("status.progress", params).await?;
+            if cli.json {
+                print_response(&resp, true);
+            } else if resp.ok {
+                match value {
+                    Some(v) => println!("Progress set to {v:.2}"),
+                    None => println!("Progress cleared"),
+                }
+            } else {
+                print_response(&resp, false);
+            }
+        }
         Command::RemoveEntry { key, workspace } => {
             if key.starts_with("agent.") {
                 anyhow::bail!(

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -796,6 +796,15 @@ async fn main() -> anyhow::Result<()> {
             let ws_id = workspace
                 .or_else(|| std::env::var("AMUX_WORKSPACE_ID").ok())
                 .unwrap_or_else(|| "0".to_string());
+            // Require exactly one of VALUE or --clear. clap already
+            // rejects `--clear 0.5` via `conflicts_with`; this is the
+            // missing half — a bare `amux set-progress` shouldn't
+            // silently clear the bar by sending a null value.
+            if value.is_none() && !clear {
+                anyhow::bail!(
+                    "set-progress requires either a VALUE or --clear (bare invocation has no effect)"
+                );
+            }
             let value = if clear { None } else { value };
             if let Some(v) = value {
                 if !v.is_finite() {
@@ -804,11 +813,6 @@ async fn main() -> anyhow::Result<()> {
                 if !(0.0..=1.0).contains(&v) {
                     anyhow::bail!("progress value must be in [0.0, 1.0] (got {v})");
                 }
-            } else if !clear && label.is_some() {
-                // A label without a bar is meaningless — the server
-                // drops labels on a `None` value anyway. Surface this
-                // to the caller so a script bug doesn't silently no-op.
-                anyhow::bail!("--label requires a progress value or --clear");
             }
             let mut params = serde_json::json!({
                 "workspace_id": ws_id,

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -160,6 +160,23 @@ pub struct RemoveEntryParams {
     pub key: String,
 }
 
+/// Parameters for `status.progress`: set or clear the per-workspace
+/// progress bar and its optional label.
+///
+/// `value` is clamped to the `[0.0, 1.0]` range server-side so a caller
+/// passing e.g. `34.0 / 120.0 * 100.0` instead of the fraction doesn't
+/// paint a garbage-width bar. Omit `value` (or send `null`) to clear —
+/// the server drops the label in that case since a bare label has no
+/// bar to attach to.
+#[derive(Debug, Deserialize)]
+pub struct StatusProgressParams {
+    pub workspace_id: String,
+    #[serde(default)]
+    pub value: Option<f32>,
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct SetCwdParams {
     pub surface_id: String,

--- a/crates/amux-notify/src/store.rs
+++ b/crates/amux-notify/src/store.rs
@@ -461,6 +461,7 @@ impl NotificationStore {
                 state,
                 updated_at: now,
                 progress: None,
+                progress_label: None,
                 entries: BTreeMap::new(),
                 displayed: BTreeMap::new(),
                 pending_removals: BTreeMap::new(),
@@ -469,6 +470,7 @@ impl NotificationStore {
         entry.updated_at = now;
         // set_status is a "coarse" update: clears any existing progress.
         entry.progress = None;
+        entry.progress_label = None;
 
         apply_legacy_field(
             &mut entry.entries,
@@ -564,6 +566,7 @@ impl NotificationStore {
                 state: AgentState::Idle,
                 updated_at: now,
                 progress: None,
+                progress_label: None,
                 entries: BTreeMap::new(),
                 displayed: BTreeMap::new(),
                 pending_removals: BTreeMap::new(),
@@ -648,10 +651,24 @@ impl NotificationStore {
         }
     }
 
-    /// Set workspace progress (0.0–1.0). Pass `None` to clear.
-    pub fn set_progress(&mut self, workspace_id: u64, progress: Option<f32>) {
+    /// Set workspace progress (0.0–1.0) with an optional short label
+    /// (e.g. `"compiling 34/120"`). Pass `progress = None` to clear the
+    /// bar entirely; the label is cleared alongside in that case since a
+    /// lingering label without a bar has no place to render.
+    ///
+    /// This is a no-op for workspaces the store has never seen — the
+    /// progress bar is a decoration on top of an existing workspace row,
+    /// not a reason to allocate one. Call [`Self::set_status`] first if
+    /// you need to create the row.
+    pub fn set_progress(
+        &mut self,
+        workspace_id: u64,
+        progress: Option<f32>,
+        label: Option<String>,
+    ) {
         if let Some(status) = self.workspace_statuses.get_mut(&workspace_id) {
             status.progress = progress;
+            status.progress_label = if progress.is_some() { label } else { None };
             status.updated_at = Instant::now();
         }
     }
@@ -1444,14 +1461,40 @@ mod tests {
         // set_status creates entry with no progress
         store.set_status(1, AgentState::Active, Some("Building".into()), None, None);
         assert!(store.workspace_status(1).unwrap().progress.is_none());
+        assert!(store.workspace_status(1).unwrap().progress_label.is_none());
 
         // set_progress adds progress
-        store.set_progress(1, Some(0.5));
+        store.set_progress(1, Some(0.5), None);
         assert_eq!(store.workspace_status(1).unwrap().progress, Some(0.5));
 
-        // set_status clears progress
+        // set_progress with a label stores both
+        store.set_progress(1, Some(0.75), Some("compiling 75/100".into()));
+        assert_eq!(store.workspace_status(1).unwrap().progress, Some(0.75));
+        assert_eq!(
+            store.workspace_status(1).unwrap().progress_label.as_deref(),
+            Some("compiling 75/100")
+        );
+
+        // Clearing progress also drops the label — an orphan label with
+        // no bar has nowhere to render.
+        store.set_progress(1, None, Some("stale".into()));
+        assert!(store.workspace_status(1).unwrap().progress.is_none());
+        assert!(store.workspace_status(1).unwrap().progress_label.is_none());
+
+        // Restore a bar+label, then verify set_status clears both.
+        store.set_progress(1, Some(0.25), Some("step 1".into()));
         store.set_status(1, AgentState::Idle, None, None, None);
         assert!(store.workspace_status(1).unwrap().progress.is_none());
+        assert!(store.workspace_status(1).unwrap().progress_label.is_none());
+    }
+
+    #[test]
+    fn set_progress_on_missing_workspace_is_noop() {
+        // `set_progress` is a decoration on top of an existing row; it
+        // shouldn't lazily allocate one just to stash a value.
+        let mut store = NotificationStore::new();
+        store.set_progress(99, Some(0.5), Some("ignored".into()));
+        assert!(store.workspace_status(99).is_none());
     }
 
     #[test]

--- a/crates/amux-notify/src/types.rs
+++ b/crates/amux-notify/src/types.rs
@@ -141,6 +141,10 @@ pub struct WorkspaceStatus {
     pub updated_at: Instant,
     /// Optional progress value (0.0–1.0) for progress bar display.
     pub progress: Option<f32>,
+    /// Optional short label rendered alongside the progress bar (e.g.
+    /// `"compiling 34/120"`). Only meaningful when [`Self::progress`] is
+    /// `Some` — cleared together with it whenever the bar clears.
+    pub progress_label: Option<String>,
     /// Keyed status entries — authoritative, written immediately by
     /// `upsert_entry` / `set_status` / `remove_entry`. Use
     /// [`Self::entries_by_priority`] for the ordered render list;


### PR DESCRIPTION
## Summary

Parity plan [#260](https://github.com/daveowenatl/amux/issues/260) — gap **G16** (progress bar label).

Progress was a dead field on `WorkspaceStatus`: rendered by the sidebar but never written to by any IPC or CLI path. This wires the full end-to-end path and adds cmux parity on the optional short caption ("compiling 34/120") that renders beside the bar.

- `WorkspaceStatus.progress_label: Option<String>`, cleared alongside `progress` so an orphan label can never outlive its bar.
- `NotificationStore::set_progress(id, value, label)` writes both and clears the label when `value` is `None`.
- New `status.progress` IPC method — `StatusProgressParams` clamps `value` into `[0.0, 1.0]` server-side and collapses NaN to `None`, so a caller passing raw counters or percentages can't paint a garbage-width bar.
- New `amux set-progress VALUE [--label TEXT] [--clear]` CLI. `--label` without a value (and without `--clear`) is an error — silently dropping would hide script bugs.
- Sidebar row reserves an extra metadata line when a label is present, renders the label above the thin bar so the bar's baseline stays consistent across workspaces.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p amux-notify -p amux-session -p amux-cli -p amux-ipc -p amux-app` — 138 tests pass
- [ ] Manual smoke: `amux set-progress 0.5 --label "step 3/10"` shows bar + label in the sidebar; `amux set-progress --clear` drops both

Closes part of #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)