### PR TITLE
Latest output line preview in sidebar (#260 G11)

### DIFF
--- a/crates/amux-app/src/frame_update.rs
+++ b/crates/amux-app/src/frame_update.rs
@@ -155,6 +155,13 @@ impl eframe::App for AmuxApp {
                 if bytes_this_frame >= MAX_BYTES_PER_SURFACE_PER_FRAME {
                     pending_data = true;
                 }
+                // G11: refresh the latest-output-line cache whenever this
+                // surface produced PTY output this frame. Gated on
+                // `bytes_this_frame > 0` so idle surfaces don't re-scan
+                // their viewports on every tick.
+                if bytes_this_frame > 0 {
+                    surface.refresh_latest_output_line();
+                }
                 // Detect process exit once the channel is drained
                 if surface.exited.is_none() && !surface.pane.is_alive() {
                     let message = match surface.pane.exit_status() {

--- a/crates/amux-app/src/managed_pane.rs
+++ b/crates/amux-app/src/managed_pane.rs
@@ -184,6 +184,11 @@ pub(crate) struct PaneSurface {
     pub(crate) user_title: Option<String>,
     /// Set when the PTY process exits.
     pub(crate) exited: Option<ExitInfo>,
+    /// G11: most recent non-empty line from the viewport. Refreshed by
+    /// [`PaneSurface::refresh_latest_output_line`] after PTY bytes are
+    /// fed, so the sidebar can render a one-line log preview without
+    /// re-reading the viewport for every row on every frame.
+    pub(crate) latest_output_line: Option<String>,
 }
 
 impl PaneSurface {
@@ -197,6 +202,37 @@ impl PaneSurface {
             self.pane.scroll_to_bottom();
         }
     }
+
+    /// G11: re-sample the viewport and cache the last non-empty visible
+    /// line so the sidebar can render a log preview under the agent
+    /// status. Called after a batch of PTY bytes is fed in the drain
+    /// loop; cheap enough at that cadence because it only runs for
+    /// surfaces that actually produced output this frame.
+    ///
+    /// The returned line is trimmed to [`Self::LATEST_LINE_MAX_CHARS`]
+    /// characters so a multi-kilobyte single-line write (e.g. a long
+    /// JSON blob with no newlines) can't blow up the sidebar draw or
+    /// the session snapshot.
+    pub(crate) fn refresh_latest_output_line(&mut self) {
+        let text = self.pane.read_screen_text();
+        let line = text.lines().rev().find_map(|l| {
+            let trimmed = l.trim_end();
+            (!trimmed.trim().is_empty()).then(|| trimmed.to_string())
+        });
+        self.latest_output_line = line.map(|l| {
+            if l.chars().count() > Self::LATEST_LINE_MAX_CHARS {
+                l.chars().take(Self::LATEST_LINE_MAX_CHARS).collect()
+            } else {
+                l
+            }
+        });
+    }
+
+    /// Cap on [`Self::latest_output_line`] length. The sidebar truncates
+    /// by measured width anyway, but a hard character cap keeps the
+    /// cached string from pinning pathological amounts of memory when
+    /// an agent writes one unbroken megabyte to stdout.
+    pub(crate) const LATEST_LINE_MAX_CHARS: usize = 512;
 }
 
 /// A leaf in the split tree. Each pane has its own tab bar with

--- a/crates/amux-app/src/managed_pane.rs
+++ b/crates/amux-app/src/managed_pane.rs
@@ -184,11 +184,6 @@ pub(crate) struct PaneSurface {
     pub(crate) user_title: Option<String>,
     /// Set when the PTY process exits.
     pub(crate) exited: Option<ExitInfo>,
-    /// G11: most recent non-empty line from the viewport. Refreshed by
-    /// [`PaneSurface::refresh_latest_output_line`] after PTY bytes are
-    /// fed, so the sidebar can render a one-line log preview without
-    /// re-reading the viewport for every row on every frame.
-    pub(crate) latest_output_line: Option<String>,
 }
 
 impl PaneSurface {
@@ -204,35 +199,59 @@ impl PaneSurface {
     }
 
     /// G11: re-sample the viewport and cache the last non-empty visible
-    /// line so the sidebar can render a log preview under the agent
-    /// status. Called after a batch of PTY bytes is fed in the drain
-    /// loop; cheap enough at that cadence because it only runs for
-    /// surfaces that actually produced output this frame.
+    /// line on [`SurfaceMetadata::latest_output_line`] so the sidebar
+    /// can render a log preview under the agent status. Called after a
+    /// batch of PTY bytes is fed in the drain loop; cheap enough at
+    /// that cadence because it only runs for surfaces that actually
+    /// produced output this frame.
     ///
-    /// The returned line is trimmed to [`Self::LATEST_LINE_MAX_CHARS`]
-    /// characters so a multi-kilobyte single-line write (e.g. a long
-    /// JSON blob with no newlines) can't blow up the sidebar draw or
-    /// the session snapshot.
+    /// Reads only the last `LATEST_LINE_SCAN_LINES` lines via
+    /// [`TerminalBackend::read_screen_lines`] — that's long enough to
+    /// skip a trailing prompt with a couple of blank lines above it,
+    /// short enough that backends can stay fast (no need to materialize
+    /// the whole viewport just to find the tail). The stored line is
+    /// capped at [`Self::LATEST_LINE_MAX_CHARS`] so a multi-kilobyte
+    /// single-line write (e.g. a long JSON blob with no newlines)
+    /// can't blow up the sidebar draw or the session snapshot.
     pub(crate) fn refresh_latest_output_line(&mut self) {
-        let text = self.pane.read_screen_text();
-        let line = text.lines().rev().find_map(|l| {
-            let trimmed = l.trim_end();
-            (!trimmed.trim().is_empty()).then(|| trimmed.to_string())
-        });
-        self.latest_output_line = line.map(|l| {
-            if l.chars().count() > Self::LATEST_LINE_MAX_CHARS {
-                l.chars().take(Self::LATEST_LINE_MAX_CHARS).collect()
-            } else {
-                l
-            }
-        });
+        let text = self
+            .pane
+            .read_screen_lines(Self::LATEST_LINE_SCAN_SPEC, false);
+        self.metadata.latest_output_line = pick_latest_output_line(&text);
     }
 
-    /// Cap on [`Self::latest_output_line`] length. The sidebar truncates
-    /// by measured width anyway, but a hard character cap keeps the
-    /// cached string from pinning pathological amounts of memory when
-    /// an agent writes one unbroken megabyte to stdout.
+    /// Cap on [`SurfaceMetadata::latest_output_line`] length. The sidebar
+    /// truncates by measured width anyway, but a hard character cap keeps
+    /// the cached string from pinning pathological amounts of memory
+    /// when an agent writes one unbroken megabyte to stdout.
     pub(crate) const LATEST_LINE_MAX_CHARS: usize = 512;
+    /// Line-range spec passed to
+    /// [`TerminalBackend::read_screen_lines`] when sampling for the log
+    /// preview. Picks up the last `N` lines so the scan can always find
+    /// the latest non-empty output line above any trailing prompt /
+    /// blank rows without materializing the full screen.
+    const LATEST_LINE_SCAN_SPEC: &'static str = "-20";
+}
+
+/// Extract the last non-empty line from a chunk of viewport text and
+/// cap it at [`PaneSurface::LATEST_LINE_MAX_CHARS`] characters. Split
+/// out of [`PaneSurface::refresh_latest_output_line`] so the scan
+/// logic (trim handling, empty filter, length cap) can be unit-tested
+/// without standing up a real backend.
+pub(crate) fn pick_latest_output_line(text: &str) -> Option<String> {
+    let line = text.lines().rev().find_map(|l| {
+        let trimmed = l.trim_end();
+        (!trimmed.trim().is_empty()).then(|| trimmed.to_string())
+    })?;
+    Some(
+        if line.chars().count() > PaneSurface::LATEST_LINE_MAX_CHARS {
+            line.chars()
+                .take(PaneSurface::LATEST_LINE_MAX_CHARS)
+                .collect()
+        } else {
+            line
+        },
+    )
 }
 
 /// A leaf in the split tree. Each pane has its own tab bar with
@@ -386,5 +405,55 @@ impl ManagedPane {
             is_alive: self.is_alive(),
             surface_count: self.tab_count(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latest_line_picks_last_non_blank() {
+        // Prompt `$ ` keeps its `$` — trim_end removes the trailing
+        // space but the line is still non-empty, so the scan returns it
+        // rather than skipping further up to `middle output`. Sidebar
+        // dedupe happens a layer up; this helper only cares about
+        // "latest non-empty".
+        let screen = "first line\nmiddle output\n$ \n\n";
+        assert_eq!(pick_latest_output_line(screen), Some("$".to_string()));
+    }
+
+    #[test]
+    fn latest_line_skips_trailing_blank_lines() {
+        // Trailing whitespace-only lines are skipped, but a line with
+        // any real content (here: `middle output`) is returned.
+        let screen = "first line\nmiddle output\n   \n\t\n";
+        assert_eq!(
+            pick_latest_output_line(screen),
+            Some("middle output".to_string()),
+        );
+    }
+
+    #[test]
+    fn latest_line_returns_none_when_all_blank() {
+        assert_eq!(pick_latest_output_line(""), None);
+        assert_eq!(pick_latest_output_line("\n\n   \n\t\n"), None);
+    }
+
+    #[test]
+    fn latest_line_trims_trailing_whitespace() {
+        // Trim trailing spaces/tabs but keep leading indentation so
+        // code-looking output doesn't get reflowed.
+        assert_eq!(
+            pick_latest_output_line("    indented   \n"),
+            Some("    indented".to_string()),
+        );
+    }
+
+    #[test]
+    fn latest_line_caps_at_max_chars() {
+        let long = "x".repeat(PaneSurface::LATEST_LINE_MAX_CHARS + 50);
+        let out = pick_latest_output_line(&long).expect("non-empty");
+        assert_eq!(out.chars().count(), PaneSurface::LATEST_LINE_MAX_CHARS);
     }
 }

--- a/crates/amux-app/src/notifications_ui.rs
+++ b/crates/amux-app/src/notifications_ui.rs
@@ -252,10 +252,9 @@ impl AmuxApp {
                 if !sanitized.is_empty() && sanitized.as_ref() != "?" {
                     meta.surface_title = Some(sanitized.into_owned());
                 }
-                // G11: surface the cached latest-output line to the sidebar.
-                // Refreshed in the PTY drain path so the read here is just
-                // a clone of the cached string.
-                meta.latest_output_line = sf.latest_output_line.clone();
+                // G11: the cached latest-output-line lives on
+                // `metadata.latest_output_line` and came along with the
+                // clone above — no extra copy needed here.
                 meta
             })
             .unwrap_or_default()

--- a/crates/amux-app/src/notifications_ui.rs
+++ b/crates/amux-app/src/notifications_ui.rs
@@ -252,6 +252,10 @@ impl AmuxApp {
                 if !sanitized.is_empty() && sanitized.as_ref() != "?" {
                     meta.surface_title = Some(sanitized.into_owned());
                 }
+                // G11: surface the cached latest-output line to the sidebar.
+                // Refreshed in the PTY drain path so the read here is just
+                // a clone of the cached string.
+                meta.latest_output_line = sf.latest_output_line.clone();
                 meta
             })
             .unwrap_or_default()

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -154,6 +154,28 @@ fn build_status_rows(status: &amux_notify::WorkspaceStatus) -> Vec<(&str, i32)> 
         .collect()
 }
 
+/// G11: pick the latest-output-line to render beneath a workspace's
+/// keyed status rows. Returns the cached viewport tail trimmed of
+/// trailing whitespace, and `None` if:
+///
+/// - the surface has no cached preview yet,
+/// - the cached preview is empty after trimming, or
+/// - the preview's trimmed text matches any status row's text
+///   (so the sidebar doesn't echo e.g. `claude.tool = "Running tests"`
+///   on one row and the terminal echo of the same string on the next).
+///
+/// Extracted so the trim / empty / dedupe behaviour is unit-testable
+/// without wiring up a real `Workspace` and `NotificationStore`.
+fn pick_sidebar_log_line<'a>(
+    latest_output_line: Option<&'a str>,
+    status_rows: &[(&str, i32)],
+) -> Option<&'a str> {
+    latest_output_line
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .filter(|l| !status_rows.iter().any(|(text, _)| text.trim() == *l))
+}
+
 /// Format an unread count for the badge, capping at `BADGE_MAX_COUNT`.
 fn badge_label(unread: usize) -> String {
     if unread > BADGE_MAX_COUNT {
@@ -467,16 +489,13 @@ fn render_workspace_row(
     let has_color = ws.color.is_some();
     let has_git_or_cwd = metadata.is_some_and(|m| m.git_branch.is_some() || m.cwd.is_some());
     let has_pr = metadata.is_some_and(|m| m.pr_number.is_some());
-    // G11: latest output line (dim preview beneath the keyed status rows).
-    // Hidden when the most-recent visible line duplicates what a status
-    // row already shows, so we don't double-render e.g. `claude.tool =
-    // "Running tests"` on one line and the terminal echo of the same
-    // string on the next.
-    let latest_log_line = metadata
-        .and_then(|m| m.latest_output_line.as_deref())
-        .map(str::trim)
-        .filter(|l| !l.is_empty())
-        .filter(|l| !status_rows.iter().any(|(text, _)| text.trim() == *l));
+    // G11: latest output line (dim preview beneath the keyed status
+    // rows). The helper handles trim / empty / dedupe so the inline
+    // logic here stays a single field-access + call.
+    let latest_log_line = pick_sidebar_log_line(
+        metadata.and_then(|m| m.latest_output_line.as_deref()),
+        &status_rows,
+    );
     let has_log_line = latest_log_line.is_some();
 
     // Compute title text early so we can measure if it needs two lines.
@@ -1161,6 +1180,44 @@ mod tests {
         assert_eq!(
             RowVisuals::Hovered.bg(&chrome),
             RowVisuals::Idle.bg(&chrome),
+        );
+    }
+
+    #[test]
+    fn log_line_none_when_cache_empty() {
+        assert_eq!(pick_sidebar_log_line(None, &[]), None);
+    }
+
+    #[test]
+    fn log_line_none_when_only_whitespace() {
+        assert_eq!(pick_sidebar_log_line(Some("   \t  "), &[]), None);
+        assert_eq!(pick_sidebar_log_line(Some(""), &[]), None);
+    }
+
+    #[test]
+    fn log_line_trims_surrounding_whitespace() {
+        assert_eq!(
+            pick_sidebar_log_line(Some("  hello world   "), &[]),
+            Some("hello world"),
+        );
+    }
+
+    #[test]
+    fn log_line_hidden_when_duplicates_status_row() {
+        // If the viewport's last line matches a status row's text (modulo
+        // trimming), don't render it — the structured status row already
+        // communicates that content.
+        let rows: &[(&str, i32)] = &[("Running tests", 10)];
+        assert_eq!(pick_sidebar_log_line(Some("Running tests"), rows), None);
+        assert_eq!(pick_sidebar_log_line(Some("  Running tests  "), rows), None,);
+    }
+
+    #[test]
+    fn log_line_passes_through_when_no_status_collision() {
+        let rows: &[(&str, i32)] = &[("Running tests", 10)];
+        assert_eq!(
+            pick_sidebar_log_line(Some("ok 1 - foo"), rows),
+            Some("ok 1 - foo"),
         );
     }
 

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -50,6 +50,15 @@ const PROGRESS_BAR_HEIGHT: f32 = 3.0;
 const DROP_INDICATOR_HEIGHT: f32 = 2.0;
 const METADATA_FONT_SIZE: f32 = 10.0;
 const METADATA_LINE_HEIGHT: f32 = 16.0;
+/// G11: dedicated font size for the latest-output-line preview. Matches
+/// the other metadata rows so the preview doesn't stand out, just adds
+/// context under the keyed status rows.
+const LOG_PREVIEW_FONT_SIZE: f32 = 10.0;
+/// G11: dimmer than `meta_color` (gray 190) so the log preview reads as
+/// background context rather than a structured status row. The keyed
+/// status rows (claude.tool, agent.message) use `meta_color` at gray
+/// 190; the preview uses gray 140 to sit visually beneath them.
+const LOG_PREVIEW_COLOR: Color32 = Color32::from_gray(140);
 /// G6: row-height animation duration. When a status entry appears or
 /// expires, the row interpolates toward the new target height over
 /// this window instead of popping instantly. egui's animation manager
@@ -396,7 +405,9 @@ impl RowVisuals {
     fn bg(self, chrome: &crate::theme::ChromeColors) -> Color32 {
         match self {
             RowVisuals::Idle => Color32::TRANSPARENT,
-            RowVisuals::Hovered => chrome.sidebar_hover_bg,
+            // Idle rows don't change on hover — the close-button X fade
+            // already gives enough feedback that the row is interactive.
+            RowVisuals::Hovered => Color32::TRANSPARENT,
             RowVisuals::Active => chrome.sidebar_active_bg,
             RowVisuals::ActiveHovered => chrome.sidebar_active_hover_bg,
         }
@@ -456,6 +467,17 @@ fn render_workspace_row(
     let has_color = ws.color.is_some();
     let has_git_or_cwd = metadata.is_some_and(|m| m.git_branch.is_some() || m.cwd.is_some());
     let has_pr = metadata.is_some_and(|m| m.pr_number.is_some());
+    // G11: latest output line (dim preview beneath the keyed status rows).
+    // Hidden when the most-recent visible line duplicates what a status
+    // row already shows, so we don't double-render e.g. `claude.tool =
+    // "Running tests"` on one line and the terminal echo of the same
+    // string on the next.
+    let latest_log_line = metadata
+        .and_then(|m| m.latest_output_line.as_deref())
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .filter(|l| !status_rows.iter().any(|(text, _)| text.trim() == *l));
+    let has_log_line = latest_log_line.is_some();
 
     // Compute title text early so we can measure if it needs two lines.
     let title_font = crate::fonts::bold_font(TITLE_FONT_SIZE);
@@ -507,6 +529,9 @@ fn render_workspace_row(
         row_h_live += METADATA_LINE_HEIGHT + 4.0;
     }
     row_h_live += status_rows.len() as f32 * (METADATA_LINE_HEIGHT + 2.0);
+    if has_log_line {
+        row_h_live += METADATA_LINE_HEIGHT + 2.0;
+    }
     if has_git_or_cwd {
         row_h_live += METADATA_LINE_HEIGHT + 2.0;
     }
@@ -780,8 +805,25 @@ fn render_workspace_row(
     // --- Status indicator (icon + text, matching cmux) ---
     let mut content_bottom = rect.min.y + ROW_V_PAD + title_line_h * title_lines;
 
-    // Metadata text color: light grey
-    let meta_color = Color32::from_gray(190);
+    // Text colour for metadata rows (git/cwd, PR, notif preview, low-
+    // priority status entries). On the active row everything reads as
+    // white — the grey shades used for idle rows would be near-
+    // illegible against the saturated accent fill. Font weight (bold
+    // title vs. regular meta) carries the hierarchy instead. Idle rows
+    // use a light grey so the title still dominates.
+    let meta_color = if is_active {
+        Color32::WHITE
+    } else {
+        Color32::from_gray(190)
+    };
+    // Same treatment for the G11 log preview, but a touch dimmer than
+    // `meta_color` on idle rows so it sits below the status entries in
+    // the visual hierarchy without creating a second grey stripe.
+    let log_color = if is_active {
+        Color32::WHITE
+    } else {
+        LOG_PREVIEW_COLOR
+    };
     // Status indicator color: blue when unselected, white when selected
     let status_color = if is_active {
         Color32::WHITE
@@ -840,6 +882,30 @@ fn render_workspace_row(
             &truncated,
             font,
             color,
+        );
+        content_bottom += METADATA_LINE_HEIGHT;
+    }
+
+    // --- Latest output line preview (G11) ---
+    //
+    // Dim monospace line under the keyed status rows showing the
+    // viewport's last non-empty row. Populated by
+    // `PaneSurface::refresh_latest_output_line` after each batch of PTY
+    // bytes so the read here is just a cached clone. Deduped against
+    // `status_rows` upstream so a structured status and its terminal
+    // echo don't render as two identical lines.
+    if let Some(line) = latest_log_line {
+        content_bottom += 2.0;
+        let line_x = rect.min.x + content_left;
+        let max_w = avail_w - content_left - ROW_H_PAD;
+        let line_font = egui::FontId::monospace(LOG_PREVIEW_FONT_SIZE);
+        let truncated = truncate_text(ui, line, &line_font, max_w);
+        row_painter.text(
+            egui::pos2(line_x, content_bottom),
+            egui::Align2::LEFT_TOP,
+            &truncated,
+            line_font,
+            log_color,
         );
         content_bottom += METADATA_LINE_HEIGHT;
     }
@@ -1083,6 +1149,19 @@ mod tests {
         assert!(RowVisuals::ActiveHovered.is_active());
         assert!(!RowVisuals::Hovered.is_active());
         assert!(!RowVisuals::Idle.is_active());
+    }
+
+    #[test]
+    fn idle_hover_matches_idle_background() {
+        // Idle rows must not change background on hover — the close-X
+        // fade already signals that the row is interactive, and adding
+        // a second hover treatment made the sidebar visually noisy
+        // during pointer travel.
+        let chrome = crate::theme::Theme::default().chrome;
+        assert_eq!(
+            RowVisuals::Hovered.bg(&chrome),
+            RowVisuals::Idle.bg(&chrome),
+        );
     }
 
     #[test]

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -1044,6 +1044,7 @@ pub(crate) fn spawn_surface(
         metadata,
         user_title: None,
         exited: None,
+        latest_output_line: None,
     })
 }
 

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -1044,7 +1044,6 @@ pub(crate) fn spawn_surface(
         metadata,
         user_title: None,
         exited: None,
-        latest_output_line: None,
     })
 }
 

--- a/crates/amux-app/src/theme.rs
+++ b/crates/amux-app/src/theme.rs
@@ -26,9 +26,6 @@ pub(crate) struct TerminalColors {
 #[derive(Debug, Clone)]
 pub(crate) struct ChromeColors {
     pub sidebar_bg: Color32,
-    /// Sidebar row background when the row is hovered but not the active
-    /// workspace. Subtle white overlay applied on top of `sidebar_bg`.
-    pub sidebar_hover_bg: Color32,
     /// Active/selected row background in the sidebar (derived from accent).
     pub sidebar_active_bg: Color32,
     /// Sidebar row background when the row is active AND hovered. Derived
@@ -162,7 +159,6 @@ impl ChromeColors {
         let [br, bg_g, bb] = bg;
         Self {
             sidebar_bg: darken_rgb(br, bg_g, bb, 0.15),
-            sidebar_hover_bg: Color32::from_rgba_unmultiplied(255, 255, 255, 20),
             sidebar_active_bg: accent,
             sidebar_active_hover_bg: lighten_color(accent, 0.12),
             tab_bar_bg: None,
@@ -327,7 +323,6 @@ impl Default for Theme {
                 // the sidebar reads as a distinct panel rather than
                 // blending into the terminal.
                 sidebar_bg: Color32::from_rgb(0x1d, 0x1f, 0x25),
-                sidebar_hover_bg: Color32::from_rgba_unmultiplied(255, 255, 255, 20),
                 // Accent: amux blue — kept distinct from the Monokai
                 // terminal palette so the active workspace/tab
                 // highlight doesn't blend into the orange ANSI cells.

--- a/crates/amux-core/src/model.rs
+++ b/crates/amux-core/src/model.rs
@@ -78,6 +78,11 @@ pub struct SurfaceMetadata {
     pub pr_state: Option<String>, // "open", "merged", "closed"
     /// Surface title from OSC 0/2 (window title set by shell/agent).
     pub surface_title: Option<String>,
+    /// Most recent non-empty line from the focused surface's viewport.
+    /// Sampled lazily in the PTY drain path (G11) so the sidebar can show
+    /// a one-line log preview under the agent status. `None` when the
+    /// viewport is empty or when no terminal surface is active.
+    pub latest_output_line: Option<String>,
 }
 
 /// Info about a process that has exited.


### PR DESCRIPTION
## Summary

Adds a dim monospace preview of the focused surface's last non-empty viewport line under the keyed status rows. Closes G11 on #260.

- `PaneSurface` caches `latest_output_line`, refreshed in the PTY drain path whenever the surface produced bytes that frame (idle surfaces don't re-scan).
- Exposed through `SurfaceMetadata` so the sidebar can render it without a second pane-map walk.
- Deduped against the status-row texts so e.g. \`claude.tool = \"Running tests\"\` and the terminal echo of the same string don't stack.

Also in this PR (related UX fixes surfaced while testing G11):

- **Active-row text is now white.** With the greyscale hierarchy enabled for idle rows, the active row's low-priority meta text was illegible against the accent fill. Font weight carries the title/body distinction on the active row instead.
- **Idle-row hover background removed.** The close-X fade already signals interactivity; the extra hover overlay made the sidebar noisy during pointer travel. `sidebar_hover_bg` theme field dropped (no remaining callers).

## Test plan

- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --workspace\` green (ghostty_integration PTY test passes standalone; its failure under \`--workspace\` is a pre-existing PTY-resource contention, unrelated)
- [ ] Visual: active workspace row reads as all-white; idle rows retain greyscale hierarchy
- [ ] Visual: log preview appears under keyed status rows when an agent is producing output
- [ ] Visual: hovering an idle row no longer changes its background
- [ ] Preview doesn't duplicate identical status-row text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar now displays a preview of the latest terminal output line for each pane.
  * Enhanced color differentiation for active and inactive sidebar rows.

* **Style**
  * Refined hover background styling in the sidebar.
  * Adjusted color palette for active row metadata and log previews.

* **Tests**
  * Added comprehensive unit tests for sidebar preview rendering and styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->