### PR TITLE
Distinct hover/active/unread sidebar row visuals (#260 G19)

### DIFF
--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -9,9 +9,13 @@ use amux_core::model::{SidebarDragState, SidebarState, SurfaceMetadata, Workspac
 // Colors (cmux dark mode equivalents)
 // ---------------------------------------------------------------------------
 
-const ROW_HOVER_BG: Color32 = Color32::from_rgba_premultiplied(15, 15, 15, 15);
 const TEXT_ACTIVE: Color32 = Color32::WHITE;
 const TEXT_INACTIVE: Color32 = Color32::from_gray(180);
+/// Title color for unread-but-not-active rows. Brighter than
+/// `TEXT_INACTIVE` so an unread-but-idle row reads as "wants
+/// attention" without stealing the selected row's full-white
+/// treatment.
+const TEXT_UNREAD: Color32 = Color32::from_gray(230);
 const BADGE_ACTIVE_BG: Color32 = Color32::from_rgba_premultiplied(64, 64, 64, 64);
 const CLOSE_BTN_COLOR: Color32 = Color32::from_rgba_premultiplied(140, 140, 140, 179);
 const PROGRESS_TRACK: Color32 = Color32::from_rgba_premultiplied(20, 20, 20, 20);
@@ -354,6 +358,45 @@ fn handle_drag_reorder(
     }
 }
 
+/// Four-way combination of active/hover states for a workspace row.
+///
+/// Prior to G19 we used nested `if is_active / else if hovered` which
+/// meant hovering the active row produced no visual response (hover
+/// was swallowed by the active branch). Keeping the combinations as
+/// a single enum forces the render code to handle all four, and lets
+/// the theme expose separate tokens for `Active` vs `ActiveHovered`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RowVisuals {
+    Idle,
+    Hovered,
+    Active,
+    ActiveHovered,
+}
+
+impl RowVisuals {
+    fn resolve(is_active: bool, hovered: bool) -> Self {
+        match (is_active, hovered) {
+            (true, true) => RowVisuals::ActiveHovered,
+            (true, false) => RowVisuals::Active,
+            (false, true) => RowVisuals::Hovered,
+            (false, false) => RowVisuals::Idle,
+        }
+    }
+
+    fn is_active(self) -> bool {
+        matches!(self, RowVisuals::Active | RowVisuals::ActiveHovered)
+    }
+
+    fn bg(self, chrome: &crate::theme::ChromeColors) -> Color32 {
+        match self {
+            RowVisuals::Idle => Color32::TRANSPARENT,
+            RowVisuals::Hovered => chrome.sidebar_hover_bg,
+            RowVisuals::Active => chrome.sidebar_active_bg,
+            RowVisuals::ActiveHovered => chrome.sidebar_active_hover_bg,
+        }
+    }
+}
+
 /// Renders a workspace row. Returns (actions, allocated_rect).
 #[allow(clippy::too_many_arguments)]
 fn render_workspace_row(
@@ -581,14 +624,9 @@ fn render_workspace_row(
     });
 
     // --- Background ---
+    let visuals = RowVisuals::resolve(is_active, hovered);
     let opacity = if is_being_dragged { 0.6 } else { 1.0 };
-    let bg = if is_active {
-        with_opacity(theme.chrome.sidebar_active_bg, opacity)
-    } else if hovered {
-        with_opacity(ROW_HOVER_BG, opacity)
-    } else {
-        Color32::TRANSPARENT
-    };
+    let bg = with_opacity(visuals.bg(&theme.chrome), opacity);
     ui.painter().rect_filled(rect, ROW_CORNER_RADIUS, bg);
 
     // --- Workspace color capsule (leading edge) ---
@@ -608,8 +646,13 @@ fn render_workspace_row(
     };
 
     // --- Title (or rename TextEdit) ---
-    let title_color = if is_active {
+    // G19: active rows are full-white; non-active rows with unread
+    // notifications get a brighter-than-idle grey so they read as
+    // "wants attention" without matching the selected row.
+    let title_color = if visuals.is_active() {
         TEXT_ACTIVE
+    } else if unread > 0 {
+        TEXT_UNREAD
     } else {
         TEXT_INACTIVE
     };
@@ -987,6 +1030,31 @@ fn shorten_path(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn row_visuals_resolves_all_four_combinations() {
+        use RowVisuals::*;
+        assert_eq!(RowVisuals::resolve(false, false), Idle);
+        assert_eq!(RowVisuals::resolve(false, true), Hovered);
+        assert_eq!(RowVisuals::resolve(true, false), Active);
+        assert_eq!(RowVisuals::resolve(true, true), ActiveHovered);
+    }
+
+    #[test]
+    fn row_visuals_active_hover_distinct_from_active() {
+        // Regression for G19: hovering the selected row must produce a
+        // different background than the selected-but-not-hovered row,
+        // so hover stays visible over active.
+        let chrome = crate::theme::Theme::default().chrome;
+        assert_ne!(
+            RowVisuals::Active.bg(&chrome),
+            RowVisuals::ActiveHovered.bg(&chrome),
+        );
+        assert!(RowVisuals::Active.is_active());
+        assert!(RowVisuals::ActiveHovered.is_active());
+        assert!(!RowVisuals::Hovered.is_active());
+        assert!(!RowVisuals::Idle.is_active());
+    }
 
     #[test]
     fn badge_label_passes_through_small_counts() {

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -162,7 +162,7 @@ impl ChromeColors {
         let [br, bg_g, bb] = bg;
         Self {
             sidebar_bg: darken_rgb(br, bg_g, bb, 0.15),
-            sidebar_hover_bg: Color32::from_rgba_premultiplied(255, 255, 255, 20),
+            sidebar_hover_bg: Color32::from_rgba_unmultiplied(255, 255, 255, 20),
             sidebar_active_bg: accent,
             sidebar_active_hover_bg: lighten_color(accent, 0.12),
             tab_bar_bg: None,
@@ -290,6 +290,9 @@ impl Default for Theme {
     /// blue (`#3d7dff`) so the active workspace/tab highlight is
     /// visually distinct from the Monokai orange.
     fn default() -> Self {
+        // amux blue — one source of truth for `accent`,
+        // `sidebar_active_bg`, and the derived `sidebar_active_hover_bg`.
+        let accent = Color32::from_rgb(0x3d, 0x7d, 0xff);
         Self {
             terminal: TerminalColors {
                 // Monokai Classic (cmux default)
@@ -324,19 +327,19 @@ impl Default for Theme {
                 // the sidebar reads as a distinct panel rather than
                 // blending into the terminal.
                 sidebar_bg: Color32::from_rgb(0x1d, 0x1f, 0x25),
-                sidebar_hover_bg: Color32::from_rgba_premultiplied(255, 255, 255, 20),
+                sidebar_hover_bg: Color32::from_rgba_unmultiplied(255, 255, 255, 20),
                 // Accent: amux blue — kept distinct from the Monokai
                 // terminal palette so the active workspace/tab
                 // highlight doesn't blend into the orange ANSI cells.
-                sidebar_active_bg: Color32::from_rgb(0x3d, 0x7d, 0xff),
-                sidebar_active_hover_bg: Color32::from_rgb(0x5a, 0x93, 0xff),
+                sidebar_active_bg: accent,
+                sidebar_active_hover_bg: lighten_color(accent, 0.12),
                 tab_bar_bg: None,  // falls back to terminal background
                 titlebar_bg: None, // falls back to tab bar background
                 tab_active_bg: Color32::from_rgb(0x25, 0x28, 0x30), // match terminal bg
                 tab_bar_border: Color32::from_rgb(0x3a, 0x3c, 0x43),
                 tab_border: Color32::from_rgb(0x3a, 0x3c, 0x43),
                 divider: Color32::from_rgb(0x3a, 0x3c, 0x43),
-                accent: Color32::from_rgb(0x3d, 0x7d, 0xff),
+                accent,
                 notification_ring: Color32::from_rgb(40, 120, 255),
                 pane_dim_alpha: 100,
             },

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -26,8 +26,15 @@ pub(crate) struct TerminalColors {
 #[derive(Debug, Clone)]
 pub(crate) struct ChromeColors {
     pub sidebar_bg: Color32,
+    /// Sidebar row background when the row is hovered but not the active
+    /// workspace. Subtle white overlay applied on top of `sidebar_bg`.
+    pub sidebar_hover_bg: Color32,
     /// Active/selected row background in the sidebar (derived from accent).
     pub sidebar_active_bg: Color32,
+    /// Sidebar row background when the row is active AND hovered. Derived
+    /// by lightening `sidebar_active_bg` so hover stays visible over the
+    /// selected row instead of collapsing into the plain active state.
+    pub sidebar_active_hover_bg: Color32,
     /// Tab bar background. Falls back to terminal background when `None`.
     pub tab_bar_bg: Option<Color32>,
     /// Title bar / top padding background. Falls back to `tab_bar_bg` when `None`.
@@ -155,7 +162,9 @@ impl ChromeColors {
         let [br, bg_g, bb] = bg;
         Self {
             sidebar_bg: darken_rgb(br, bg_g, bb, 0.15),
+            sidebar_hover_bg: Color32::from_rgba_premultiplied(255, 255, 255, 20),
             sidebar_active_bg: accent,
+            sidebar_active_hover_bg: lighten_color(accent, 0.12),
             tab_bar_bg: None,
             titlebar_bg: None,
             tab_active_bg: Color32::from_rgb(br, bg_g, bb),
@@ -220,6 +229,7 @@ impl Theme {
                 let c = Color32::from_rgb(r, g, b);
                 self.chrome.accent = c;
                 self.chrome.sidebar_active_bg = c;
+                self.chrome.sidebar_active_hover_bg = lighten_color(c, 0.12);
             }
         }
         if let Some(ref hex) = colors.sidebar_bg {
@@ -255,6 +265,11 @@ fn lighten_rgb(r: u8, g: u8, b: u8, amount: f32) -> Color32 {
         (g as f32 + (255.0 - g as f32) * amount) as u8,
         (b as f32 + (255.0 - b as f32) * amount) as u8,
     )
+}
+
+/// Lighten an opaque `Color32` toward white by `amount` (0.0–1.0).
+fn lighten_color(c: Color32, amount: f32) -> Color32 {
+    lighten_rgb(c.r(), c.g(), c.b(), amount)
 }
 
 impl Default for Theme {
@@ -309,10 +324,12 @@ impl Default for Theme {
                 // the sidebar reads as a distinct panel rather than
                 // blending into the terminal.
                 sidebar_bg: Color32::from_rgb(0x1d, 0x1f, 0x25),
+                sidebar_hover_bg: Color32::from_rgba_premultiplied(255, 255, 255, 20),
                 // Accent: amux blue — kept distinct from the Monokai
                 // terminal palette so the active workspace/tab
                 // highlight doesn't blend into the orange ANSI cells.
                 sidebar_active_bg: Color32::from_rgb(0x3d, 0x7d, 0xff),
+                sidebar_active_hover_bg: Color32::from_rgb(0x5a, 0x93, 0xff),
                 tab_bar_bg: None,  // falls back to terminal background
                 titlebar_bg: None, // falls back to tab bar background
                 tab_active_bg: Color32::from_rgb(0x25, 0x28, 0x30), // match terminal bg


### PR DESCRIPTION
## Summary

Closes G19 from the sidebar parity plan (#260).

Before this change, `render_workspace_row` used nested `if is_active / else if hovered` for both background and title color, which meant hovering the selected row produced **no** visual response — hover was swallowed by the active branch. cmux has distinct treatments for each of the four (active × hover) states.

## Changes

- `RowVisuals` enum in `sidebar.rs` covers all four combinations (`Idle`, `Hovered`, `Active`, `ActiveHovered`). `resolve()` is a total function on the two booleans, so no combination can be accidentally dropped.
- Two new `ChromeColors` tokens:
  - `sidebar_hover_bg` — subtle white overlay for unselected+hovered rows (was the `ROW_HOVER_BG` const, now theme-visible so it re-derives from terminal bg).
  - `sidebar_active_hover_bg` — accent lightened 12% toward white. Active rows pick up a visible hover response without matching the non-active hover treatment.
- New `TEXT_UNREAD` title color (gray 230) for non-active rows with unread notifications — brighter than `TEXT_INACTIVE` (gray 180) so unread rows read as "wants attention" without stealing the selected row's full-white title.
- `Theme::apply_color_config` re-derives `sidebar_active_hover_bg` when the user overrides `accent`, so custom palettes don't desync.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`
- [x] Unit test: `RowVisuals::resolve` covers all 4 combinations
- [x] Regression test: `Active.bg() != ActiveHovered.bg()`
- [ ] Manual: hover the selected workspace row — row visibly brightens
- [ ] Manual: hover an unselected row — subtle white overlay appears
- [ ] Manual: non-active row with unread badge — title reads slightly brighter than idle rows
- [ ] Manual: override `accent` in `~/.amux/config.toml`; confirm active-hover bg tracks the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced sidebar row appearance with improved visual states for hover and selection
  * Added distinct text colors for unread items, active selections, and inactive rows
  * Improved visual feedback when hovering over selected sidebar rows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->