### PR TITLE
Freeze sidebar row geometry during interaction (#260 G4)

### DIFF
--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -453,26 +453,38 @@ fn render_workspace_row(
     // Dynamic row height
     let title_line_h = TITLE_FONT_SIZE + 2.0;
     let title_lines = if title_needs_wrap { 2.0 } else { 1.0 };
-    let mut row_h = ROW_V_PAD * 2.0 + title_line_h * title_lines;
+    let mut row_h_live = ROW_V_PAD * 2.0 + title_line_h * title_lines;
     if has_status {
-        row_h += METADATA_LINE_HEIGHT + 4.0;
+        row_h_live += METADATA_LINE_HEIGHT + 4.0;
     }
-    row_h += status_rows.len() as f32 * (METADATA_LINE_HEIGHT + 2.0);
+    row_h_live += status_rows.len() as f32 * (METADATA_LINE_HEIGHT + 2.0);
     if has_git_or_cwd {
-        row_h += METADATA_LINE_HEIGHT + 2.0;
+        row_h_live += METADATA_LINE_HEIGHT + 2.0;
     }
     if has_pr {
-        row_h += METADATA_LINE_HEIGHT + 2.0;
+        row_h_live += METADATA_LINE_HEIGHT + 2.0;
     }
     if has_notif_text {
-        row_h += NOTIF_PREVIEW_HEIGHT + 2.0;
+        row_h_live += NOTIF_PREVIEW_HEIGHT + 2.0;
     }
     if has_progress {
-        row_h += PROGRESS_BAR_HEIGHT + 4.0;
+        row_h_live += PROGRESS_BAR_HEIGHT + 4.0;
     }
     if has_progress_label {
-        row_h += METADATA_LINE_HEIGHT + 2.0;
+        row_h_live += METADATA_LINE_HEIGHT + 2.0;
     }
+
+    // G4: if this row is mid-interaction (drag in progress or context
+    // menu open, set via the freeze-update block below on a prior frame),
+    // allocate the frozen height instead of the live one so the row
+    // can't shift under the pointer when a status entry arrives or
+    // expires mid-interaction. Geometry-only freeze: text content still
+    // reflects live state, just within a pinned rect.
+    let row_h = state
+        .frozen_row_heights
+        .get(&ws.id)
+        .copied()
+        .unwrap_or(row_h_live);
 
     let avail_w = ui.available_width();
     let (rect, response) =
@@ -888,6 +900,21 @@ fn render_workspace_row(
         } else {
             actions.push(SidebarAction::SwitchWorkspace(idx));
         }
+    }
+
+    // G4: update the geometry freeze. While the context menu is open or
+    // this row is being dragged, pin `row_h` to the value captured on
+    // the first frame of interaction. Clear on the first frame the
+    // interaction ends. The freeze takes effect on the frame *after*
+    // interaction starts, since we need `response` to detect it — this
+    // is fine in practice because any status change mid-interaction
+    // arrives on a later frame.
+    let interaction_active =
+        response.context_menu_opened() || state.drag.as_ref().is_some_and(|d| d.source_idx == idx);
+    if interaction_active {
+        state.frozen_row_heights.entry(ws.id).or_insert(row_h_live);
+    } else {
+        state.frozen_row_heights.remove(&ws.id);
     }
 
     (actions, rect)

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -633,6 +633,7 @@ pub(crate) fn fresh_startup(
             visible: true,
             width: DEFAULT_SIDEBAR_WIDTH,
             drag: None,
+            frozen_row_heights: HashMap::new(),
         },
         notifications: NotificationStore::new(),
         pending_browser_restores: Vec::new(),
@@ -794,6 +795,7 @@ pub(crate) fn restore_session(
         visible: session.sidebar.visible,
         width: session.sidebar.width,
         drag: None,
+        frozen_row_heights: HashMap::new(),
     };
 
     // Don't restore notifications (the pane-level unread ring) — they're

--- a/crates/amux-core/src/model.rs
+++ b/crates/amux-core/src/model.rs
@@ -39,6 +39,12 @@ pub struct SidebarState {
     pub width: f32,
     /// Drag reorder state.
     pub drag: Option<SidebarDragState>,
+    /// G4: per-workspace geometry freeze. While a row is being interacted
+    /// with (context menu open, drag in progress), its `row_h` is pinned
+    /// to the value captured at interaction start so the row can't shift
+    /// under the pointer when a status entry arrives or expires mid-
+    /// interaction. Cleared on the first frame the interaction ends.
+    pub frozen_row_heights: HashMap<u64, f32>,
 }
 
 pub struct SidebarDragState {


### PR DESCRIPTION
## Summary

Closes G4 from the sidebar parity plan (#260).

While a sidebar row's context menu is open or the row is being dragged, status entries arriving or expiring would change the row's height and could shift the row out from under the pointer. This freezes the row's geometry for the duration of the interaction.

**Scope:** geometry-only — text content within the row still reflects live state. Only the rect allocation is pinned.

## Implementation

- New `frozen_row_heights: HashMap<u64, f32>` on `SidebarState`
- `render_workspace_row` computes `row_h_live` as before, then looks up `frozen_row_heights.get(&ws.id)` and uses the frozen value if present
- After response handling, sets the entry on interaction start (`response.context_menu_opened() || dragging`) and removes it on interaction end

The freeze takes effect one frame *after* interaction starts (we need `response` to detect the state). Any mid-interaction status change arrives on a later frame, so in practice the pinned height is already active by then.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p amux-app`
- [ ] Manual: right-click a workspace row whose agent is actively posting/clearing status — the menu stays anchored
- [ ] Manual: drag a workspace row while its agent's status is changing — the drop target doesn't jitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)