### PR TITLE
Drop star prefix; render task as dedicated row (#260 G18)

### DIFF
--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -377,14 +377,22 @@ fn render_workspace_row(
 
     // Compute title text early so we can measure if it needs two lines.
     let title_font = crate::fonts::bold_font(TITLE_FONT_SIZE);
-    // Title priority: user-set name (sticky) > agent task > surface
-    // title > default workspace name. A user who explicitly renamed
-    // the workspace via the rename modal should not have their choice
-    // overwritten by agent status or auto-detected titles.
+    // Task is rendered as its own row (G18), not baked into the title.
+    let agent_task = status
+        .as_ref()
+        .and_then(|s| s.displayed_task())
+        .filter(|t| !t.is_empty());
+    let has_agent_task = agent_task.is_some();
+
+    // Title priority: user-set name (sticky) > surface title > default
+    // workspace name. A user who explicitly renamed the workspace via
+    // the rename modal should not have their choice overwritten by
+    // auto-detected titles. The agent task previously lived here as a
+    // `✱ task` prefix (G18); it now has its own row below the status
+    // indicator so long task strings don't crowd the title and the
+    // title reflects *workspace identity* rather than *agent activity*.
     let base_title = if let Some(ref ut) = ws.user_title {
         ut.clone()
-    } else if let Some(task) = status.as_ref().and_then(|s| s.displayed_task()) {
-        format!("\u{2731} {task}")
     } else if let Some(st) = metadata.and_then(|m| m.surface_title.as_ref()) {
         st.clone()
     } else {
@@ -424,6 +432,9 @@ fn render_workspace_row(
     }
     if has_status {
         row_h += METADATA_LINE_HEIGHT + 4.0;
+    }
+    if has_agent_task {
+        row_h += METADATA_LINE_HEIGHT + 2.0;
     }
     if has_git_or_cwd {
         row_h += METADATA_LINE_HEIGHT + 2.0;
@@ -694,6 +705,30 @@ fn render_workspace_row(
             egui::Align2::LEFT_TOP,
             &truncated,
             status_font,
+            status_color,
+        );
+        content_bottom += METADATA_LINE_HEIGHT;
+    }
+
+    // --- Agent task (distinct row, G18) ---
+    //
+    // Previously jammed into the title as `✱ {task}`; now lives as its
+    // own row so (a) the title reflects workspace identity and (b) long
+    // task strings don't force title wrap/truncation. Uses the same
+    // `status_color` as the indicator above to associate it visually
+    // with the agent's activity.
+    if let Some(task) = agent_task {
+        content_bottom += 2.0;
+        let task_x = rect.min.x + content_left;
+        let max_w = avail_w - content_left - ROW_H_PAD;
+        let task_font = egui::FontId::proportional(METADATA_FONT_SIZE);
+        let task_text = format!("\u{2731} {task}");
+        let truncated = truncate_text(ui, &task_text, &task_font, max_w);
+        ui.painter().text(
+            egui::pos2(task_x, content_bottom),
+            egui::Align2::LEFT_TOP,
+            &truncated,
+            task_font,
             status_color,
         );
         content_bottom += METADATA_LINE_HEIGHT;

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -722,8 +722,7 @@ fn render_workspace_row(
         let task_x = rect.min.x + content_left;
         let max_w = avail_w - content_left - ROW_H_PAD;
         let task_font = egui::FontId::proportional(METADATA_FONT_SIZE);
-        let task_text = format!("\u{2731} {task}");
-        let truncated = truncate_text(ui, &task_text, &task_font, max_w);
+        let truncated = truncate_text(ui, task, &task_font, max_w);
         ui.painter().text(
             egui::pos2(task_x, content_bottom),
             egui::Align2::LEFT_TOP,


### PR DESCRIPTION
## Summary

Implements G18 from #260: stop baking the agent task into the title with a \`✱\` prefix. The task now renders as its own row below the status indicator.

**Before:** title = \`✱ Running tests (12/48)\` — crowded, truncated, changes every tool call.
**After:** title = workspace identity (user rename / surface title / default); task gets a dedicated row.

- Title priority simplifies to: user_title > surface_title > ws.title
- New row reuses the status indicator's color (so they read as a pair)
- Row height picks up a \`METADATA_LINE_HEIGHT + 2.0\` slot when a task is present
- No API changes — \`displayed_task\` already existed from G1/G3

Foundation for G20 (priority-sorted rendering): task is now a plain row, not a special title-composition case.

## Test plan

- [x] \`cargo clippy --workspace -- -D warnings\` / \`cargo fmt --check\` / \`cargo test -p amux-app\`
- [ ] Manual: start an agent, verify title stays stable while \`✱ task\` appears/updates in its own row
- [ ] Manual: long task text no longer forces title truncation

Refs #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)