### PR TITLE
Pinned workspace state (#260 G8)

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -347,6 +347,13 @@ impl eframe::App for AmuxApp {
                             {
                                 self.active_workspace_idx += 1;
                             }
+                            // Reassert the pinned-first invariant: a drag
+                            // that crossed the pin boundary snaps back so
+                            // pinned workspaces always group at the top.
+                            workspace_ops::enforce_pinned_first(
+                                &mut self.workspaces,
+                                &mut self.active_workspace_idx,
+                            );
                         }
                     }
                     sidebar::SidebarAction::SetWorkspaceColor(idx, color) => {
@@ -357,20 +364,10 @@ impl eframe::App for AmuxApp {
                     sidebar::SidebarAction::TogglePinWorkspace(idx) => {
                         if idx < self.workspaces.len() {
                             self.workspaces[idx].pinned = !self.workspaces[idx].pinned;
-                            // Resort so pinned workspaces float to the top,
-                            // preserving relative order within each group.
-                            // `active_workspace_idx` is tracked by workspace id
-                            // across the reshuffle because indices would change.
-                            let active_id =
-                                self.workspaces.get(self.active_workspace_idx).map(|w| w.id);
-                            self.workspaces.sort_by_key(|w| !w.pinned);
-                            if let Some(id) = active_id {
-                                if let Some(new_idx) =
-                                    self.workspaces.iter().position(|w| w.id == id)
-                                {
-                                    self.active_workspace_idx = new_idx;
-                                }
-                            }
+                            workspace_ops::enforce_pinned_first(
+                                &mut self.workspaces,
+                                &mut self.active_workspace_idx,
+                            );
                         }
                     }
                 }

--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -354,6 +354,25 @@ impl eframe::App for AmuxApp {
                             self.workspaces[idx].color = color;
                         }
                     }
+                    sidebar::SidebarAction::TogglePinWorkspace(idx) => {
+                        if idx < self.workspaces.len() {
+                            self.workspaces[idx].pinned = !self.workspaces[idx].pinned;
+                            // Resort so pinned workspaces float to the top,
+                            // preserving relative order within each group.
+                            // `active_workspace_idx` is tracked by workspace id
+                            // across the reshuffle because indices would change.
+                            let active_id =
+                                self.workspaces.get(self.active_workspace_idx).map(|w| w.id);
+                            self.workspaces.sort_by_key(|w| !w.pinned);
+                            if let Some(id) = active_id {
+                                if let Some(new_idx) =
+                                    self.workspaces.iter().position(|w| w.id == id)
+                                {
+                                    self.active_workspace_idx = new_idx;
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -668,6 +668,7 @@ impl AmuxApp {
                 zoomed: ws.zoomed,
                 panes: saved_panes,
                 color: ws.color,
+                pinned: ws.pinned,
                 workspace_status,
             });
         }

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -67,6 +67,7 @@ pub(crate) enum SidebarAction {
     MarkWorkspaceRead(usize),
     ReorderWorkspace(usize, usize),
     SetWorkspaceColor(usize, Option<[u8; 4]>),
+    TogglePinWorkspace(usize),
 }
 
 // ---------------------------------------------------------------------------
@@ -342,7 +343,7 @@ fn render_workspace_row(
     // title > default workspace name. A user who explicitly renamed
     // the workspace via the rename modal should not have their choice
     // overwritten by agent status or auto-detected titles.
-    let display_title = if let Some(ref ut) = ws.user_title {
+    let base_title = if let Some(ref ut) = ws.user_title {
         ut.clone()
     } else if let Some(task) = status.as_ref().and_then(|s| s.displayed_task()) {
         format!("\u{2731} {task}")
@@ -350,6 +351,14 @@ fn render_workspace_row(
         st.clone()
     } else {
         ws.title.clone()
+    };
+    // Prepend a pin glyph for pinned workspaces. Included in the
+    // measured `display_title` so wrap / ellipsis calculations below
+    // reserve room for it.
+    let display_title = if ws.pinned {
+        format!("\u{1F4CC} {base_title}")
+    } else {
+        base_title
     };
     let content_left_est = if has_color {
         ROW_H_PAD + COLOR_CAPSULE_WIDTH + 4.0
@@ -445,6 +454,15 @@ fn render_workspace_row(
                 ui.close_menu();
             }
             ui.separator();
+            let pin_label = if ws.pinned {
+                "Unpin Workspace"
+            } else {
+                "Pin Workspace"
+            };
+            if ui.button(pin_label).clicked() {
+                actions.push(SidebarAction::TogglePinWorkspace(idx));
+                ui.close_menu();
+            }
             if ui.button("Mark All Read").clicked() {
                 actions.push(SidebarAction::MarkWorkspaceRead(idx));
                 ui.close_menu();

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -619,6 +619,7 @@ pub(crate) fn fresh_startup(
         dragging_divider: None,
         last_pane_sizes: HashMap::new(),
         color: None,
+        pinned: false,
     };
 
     Ok(StartupState {
@@ -769,6 +770,7 @@ pub(crate) fn restore_session(
             dragging_divider: None,
             last_pane_sizes: HashMap::new(),
             color: saved_ws.color,
+            pinned: saved_ws.pinned,
         });
     }
 

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -842,9 +842,15 @@ pub(crate) fn restore_session(
         }
     }
 
-    let active_idx = session
+    let mut active_idx = session
         .active_workspace_idx
         .min(workspaces.len().saturating_sub(1));
+
+    // Session files written before G8 — or any manually-reordered save —
+    // can ship pinned workspaces interleaved with unpinned ones. Enforce
+    // the pinned-first invariant on load so what the user sees matches
+    // what the toggle and drag-reorder paths produce.
+    workspace_ops::enforce_pinned_first(&mut workspaces, &mut active_idx);
 
     StartupState {
         workspaces,

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -120,6 +120,7 @@ impl AmuxApp {
                     dragging_divider: None,
                     last_pane_sizes: HashMap::new(),
                     color: None,
+                    pinned: false,
                 };
 
                 self.workspaces.push(workspace);

--- a/crates/amux-app/src/workspace_ops.rs
+++ b/crates/amux-app/src/workspace_ops.rs
@@ -2,6 +2,26 @@
 
 use crate::*;
 
+/// Stably partition `workspaces` so pinned entries come first, preserving
+/// relative order within each group, and rewrite `active_idx` so it still
+/// points at the same workspace (by id) after the reshuffle.
+///
+/// Called after any mutation that can change workspace ordering —
+/// pin toggle, drag-reorder, session restore — to keep the "pinned sorts
+/// to the top" invariant intact. A stable sort means unpinned drag order
+/// and pinned drag order are both preserved within their group, so a user
+/// dragging two pinned workspaces around each other still sees their
+/// manual order.
+pub(crate) fn enforce_pinned_first(workspaces: &mut [Workspace], active_idx: &mut usize) {
+    let active_id = workspaces.get(*active_idx).map(|w| w.id);
+    workspaces.sort_by_key(|w| !w.pinned);
+    if let Some(id) = active_id {
+        if let Some(new_idx) = workspaces.iter().position(|w| w.id == id) {
+            *active_idx = new_idx;
+        }
+    }
+}
+
 impl AmuxApp {
     /// Check if any egui text field (omnibar, rename modal, find bar) has focus.
     pub(crate) fn has_focused_text_field(&self) -> bool {

--- a/crates/amux-core/src/model.rs
+++ b/crates/amux-core/src/model.rs
@@ -28,6 +28,10 @@ pub struct Workspace {
     pub last_pane_sizes: HashMap<PaneId, (usize, usize)>,
     /// Optional workspace color for sidebar indicator.
     pub color: Option<[u8; 4]>,
+    /// When true, the workspace sorts to the top of the sidebar and
+    /// renders a pin glyph next to its title. Toggled via the sidebar
+    /// context menu and persisted across sessions.
+    pub pinned: bool,
 }
 
 pub struct SidebarState {

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -80,6 +80,11 @@ pub struct SavedWorkspace {
     pub panes: HashMap<u64, SavedManagedPane>,
     #[serde(default)]
     pub color: Option<[u8; 4]>,
+    /// When true, the workspace sorts to the top of the sidebar and
+    /// renders with a pin glyph. Defaults to `false`, so session files
+    /// written before this field existed deserialize unchanged.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub pinned: bool,
     /// Non-reserved keyed status entries (user publications via
     /// `amux set-status`, e.g. `git.branch` or a workspace description).
     /// Reserved `agent.*` slots and the live `AgentState` / progress are
@@ -348,6 +353,7 @@ mod tests {
                 zoomed: None,
                 panes,
                 color: None,
+                pinned: false,
                 workspace_status: None,
             }],
             active_workspace_idx: 0,
@@ -537,6 +543,42 @@ mod tests {
         let session = minimal_session();
         let json = serde_json::to_string(&session).unwrap();
         assert!(!json.contains("workspace_status"));
+    }
+
+    #[test]
+    fn pinned_default_false_is_omitted_from_json() {
+        // skip_serializing_if on `pinned` keeps the common case terse.
+        let session = minimal_session();
+        let json = serde_json::to_string(&session).unwrap();
+        assert!(!json.contains("\"pinned\""));
+    }
+
+    #[test]
+    fn pinned_round_trips() {
+        let mut session = minimal_session();
+        session.workspaces[0].pinned = true;
+        let json = serde_json::to_string(&session).unwrap();
+        assert!(json.contains("\"pinned\":true"));
+        let restored: SessionData = serde_json::from_str(&json).unwrap();
+        assert!(restored.workspaces[0].pinned);
+    }
+
+    #[test]
+    fn deserialize_without_pinned_defaults_to_false() {
+        // Sessions written before the `pinned` field existed must still
+        // load cleanly.
+        let mut session = minimal_session();
+        session.workspaces[0].pinned = false;
+        let mut json: serde_json::Value = serde_json::to_value(&session).unwrap();
+        // Confirm the field is absent in the default case.
+        assert!(json["workspaces"][0].get("pinned").is_none());
+        // And a hand-written session without the field decodes.
+        json["workspaces"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("pinned");
+        let restored: SessionData = serde_json::from_value(json).unwrap();
+        assert!(!restored.workspaces[0].pinned);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements G8 from the sidebar parity plan (#260): pinned workspaces sort to the top of the sidebar and display a 📌 glyph next to the title.

- New `Workspace.pinned: bool` (defaults to `false`)
- Context menu entry: **Pin Workspace** / **Unpin Workspace**
- Toggle triggers a stable sort by `!pinned`; `active_workspace_idx` is retargeted by workspace id so the active selection follows the reshuffle
- Persisted via `SavedWorkspace.pinned` with `#[serde(default, skip_serializing_if = "std::ops::Not::not")]` — old session files load unchanged and non-pinned workspaces don't bloat the JSON
- Pin glyph is prepended to `display_title` and included in the wrap/ellipsis width calculation

## Test plan

- [x] `cargo test -p amux-session` — new tests for default-false, round-trip, and missing-field deserialize
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Manual: right-click a workspace → Pin → it floats to top with 📌
- [ ] Manual: restart amux → pinned state persists
- [ ] Manual: unpin → workspace returns to its group

Refs #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace pinning capability—users can pin/unpin workspaces via context menu to keep them at the top of the sidebar.
  * Pinned workspaces display with a pin icon (📌) for visual identification.
  * Workspace pinned state is now persisted across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->