### PR TITLE
Support multiple PR rows in sidebar (#260 G13)

### DIFF
--- a/crates/amux-app/src/ipc_dispatch.rs
+++ b/crates/amux-app/src/ipc_dispatch.rs
@@ -108,9 +108,7 @@ impl AmuxApp {
                         let surface = self.resolve_surface_mut(&params.surface_id);
                         match surface {
                             Some(sf) => {
-                                sf.metadata.pr_number = params.number;
-                                sf.metadata.pr_title = params.title;
-                                sf.metadata.pr_state = params.state;
+                                apply_set_pr(&mut sf.metadata.prs, &params);
                                 Response::ok(req.id.clone(), serde_json::json!({}))
                             }
                             None => Response::err(req.id.clone(), "not_found", "surface not found"),
@@ -1258,5 +1256,149 @@ impl AmuxApp {
         } else {
             None
         }
+    }
+}
+
+/// Apply a `surface.set_pr` IPC request to the surface's PR list.
+///
+/// G13 semantics:
+/// - `replace = true` → clobber the list. If `number` is set, the list
+///   becomes a single-entry list with that PR; otherwise the list is
+///   cleared. This is the path for "clear all" and for callers that
+///   want the old single-PR behaviour.
+/// - `replace = false` (default) → upsert by `number`. An existing PR
+///   with the same number is updated in place; otherwise the new PR
+///   is appended.
+/// - `replace = false` with `number = None` is a no-op (nothing to
+///   upsert). Legacy callers that sent an empty body are preserved —
+///   they used to overwrite a single optional PR to `None`, which had
+///   no visible effect when nothing was set, and now matches that
+///   no-op outcome for the list case.
+pub(crate) fn apply_set_pr(
+    prs: &mut Vec<amux_core::model::PrSummary>,
+    params: &amux_ipc::methods::SetPrParams,
+) {
+    if params.replace {
+        prs.clear();
+        if let Some(number) = params.number {
+            prs.push(amux_core::model::PrSummary {
+                number,
+                title: params.title.clone(),
+                state: params.state.clone(),
+            });
+        }
+        return;
+    }
+    let Some(number) = params.number else {
+        return;
+    };
+    if let Some(existing) = prs.iter_mut().find(|p| p.number == number) {
+        existing.title = params.title.clone();
+        existing.state = params.state.clone();
+    } else {
+        prs.push(amux_core::model::PrSummary {
+            number,
+            title: params.title.clone(),
+            state: params.state.clone(),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_set_pr;
+    use amux_core::model::PrSummary;
+    use amux_ipc::methods::SetPrParams;
+
+    fn params(number: Option<u32>, replace: bool) -> SetPrParams {
+        SetPrParams {
+            surface_id: "s".to_string(),
+            number,
+            title: number.map(|n| format!("PR #{n}")),
+            state: Some("open".to_string()),
+            replace,
+        }
+    }
+
+    #[test]
+    fn replace_with_number_overwrites_list() {
+        let mut prs = vec![
+            PrSummary {
+                number: 1,
+                title: None,
+                state: None,
+            },
+            PrSummary {
+                number: 2,
+                title: None,
+                state: None,
+            },
+        ];
+        apply_set_pr(&mut prs, &params(Some(3), true));
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].number, 3);
+    }
+
+    #[test]
+    fn replace_without_number_clears_list() {
+        let mut prs = vec![PrSummary {
+            number: 1,
+            title: None,
+            state: None,
+        }];
+        apply_set_pr(&mut prs, &params(None, true));
+        assert!(prs.is_empty());
+    }
+
+    #[test]
+    fn upsert_appends_new_pr() {
+        let mut prs = vec![PrSummary {
+            number: 1,
+            title: None,
+            state: None,
+        }];
+        apply_set_pr(&mut prs, &params(Some(2), false));
+        assert_eq!(prs.len(), 2);
+        assert_eq!(prs[0].number, 1);
+        assert_eq!(prs[1].number, 2);
+    }
+
+    #[test]
+    fn upsert_updates_matching_number_in_place() {
+        let mut prs = vec![
+            PrSummary {
+                number: 1,
+                title: Some("old".into()),
+                state: Some("open".into()),
+            },
+            PrSummary {
+                number: 2,
+                title: None,
+                state: None,
+            },
+        ];
+        let p = SetPrParams {
+            surface_id: "s".into(),
+            number: Some(1),
+            title: Some("new".into()),
+            state: Some("merged".into()),
+            replace: false,
+        };
+        apply_set_pr(&mut prs, &p);
+        assert_eq!(prs.len(), 2);
+        assert_eq!(prs[0].title.as_deref(), Some("new"));
+        assert_eq!(prs[0].state.as_deref(), Some("merged"));
+    }
+
+    #[test]
+    fn upsert_without_number_is_no_op() {
+        let mut prs = vec![PrSummary {
+            number: 1,
+            title: None,
+            state: None,
+        }];
+        let before = prs.clone();
+        apply_set_pr(&mut prs, &params(None, false));
+        assert_eq!(prs, before);
     }
 }

--- a/crates/amux-app/src/main.rs
+++ b/crates/amux-app/src/main.rs
@@ -595,9 +595,19 @@ impl AmuxApp {
                                     rows: rows as u16,
                                     git_branch: sf.metadata.git_branch.clone(),
                                     git_dirty: sf.metadata.git_dirty,
-                                    pr_number: sf.metadata.pr_number,
-                                    pr_title: sf.metadata.pr_title.clone(),
-                                    pr_state: sf.metadata.pr_state.clone(),
+                                    pr_number: None,
+                                    pr_title: None,
+                                    pr_state: None,
+                                    prs: sf
+                                        .metadata
+                                        .prs
+                                        .iter()
+                                        .map(|p| amux_session::SavedPrSummary {
+                                            number: p.number,
+                                            title: p.title.clone(),
+                                            state: p.state.clone(),
+                                        })
+                                        .collect(),
                                     user_title: sf.user_title.clone(),
                                 }
                             })

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -52,8 +52,9 @@ const METADATA_FONT_SIZE: f32 = 10.0;
 const METADATA_LINE_HEIGHT: f32 = 16.0;
 /// G13: cap on the number of PR rows rendered beneath a workspace.
 /// More than this would start to dominate the sidebar for a workspace
-/// that publishes a PR per tiny feature branch; we fall back to
-/// "#N, #M, ... +K more" on the final visible row once this cap is hit.
+/// that publishes a PR per tiny feature branch; PRs still render one
+/// per row, and once this cap is hit the last visible PR row appends
+/// a `+K more` suffix to indicate additional hidden PRs.
 const MAX_PR_ROWS: usize = 3;
 /// G6: row-height animation duration. When a status entry appears or
 /// expires, the row interpolates toward the new target height over

--- a/crates/amux-app/src/sidebar.rs
+++ b/crates/amux-app/src/sidebar.rs
@@ -50,6 +50,11 @@ const PROGRESS_BAR_HEIGHT: f32 = 3.0;
 const DROP_INDICATOR_HEIGHT: f32 = 2.0;
 const METADATA_FONT_SIZE: f32 = 10.0;
 const METADATA_LINE_HEIGHT: f32 = 16.0;
+/// G13: cap on the number of PR rows rendered beneath a workspace.
+/// More than this would start to dominate the sidebar for a workspace
+/// that publishes a PR per tiny feature branch; we fall back to
+/// "#N, #M, ... +K more" on the final visible row once this cap is hit.
+const MAX_PR_ROWS: usize = 3;
 /// G6: row-height animation duration. When a status entry appears or
 /// expires, the row interpolates toward the new target height over
 /// this window instead of popping instantly. egui's animation manager
@@ -455,7 +460,7 @@ fn render_workspace_row(
     let has_notif_text = !has_status_rows && latest_notif.is_some_and(|n| !n.body.is_empty());
     let has_color = ws.color.is_some();
     let has_git_or_cwd = metadata.is_some_and(|m| m.git_branch.is_some() || m.cwd.is_some());
-    let has_pr = metadata.is_some_and(|m| m.pr_number.is_some());
+    let pr_row_count = metadata.map(|m| m.prs.len().min(MAX_PR_ROWS)).unwrap_or(0);
 
     // Compute title text early so we can measure if it needs two lines.
     let title_font = crate::fonts::bold_font(TITLE_FONT_SIZE);
@@ -510,9 +515,7 @@ fn render_workspace_row(
     if has_git_or_cwd {
         row_h_live += METADATA_LINE_HEIGHT + 2.0;
     }
-    if has_pr {
-        row_h_live += METADATA_LINE_HEIGHT + 2.0;
-    }
+    row_h_live += pr_row_count as f32 * (METADATA_LINE_HEIGHT + 2.0);
     if has_notif_text {
         row_h_live += NOTIF_PREVIEW_HEIGHT + 2.0;
     }
@@ -874,15 +877,29 @@ fn render_workspace_row(
             content_bottom += METADATA_LINE_HEIGHT;
         }
 
-        // --- PR badge ---
-        if let Some(pr_num) = meta.pr_number {
-            let pr_state = meta.pr_state.as_deref().unwrap_or("open");
+        // --- PR rows ---
+        // G13: one row per attached PR, capped at `MAX_PR_ROWS`. Surplus
+        // PRs are collapsed into a `+N more` suffix on the final visible
+        // row rather than silently dropped, so a workspace with many
+        // dependent branches doesn't look like only a few are tracked.
+        let total_prs = meta.prs.len();
+        let visible_prs = total_prs.min(MAX_PR_ROWS);
+        let overflow = total_prs.saturating_sub(visible_prs);
+        for (i, pr) in meta.prs.iter().take(visible_prs).enumerate() {
+            let pr_state = pr.state.as_deref().unwrap_or("open");
             let pr_color = meta_color;
             content_bottom += 2.0;
             let pr_x = rect.min.x + content_left;
             let max_w = avail_w - content_left - ROW_H_PAD;
             let pr_font = egui::FontId::proportional(METADATA_FONT_SIZE);
-            let pr_text = format!("\u{1F517} PR #{pr_num} {pr_state}");
+            let base = format!("\u{1F517} PR #{} {}", pr.number, pr_state);
+            let pr_text = if i + 1 == visible_prs && overflow > 0 {
+                format!("{base}  +{overflow} more")
+            } else if let Some(title) = pr.title.as_deref().filter(|t| !t.is_empty()) {
+                format!("{base}  {title}")
+            } else {
+                base
+            };
             let truncated = truncate_text(ui, &pr_text, &pr_font, max_w);
             row_painter.text(
                 egui::pos2(pr_x, content_bottom),

--- a/crates/amux-app/src/startup.rs
+++ b/crates/amux-app/src/startup.rs
@@ -695,9 +695,27 @@ pub(crate) fn restore_session(
                         // Restore git/PR metadata from session
                         surface.metadata.git_branch = saved_sf.git_branch.clone();
                         surface.metadata.git_dirty = saved_sf.git_dirty;
-                        surface.metadata.pr_number = saved_sf.pr_number;
-                        surface.metadata.pr_title = saved_sf.pr_title.clone();
-                        surface.metadata.pr_state = saved_sf.pr_state.clone();
+                        surface.metadata.prs = if !saved_sf.prs.is_empty() {
+                            saved_sf
+                                .prs
+                                .iter()
+                                .map(|p| amux_core::model::PrSummary {
+                                    number: p.number,
+                                    title: p.title.clone(),
+                                    state: p.state.clone(),
+                                })
+                                .collect()
+                        } else if let Some(number) = saved_sf.pr_number {
+                            // Back-compat: migrate legacy single-PR fields
+                            // from pre-G13 session files.
+                            vec![amux_core::model::PrSummary {
+                                number,
+                                title: saved_sf.pr_title.clone(),
+                                state: saved_sf.pr_state.clone(),
+                            }]
+                        } else {
+                            Vec::new()
+                        };
                         surface.user_title = saved_sf.user_title.clone();
                         surfaces.push(surface);
                     }

--- a/crates/amux-cli/src/cli.rs
+++ b/crates/amux-cli/src/cli.rs
@@ -262,7 +262,7 @@ pub(crate) enum Command {
     #[command(name = "set-pr")]
     SetPr {
         /// PR number
-        #[arg(long, conflicts_with = "clear")]
+        #[arg(long, conflicts_with = "clear", required_unless_present = "clear")]
         number: Option<u32>,
         /// PR title
         #[arg(long, conflicts_with = "clear")]
@@ -271,8 +271,9 @@ pub(crate) enum Command {
         #[arg(long, conflicts_with = "clear")]
         state: Option<String>,
         /// Replace the surface's entire PR list with this one entry
-        /// instead of upserting by number
-        #[arg(long, conflicts_with = "clear")]
+        /// instead of upserting by number. Requires `--number` so a
+        /// typo/omission can't silently clear the PR list.
+        #[arg(long, conflicts_with = "clear", requires = "number")]
         replace: bool,
         /// Clear all PRs on the surface
         #[arg(long)]

--- a/crates/amux-cli/src/cli.rs
+++ b/crates/amux-cli/src/cli.rs
@@ -252,7 +252,13 @@ pub(crate) enum Command {
         #[arg(long)]
         surface: Option<String>,
     },
-    /// Set PR info for a surface
+    /// Set PR info for a surface.
+    ///
+    /// By default, this upserts by `--number` into the surface's existing
+    /// PR list — so two agents publishing a feature branch PR plus a
+    /// dependent PR can each call `set-pr` with their own number and get
+    /// two rows in the sidebar. Pass `--replace` to swap the whole list
+    /// for a single entry, or `--clear` to drop everything.
     #[command(name = "set-pr")]
     SetPr {
         /// PR number
@@ -264,7 +270,11 @@ pub(crate) enum Command {
         /// PR state: open, merged, closed
         #[arg(long, conflicts_with = "clear")]
         state: Option<String>,
-        /// Clear PR info
+        /// Replace the surface's entire PR list with this one entry
+        /// instead of upserting by number
+        #[arg(long, conflicts_with = "clear")]
+        replace: bool,
+        /// Clear all PRs on the surface
         #[arg(long)]
         clear: bool,
         /// Target surface ID (defaults to AMUX_SURFACE_ID)

--- a/crates/amux-cli/src/main.rs
+++ b/crates/amux-cli/src/main.rs
@@ -669,6 +669,7 @@ async fn main() -> anyhow::Result<()> {
             number,
             title,
             state,
+            replace,
             clear,
             surface,
         } => {
@@ -676,8 +677,13 @@ async fn main() -> anyhow::Result<()> {
                 .or_else(|| std::env::var("AMUX_SURFACE_ID").ok())
                 .unwrap_or_else(|| "default".to_string());
             let params = if clear {
+                // `replace: true` with no `number` is server-side shorthand
+                // for "clear the PR list". Using the explicit wire contract
+                // here means the CLI doesn't silently depend on the server's
+                // legacy "empty body is a no-op" branch.
                 serde_json::json!({
                     "surface_id": surface_id,
+                    "replace": true,
                 })
             } else {
                 serde_json::json!({
@@ -685,6 +691,7 @@ async fn main() -> anyhow::Result<()> {
                     "number": number,
                     "title": title,
                     "state": state,
+                    "replace": replace,
                 })
             };
             let resp = client.call("surface.set_pr", params).await?;

--- a/crates/amux-core/src/model.rs
+++ b/crates/amux-core/src/model.rs
@@ -67,15 +67,31 @@ pub struct DragState {
 // Surface metadata
 // ---------------------------------------------------------------------------
 
+/// A PR associated with a surface. Sidebar renders one row per summary
+/// (G13). Agents / IPC callers can attach multiple — a feature branch PR
+/// plus a dependent PR is the motivating case — which all render stacked
+/// under the git/cwd line.
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+pub struct PrSummary {
+    pub number: u32,
+    pub title: Option<String>,
+    /// "open", "merged", "closed". Free-form string so we don't have to
+    /// enumerate every forge's vocabulary (Bitbucket/GitLab differ).
+    pub state: Option<String>,
+}
+
 /// Per-surface metadata reported by shell integration, agent hooks, or OSC sequences.
 #[derive(Default, Clone)]
 pub struct SurfaceMetadata {
     pub cwd: Option<String>,
     pub git_branch: Option<String>,
     pub git_dirty: bool,
-    pub pr_number: Option<u32>,
-    pub pr_title: Option<String>,
-    pub pr_state: Option<String>, // "open", "merged", "closed"
+    /// PRs attached to this surface. Empty means no PR info set.
+    /// IPC `surface.set_pr` upserts by number (or clears when no number
+    /// supplied) so integrations can publish one PR at a time without
+    /// coordinating — a second call with a different number adds a
+    /// second row rather than replacing the first.
+    pub prs: Vec<PrSummary>,
     /// Surface title from OSC 0/2 (window title set by shell/agent).
     pub surface_title: Option<String>,
 }

--- a/crates/amux-core/src/model.rs
+++ b/crates/amux-core/src/model.rs
@@ -87,10 +87,11 @@ pub struct SurfaceMetadata {
     pub git_branch: Option<String>,
     pub git_dirty: bool,
     /// PRs attached to this surface. Empty means no PR info set.
-    /// IPC `surface.set_pr` upserts by number (or clears when no number
-    /// supplied) so integrations can publish one PR at a time without
-    /// coordinating — a second call with a different number adds a
-    /// second row rather than replacing the first.
+    /// IPC `surface.set_pr` upserts by number. When `number` is omitted,
+    /// `replace=false` is a no-op and `replace=true` clears all PRs, so
+    /// integrations can publish one PR at a time without coordinating —
+    /// a second call with a different number adds a second row rather
+    /// than replacing the first.
     pub prs: Vec<PrSummary>,
     /// Surface title from OSC 0/2 (window title set by shell/agent).
     pub surface_title: Option<String>,

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -210,8 +210,8 @@ pub struct SetPrParams {
     ///
     /// `number = None` + `replace = false` is treated as a no-op so
     /// legacy callers sending an empty body don't accidentally wipe
-    /// the list. Use an explicit `surface.clear_pr` (or
-    /// `replace = true` with `number = None`) to clear.
+    /// the list. Use `replace = true` with `number = None` to clear
+    /// the list explicitly.
     #[serde(default)]
     pub replace: bool,
 }

--- a/crates/amux-ipc/src/methods.rs
+++ b/crates/amux-ipc/src/methods.rs
@@ -202,6 +202,18 @@ pub struct SetPrParams {
     pub title: Option<String>,
     #[serde(default)]
     pub state: Option<String>,
+    /// If `true`, replace the surface's entire PR list with this one
+    /// entry. When `false` (default), upsert by [`Self::number`] into
+    /// the existing list — callers with two PRs (feature branch +
+    /// dependent) can publish each one with a single IPC call rather
+    /// than having to assemble the full list client-side.
+    ///
+    /// `number = None` + `replace = false` is treated as a no-op so
+    /// legacy callers sending an empty body don't accidentally wipe
+    /// the list. Use an explicit `surface.clear_pr` (or
+    /// `replace = true` with `number = None`) to clear.
+    #[serde(default)]
+    pub replace: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/amux-session/src/lib.rs
+++ b/crates/amux-session/src/lib.rs
@@ -206,14 +206,30 @@ pub struct SavedSurface {
     pub git_branch: Option<String>,
     #[serde(default)]
     pub git_dirty: bool,
+    /// Legacy single-PR fields (pre-G13). Retained for backwards
+    /// compatibility so old session files still deserialize; migrated into
+    /// [`Self::prs`] on load when the new field is empty. New saves write
+    /// `prs` and leave these three as `None`.
     #[serde(default)]
     pub pr_number: Option<u32>,
     #[serde(default)]
     pub pr_title: Option<String>,
     #[serde(default)]
     pub pr_state: Option<String>,
+    /// Multiple PRs attached to the surface. G13 (sidebar-parity).
+    #[serde(default)]
+    pub prs: Vec<SavedPrSummary>,
     #[serde(default)]
     pub user_title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedPrSummary {
+    pub number: u32,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub state: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -332,6 +348,7 @@ mod tests {
                     pr_number: None,
                     pr_title: None,
                     pr_state: None,
+                    prs: Vec::new(),
                     user_title: None,
                     scrollback_vt: None,
                 }],
@@ -484,6 +501,22 @@ mod tests {
         }"#;
         let surface: SavedSurface = serde_json::from_str(json).unwrap();
         assert!(surface.user_title.is_none());
+    }
+
+    #[test]
+    fn deserialize_without_prs_field_defaults_to_empty() {
+        // Pre-G13 session files don't carry the `prs` array. The
+        // `#[serde(default)]` shim must load them without error so the
+        // startup migration path can promote `pr_number`/`pr_title`/
+        // `pr_state` into the new vec at restore time.
+        let json = r#"{
+            "id": 0, "title": "zsh", "working_dir": "/tmp", "scrollback": "",
+            "cols": 80, "rows": 24, "git_branch": null, "git_dirty": false,
+            "pr_number": 42, "pr_title": "Old PR", "pr_state": "open"
+        }"#;
+        let surface: SavedSurface = serde_json::from_str(json).unwrap();
+        assert!(surface.prs.is_empty());
+        assert_eq!(surface.pr_number, Some(42));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replaces the single `pr_number`/`pr_title`/`pr_state` trio on `SurfaceMetadata` with `Vec<PrSummary>`. Sidebar renders up to 3 PR rows, with any overflow collapsed into `+N more` on the final visible row.
- `surface.set_pr` gains a `replace: bool`. Default upserts by `number` (so two agents can each publish their own PR without coordinating); `replace: true` swaps the list for a single entry, and `replace: true` with `number: None` clears it. `amux set-pr --clear` maps to the clear form.
- Session schema keeps legacy fields as `#[serde(default)]` and migrates them into the new vec on restore when the new `prs` field is empty.

Closes #260 (G13 item — tracking issue remains open for the other gaps).

## Test plan
- [ ] `cargo clippy --workspace -- -D warnings && cargo fmt --check && cargo test --workspace`
- [ ] Publish two PRs to one workspace via `amux set-pr --number 1 --title Feature` then `amux set-pr --number 2 --title Dependent` — sidebar shows two rows
- [ ] `amux set-pr --number 1 --title Updated` — row updates in place, still two rows total
- [ ] `amux set-pr --clear` — both rows disappear
- [ ] `amux set-pr --number 99 --replace` — wipes to a single PR
- [ ] Publish ≥4 PRs — final row shows `+N more`
- [ ] Load a session file written before this change — legacy single-PR field shows up as one row after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)